### PR TITLE
Create input map system

### DIFF
--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -12,8 +12,9 @@ int main() {
   quoll::Engine::setPath(std::filesystem::current_path() / "engine");
 
   quoll::EventSystem eventSystem;
+  quoll::InputDeviceManager deviceManager;
   quoll::Window window("Quoll Engine", InitialWidth, InitialHeight,
-                       eventSystem);
+                       deviceManager, eventSystem);
 
   quoll::rhi::VulkanRenderBackend backend(window);
   auto *device = backend.createDefaultDevice();
@@ -28,7 +29,8 @@ int main() {
     quoll::Engine::getLogger().info()
         << "Project selected: " << project.value().name;
 
-    quoll::editor::EditorScreen editor(window, eventSystem, device);
+    quoll::editor::EditorScreen editor(window, deviceManager, eventSystem,
+                                       device);
     editor.start(project.value());
   }
 

--- a/editor/src/quoll/editor/core/EditorSimulator.cpp
+++ b/editor/src/quoll/editor/core/EditorSimulator.cpp
@@ -3,10 +3,12 @@
 
 namespace quoll::editor {
 
-EditorSimulator::EditorSimulator(EventSystem &eventSystem, Window &window,
+EditorSimulator::EditorSimulator(InputDeviceManager &deviceManager,
+                                 EventSystem &eventSystem, Window &window,
                                  AssetRegistry &assetRegistry,
                                  EditorCamera &editorCamera)
-    : mCameraAspectRatioUpdater(window),
+    : mInputMapSystem(deviceManager, assetRegistry),
+      mCameraAspectRatioUpdater(window),
       mScriptingSystem(eventSystem, assetRegistry),
       mAnimationSystem(assetRegistry), mPhysicsSystem(eventSystem),
       mEditorCamera(editorCamera), mAudioSystem(assetRegistry) {}
@@ -61,6 +63,8 @@ void EditorSimulator::updateEditor(float dt, WorkspaceState &state) {
 void EditorSimulator::updateSimulation(float dt, WorkspaceState &state) {
   auto &entityDatabase = state.simulationScene.entityDatabase;
   mEntityDeleter.update(state.simulationScene);
+
+  mInputMapSystem.update(entityDatabase);
 
   mCameraAspectRatioUpdater.update(entityDatabase);
 

--- a/editor/src/quoll/editor/core/EditorSimulator.h
+++ b/editor/src/quoll/editor/core/EditorSimulator.h
@@ -11,6 +11,7 @@
 #include "quoll/physics/PhysicsSystem.h"
 #include "quoll/audio/AudioSystem.h"
 #include "quoll/window/Window.h"
+#include "quoll/input/InputMapSystem.h"
 
 #include "quoll/editor/editor-scene/EditorCamera.h"
 #include "quoll/editor/state/WorkspaceState.h"
@@ -28,13 +29,15 @@ public:
   /**
    * @brief Create editor simulation
    *
+   * @param deviceManager Device manager
    * @param eventSystem Event system
    * @param window Window
    * @param assetRegistry Asset registry
    * @param editorCamera Editor camera
    */
-  EditorSimulator(EventSystem &eventSystem, Window &window,
-                  AssetRegistry &assetRegistry, EditorCamera &editorCamera);
+  EditorSimulator(InputDeviceManager &deviceManager, EventSystem &eventSystem,
+                  Window &window, AssetRegistry &assetRegistry,
+                  EditorCamera &editorCamera);
 
   /**
    * @brief Main update function
@@ -97,6 +100,7 @@ private:
   ScriptingSystem mScriptingSystem;
   PhysicsSystem mPhysicsSystem;
   AudioSystem<DefaultAudioBackend> mAudioSystem;
+  InputMapSystem mInputMapSystem;
 
   WorkspaceMode mMode = WorkspaceMode::Edit;
 };

--- a/editor/src/quoll/editor/screens/EditorScreen.cpp
+++ b/editor/src/quoll/editor/screens/EditorScreen.cpp
@@ -43,9 +43,10 @@
 
 namespace quoll::editor {
 
-EditorScreen::EditorScreen(Window &window, EventSystem &eventSystem,
-                           rhi::RenderDevice *device)
-    : mWindow(window), mEventSystem(eventSystem), mDevice(device) {}
+EditorScreen::EditorScreen(Window &window, InputDeviceManager &deviceManager,
+                           EventSystem &eventSystem, rhi::RenderDevice *device)
+    : mDeviceManager(deviceManager), mWindow(window), mEventSystem(eventSystem),
+      mDevice(device) {}
 
 void EditorScreen::start(const Project &rawProject) {
   auto project = rawProject;
@@ -182,7 +183,7 @@ void EditorScreen::start(const Project &rawProject) {
 
   ui.processShortcuts(context, mEventSystem);
 
-  EditorSimulator simulator(mEventSystem, mWindow,
+  EditorSimulator simulator(mDeviceManager, mEventSystem, mWindow,
                             assetManager.getAssetRegistry(), editorCamera);
 
   mWindow.maximize();

--- a/editor/src/quoll/editor/screens/EditorScreen.h
+++ b/editor/src/quoll/editor/screens/EditorScreen.h
@@ -20,11 +20,12 @@ public:
    * @brief Create editor screen
    *
    * @param window Window
+   * @param deviceManager Device manager
    * @param eventSystem Event system
    * @param device Render device
    */
-  EditorScreen(Window &window, EventSystem &eventSystem,
-               rhi::RenderDevice *device);
+  EditorScreen(Window &window, InputDeviceManager &deviceManager,
+               EventSystem &eventSystem, rhi::RenderDevice *device);
 
   /**
    * @brief Start editor screen
@@ -34,6 +35,7 @@ public:
   void start(const Project &project);
 
 private:
+  InputDeviceManager &mDeviceManager;
   Window &mWindow;
   EventSystem &mEventSystem;
   rhi::RenderDevice *mDevice;

--- a/editor/src/quoll/editor/ui/AssetBrowser.cpp
+++ b/editor/src/quoll/editor/ui/AssetBrowser.cpp
@@ -205,7 +205,8 @@ void AssetBrowser::render(WorkspaceContext &context) {
                           entry.assetType == AssetType::Audio ||
                           entry.assetType == AssetType::LuaScript ||
                           entry.assetType == AssetType::Environment ||
-                          entry.assetType == AssetType::Animator;
+                          entry.assetType == AssetType::Animator ||
+                          entry.assetType == AssetType::InputMap;
 
         if (dndAllowed) {
           if (ImGui::BeginDragDropSource()) {

--- a/editor/src/quoll/editor/ui/EntityPanel.h
+++ b/editor/src/quoll/editor/ui/EntityPanel.h
@@ -209,6 +209,16 @@ private:
                     ActionExecutor &actionExecutor);
 
   /**
+   * @brief Render input
+   *
+   * @param scene Scene
+   * @param assetRegistry Asset registry
+   * @param actionExecutor Action executor
+   */
+  void renderInput(Scene &scene, AssetRegistry &assetRegistry,
+                   ActionExecutor &actionExecutor);
+
+  /**
    * @brief Render environment lighting component
    *
    * @param scene Scene

--- a/editor/src/quoll/editor/ui/Widgets.cpp
+++ b/editor/src/quoll/editor/ui/Widgets.cpp
@@ -155,6 +155,11 @@ void Table::column(const glm::vec3 &value) {
   ImGui::Text("%.2f %.2f %.2f", value.x, value.y, value.z);
 }
 
+void Table::column(const glm::vec2 &value) {
+  ImGui::TableNextColumn();
+  ImGui::Text("%.2f %.2f", value.x, value.y);
+}
+
 void Table::column(const glm::quat &value) {
   ImGui::TableNextColumn();
   ImGui::Text("%.2f %.2f %.2f %.2f", value.x, value.y, value.z, value.w);

--- a/editor/src/quoll/editor/ui/Widgets.h
+++ b/editor/src/quoll/editor/ui/Widgets.h
@@ -243,6 +243,13 @@ public:
   void column(const glm::vec3 &value);
 
   /**
+   * @brief Render vector2 column
+   *
+   * @param value Vector2 value
+   */
+  void column(const glm::vec2 &value);
+
+  /**
    * @brief Render quaternion column
    *
    * @param value Quaternion value

--- a/engine/src/quoll/asset/AssetCacheInputMap.cpp
+++ b/engine/src/quoll/asset/AssetCacheInputMap.cpp
@@ -127,26 +127,46 @@ Result<InputMapAssetHandle> AssetCache::loadInputMap(const Uuid &uuid) {
     return Result<InputMapAssetHandle>::Error("Bindings field must be a list");
   }
 
+  std::set<String> duplicateNames;
   for (auto scheme : root["schemes"]) {
     if (!scheme.IsMap()) {
       return Result<InputMapAssetHandle>::Error("Scheme item must be a map");
     }
 
-    if (scheme["name"].as<String>("") == "") {
+    auto name = scheme["name"].as<String>("");
+    if (name == "") {
       return Result<InputMapAssetHandle>::Error(
           "Scheme item name must be a string and cannot be empty");
     }
+
+    if (duplicateNames.contains(name)) {
+      return Result<InputMapAssetHandle>::Error(
+          "Scheme item with same name is found");
+    }
+
+    duplicateNames.insert(name);
   }
+
+  duplicateNames.clear();
 
   for (auto command : root["commands"]) {
     if (!command.IsMap()) {
       return Result<InputMapAssetHandle>::Error("Command item must be a map");
     }
 
-    if (command["name"].as<String>("") == "") {
+    auto name = command["name"].as<String>("");
+
+    if (name == "") {
       return Result<InputMapAssetHandle>::Error(
           "Command item name must be a string and cannot be empty");
     }
+
+    if (duplicateNames.contains(name)) {
+      return Result<InputMapAssetHandle>::Error(
+          "Scheme item with same name is found");
+    }
+
+    duplicateNames.insert(name);
 
     auto type = command["type"].as<String>("");
     if (type != "boolean" && type != "axis-2d") {

--- a/engine/src/quoll/entity/EntityDatabase.cpp
+++ b/engine/src/quoll/entity/EntityDatabase.cpp
@@ -40,6 +40,8 @@ EntityDatabase::EntityDatabase() {
   reg<Text>();
   reg<MeshRenderer>();
   reg<SkinnedMeshRenderer>();
+  reg<InputMapAssetRef>();
+  reg<InputMap>();
 }
 
 } // namespace quoll

--- a/engine/src/quoll/entity/EntityDatabase.h
+++ b/engine/src/quoll/entity/EntityDatabase.h
@@ -38,6 +38,7 @@
 #include "quoll/text/Text.h"
 #include "quoll/renderer/MeshRenderer.h"
 #include "quoll/renderer/SkinnedMeshRenderer.h"
+#include "quoll/input/InputMap.h"
 
 namespace quoll {
 

--- a/engine/src/quoll/input/InputDataType.h
+++ b/engine/src/quoll/input/InputDataType.h
@@ -7,4 +7,14 @@ namespace quoll {
  */
 enum InputDataType { Boolean, Axis1d, Axis2d, Axis3d };
 
+/**
+ * @brief Input data type field
+ *
+ * Used to identify what part of data
+ * the key represents
+ *
+ * `Value` parameter represents the object itself
+ */
+enum InputDataTypeField { Value, X, Y, X0, X1, Y0, Y1 };
+
 } // namespace quoll

--- a/engine/src/quoll/input/InputDevice.h
+++ b/engine/src/quoll/input/InputDevice.h
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace quoll {
+
+enum class InputDeviceType { Keyboard, Mouse, Gamepad, Unknown };
+
+using InputStateValue = std::variant<bool, float, glm::vec2>;
+
+/**
+ * @brief Input device
+ */
+struct InputDevice {
+  /**
+   * Device type
+   */
+  InputDeviceType type = InputDeviceType::Unknown;
+
+  /**
+   * Device name
+   */
+  String name;
+
+  /**
+   * Device index
+   */
+  uint32_t index = 0;
+
+  /**
+   * Device state function
+   */
+  std::function<InputStateValue(int key)> stateFn;
+};
+
+} // namespace quoll

--- a/engine/src/quoll/input/InputDeviceManager.cpp
+++ b/engine/src/quoll/input/InputDeviceManager.cpp
@@ -1,0 +1,33 @@
+#include "quoll/core/Base.h"
+#include "quoll/core/Engine.h"
+#include "InputDeviceManager.h"
+
+#include "KeyMappings.h"
+
+#include <GLFW/glfw3.h>
+
+namespace quoll {
+
+void InputDeviceManager::addDevice(InputDevice device) {
+  mDevices.push_back(device);
+  Engine::getUserLogger().info()
+      << "Device \"" << device.name << "\" connected";
+}
+
+void InputDeviceManager::removeDevice(InputDeviceType type, uint32_t index) {
+  auto it =
+      std::find_if(mDevices.begin(), mDevices.end(),
+                   [type, index](const InputDevice &existing) {
+                     return existing.type == type && existing.index == index;
+                   });
+
+  if (it == mDevices.end()) {
+    return;
+  }
+
+  auto name = it->name;
+  mDevices.erase(it);
+  Engine::getUserLogger().info() << "Device \"" << name << "\" disconnected";
+}
+
+} // namespace quoll

--- a/engine/src/quoll/input/InputDeviceManager.h
+++ b/engine/src/quoll/input/InputDeviceManager.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "quoll/entity/EntityDatabase.h"
+#include "quoll/asset/AssetRegistry.h"
+
+#include "InputDevice.h"
+
+namespace quoll {
+
+/**
+ * @brief Input device manager
+ *
+ * Stores all input devices visible from engine
+ */
+class InputDeviceManager {
+public:
+  InputDeviceManager() = default;
+  ~InputDeviceManager() = default;
+
+  InputDeviceManager(const InputDeviceManager &) = delete;
+  InputDeviceManager &operator=(const InputDeviceManager &) = delete;
+  InputDeviceManager(InputDeviceManager &&) = delete;
+  InputDeviceManager &operator=(InputDeviceManager &&) = delete;
+
+  /**
+   * @brief Add input device
+   *
+   * @param device Device
+   */
+  void addDevice(InputDevice device);
+
+  /**
+   * @brief Remove input  device
+   *
+   * @param type Input device type
+   * @param index Input device index
+   */
+  void removeDevice(InputDeviceType type, uint32_t index);
+
+  /**
+   * @brief Get input devices
+   *
+   * @return Input devices
+   */
+  inline const std::vector<InputDevice> &getDevices() const { return mDevices; }
+
+private:
+  std::vector<InputDevice> mDevices;
+};
+
+} // namespace quoll

--- a/engine/src/quoll/input/InputMap.h
+++ b/engine/src/quoll/input/InputMap.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "quoll/asset/Asset.h"
+#include "InputDataType.h"
+
+namespace quoll {
+
+/**
+ * @brief Input map asset reference
+ *
+ * Stores reference to the asset
+ */
+struct InputMapAssetRef {
+  /**
+   * Asset handle
+   */
+  InputMapAssetHandle handle = InputMapAssetHandle::Null;
+};
+
+/**
+ * @brief Input map component
+ */
+struct InputMap {
+  /**
+   * Data types representing the commands
+   */
+  std::vector<InputDataType> commandDataTypes;
+
+  /**
+   * Command name to internal command key map
+   */
+  std::unordered_map<String, size_t> commandNameMap;
+
+  /**
+   * Input key to command map
+   */
+  std::unordered_map<int, size_t> inputKeyToCommandMap;
+
+  /**
+   * Command values
+   */
+  std::vector<std::variant<bool, glm::vec2>> commandValues;
+
+  /**
+   * Used to identify what part of a value
+   * the key represents
+   *
+   * Used non-boolean value types
+   */
+  std::unordered_map<int, InputDataTypeField> inputKeyFields;
+};
+
+} // namespace quoll

--- a/engine/src/quoll/input/InputMapSystem.cpp
+++ b/engine/src/quoll/input/InputMapSystem.cpp
@@ -1,0 +1,182 @@
+#include "quoll/core/Base.h"
+#include "InputMapSystem.h"
+
+namespace quoll {
+
+InputMapSystem::InputMapSystem(InputDeviceManager &deviceManager,
+                               AssetRegistry &assetRegistry)
+    : mDeviceManager(deviceManager), mAssetRegistry(assetRegistry) {}
+
+void InputMapSystem::update(EntityDatabase &entityDatabase) {
+  for (auto [entity, ref] : entityDatabase.view<InputMapAssetRef>()) {
+    if (mAssetRegistry.getInputMaps().hasAsset(ref.handle) &&
+        !entityDatabase.has<InputMap>(entity)) {
+      entityDatabase.set(
+          entity, createInputMap(
+                      mAssetRegistry.getInputMaps().getAsset(ref.handle).data));
+    }
+  }
+
+  std::vector<Entity> componentsToDelete(0);
+  for (auto [entity, ref] : entityDatabase.view<InputMap>()) {
+    if (!entityDatabase.has<InputMapAssetRef>(entity)) {
+      componentsToDelete.push_back(entity);
+    }
+  }
+
+  for (auto entity : componentsToDelete) {
+    entityDatabase.remove<InputMap>(entity);
+  }
+
+  for (auto [_, inputMap] : entityDatabase.view<InputMap>()) {
+    for (size_t i = 0; i < inputMap.commandValues.size(); ++i) {
+      auto type = inputMap.commandDataTypes.at(i);
+      if (type == InputDataType::Boolean) {
+        inputMap.commandValues.at(i) = false;
+      } else if (type == InputDataType::Axis2d) {
+        inputMap.commandValues.at(i) = glm::vec2{0.0f, 0.0f};
+      }
+    }
+  }
+
+  for (auto [entity, inputMap] : entityDatabase.view<InputMap>()) {
+    for (auto &device : mDeviceManager.getDevices()) {
+      for (const auto &[key, command] : inputMap.inputKeyToCommandMap) {
+        auto variant = device.stateFn(key);
+
+        auto dataType = inputMap.commandDataTypes.at(command);
+        if (dataType == InputDataType::Boolean) {
+          auto &commandValue =
+              std::get<bool>(inputMap.commandValues.at(command));
+
+          if (auto *inputValue = std::get_if<bool>(&variant)) {
+            commandValue |= *inputValue;
+          } else if (auto *inputValue = std::get_if<float>(&variant)) {
+            commandValue |= (*inputValue != 0.0f);
+          } else if (auto *inputValue = std::get_if<glm::vec2>(&variant)) {
+            commandValue |= (inputValue->x != 0.0f || inputValue->y != 0.0f);
+          }
+        } else if (dataType == InputDataType::Axis2d) {
+          auto &commandValue =
+              std::get<glm::vec2>(inputMap.commandValues.at(command));
+
+          if (std::get_if<bool>(&variant) != nullptr &&
+              std::get<bool>(variant)) {
+            auto field = inputMap.inputKeyFields.at(key);
+            if (field == InputDataTypeField::X0) {
+              commandValue.x += -1.0f;
+            } else if (field == InputDataTypeField::X1) {
+              commandValue.x += 1.0f;
+            } else if (field == InputDataTypeField::Y0) {
+              commandValue.y += 1.0f;
+            } else if (field == InputDataTypeField::Y1) {
+              commandValue.y += -1.0f;
+            }
+
+          } else if (auto *inputValue = std::get_if<float>(&variant)) {
+            auto field = inputMap.inputKeyFields.at(key);
+            if (field == InputDataTypeField::X) {
+              commandValue.x += *inputValue;
+            } else if (field == InputDataTypeField::Y) {
+              commandValue.y += *inputValue;
+            }
+          } else if (auto *inputValue = std::get_if<glm::vec2>(&variant)) {
+            commandValue += *inputValue;
+          }
+
+          if (commandValue.x < 0.0f) {
+            commandValue.x = std::max(-1.0f, commandValue.x);
+          }
+
+          if (commandValue.x > 0.0f) {
+            commandValue.x = std::min(1.0f, commandValue.x);
+          }
+
+          if (commandValue.y < 0.0f) {
+            commandValue.y = std::max(-1.0f, commandValue.y);
+          }
+
+          if (commandValue.y > 0.0f) {
+            commandValue.y = std::min(1.0f, commandValue.y);
+          }
+        }
+      }
+    }
+  }
+}
+
+InputMap InputMapSystem::createInputMap(InputMapAsset &asset) {
+  InputMap inputMap{};
+
+  inputMap.commandDataTypes.reserve(asset.commands.size());
+  inputMap.commandValues.resize(asset.commands.size());
+
+  size_t commandIndex = 0;
+  for (const auto &command : asset.commands) {
+    inputMap.commandNameMap.insert_or_assign(command.name, commandIndex++);
+    inputMap.commandDataTypes.push_back(command.type);
+  }
+
+  for (const auto &binding : asset.bindings) {
+    if (const auto *value = std::get_if<InputMapValue>(&binding.value)) {
+      if (*value >= 0) {
+        inputMap.inputKeyToCommandMap.insert_or_assign(*value, binding.command);
+        inputMap.inputKeyFields.insert_or_assign(*value,
+                                                 InputDataTypeField::Value);
+      }
+    } else if (const auto *axis2d =
+                   std::get_if<InputMapAxis2dValue>(&binding.value)) {
+      if (const auto *value = std::get_if<InputMapValue>(&axis2d->x)) {
+        if (*value >= 0) {
+          inputMap.inputKeyToCommandMap.insert_or_assign(*value,
+                                                         binding.command);
+          inputMap.inputKeyFields.insert_or_assign(*value,
+                                                   InputDataTypeField::X);
+        }
+      } else if (const auto *value =
+                     std::get_if<InputMapAxisSegment>(&axis2d->x)) {
+        if (value->at(0) >= 0) {
+          inputMap.inputKeyToCommandMap.insert_or_assign(value->at(0),
+                                                         binding.command);
+          inputMap.inputKeyFields.insert_or_assign(value->at(0),
+                                                   InputDataTypeField::X0);
+        }
+
+        if (value->at(1) >= 0) {
+          inputMap.inputKeyToCommandMap.insert_or_assign(value->at(1),
+                                                         binding.command);
+          inputMap.inputKeyFields.insert_or_assign(value->at(1),
+                                                   InputDataTypeField::X1);
+        }
+      }
+
+      if (const auto *value = std::get_if<InputMapValue>(&axis2d->y)) {
+        if (*value >= 0) {
+          inputMap.inputKeyToCommandMap.insert_or_assign(*value,
+                                                         binding.command);
+          inputMap.inputKeyFields.insert_or_assign(*value,
+                                                   InputDataTypeField::Y);
+        }
+      } else if (const auto *value =
+                     std::get_if<InputMapAxisSegment>(&axis2d->y)) {
+        if (value->at(0) >= 0) {
+          inputMap.inputKeyToCommandMap.insert_or_assign(value->at(0),
+                                                         binding.command);
+          inputMap.inputKeyFields.insert_or_assign(value->at(0),
+                                                   InputDataTypeField::Y0);
+        }
+
+        if (value->at(1) >= 0) {
+          inputMap.inputKeyToCommandMap.insert_or_assign(value->at(1),
+                                                         binding.command);
+          inputMap.inputKeyFields.insert_or_assign(value->at(1),
+                                                   InputDataTypeField::Y1);
+        }
+      }
+    }
+  }
+
+  return inputMap;
+}
+
+} // namespace quoll

--- a/engine/src/quoll/input/InputMapSystem.h
+++ b/engine/src/quoll/input/InputMapSystem.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "quoll/entity/EntityDatabase.h"
+#include "quoll/asset/AssetRegistry.h"
+
+#include "InputDeviceManager.h"
+
+namespace quoll {
+
+/**
+ * @brief Input map system
+ *
+ * Maps input events to commands
+ */
+class InputMapSystem {
+public:
+  /**
+   * @brief Create input map system
+   *
+   * @param deviceManager Device manager
+   * @param assetRegistry Asset registry
+   */
+  InputMapSystem(InputDeviceManager &deviceManager,
+                 AssetRegistry &assetRegistry);
+
+  /**
+   * @brief Update
+   *
+   * @param entityDatabase Entity database
+   */
+  void update(EntityDatabase &entityDatabase);
+
+private:
+  InputMap createInputMap(InputMapAsset &asset);
+
+private:
+  InputDeviceManager &mDeviceManager;
+  AssetRegistry &mAssetRegistry;
+};
+
+} // namespace quoll

--- a/engine/src/quoll/input/KeyMappings.cpp
+++ b/engine/src/quoll/input/KeyMappings.cpp
@@ -5,126 +5,148 @@
 
 namespace quoll::input {
 
+static constexpr int KeyboardStart = 0;
 static constexpr int MouseStart = 1000;
 static constexpr int GamepadStart = 2000;
 static constexpr int GamepadAxisStart = 2100;
 
+static constexpr int MouseMove = 10;
+
+int getKeyboardKeyFromGlfw(int glfw) { return KeyboardStart + glfw; }
+
+int getMouseButtonFromGlfw(int glfw) { return MouseStart + glfw; }
+
+int getMouseMove() { return MouseMove; }
+
+int getGamepadButtonFromGlfw(int glfw) { return GamepadStart + glfw; }
+
+int getGamepadAxisFromGlfw(int glfw) { return GamepadAxisStart + glfw; }
+
 static const std::unordered_map<String, int> Mapping{
     // letters
-    {"KEY_A", GLFW_KEY_A},
-    {"KEY_B", GLFW_KEY_B},
-    {"KEY_C", GLFW_KEY_C},
-    {"KEY_D", GLFW_KEY_D},
-    {"KEY_E", GLFW_KEY_E},
-    {"KEY_F", GLFW_KEY_F},
-    {"KEY_G", GLFW_KEY_G},
-    {"KEY_H", GLFW_KEY_H},
-    {"KEY_I", GLFW_KEY_I},
-    {"KEY_J", GLFW_KEY_J},
-    {"KEY_K", GLFW_KEY_K},
-    {"KEY_L", GLFW_KEY_L},
-    {"KEY_M", GLFW_KEY_M},
-    {"KEY_N", GLFW_KEY_N},
-    {"KEY_O", GLFW_KEY_O},
-    {"KEY_P", GLFW_KEY_P},
-    {"KEY_Q", GLFW_KEY_Q},
-    {"KEY_R", GLFW_KEY_R},
-    {"KEY_S", GLFW_KEY_S},
-    {"KEY_T", GLFW_KEY_T},
-    {"KEY_U", GLFW_KEY_U},
-    {"KEY_V", GLFW_KEY_V},
-    {"KEY_W", GLFW_KEY_W},
-    {"KEY_X", GLFW_KEY_X},
-    {"KEY_Y", GLFW_KEY_Y},
-    {"KEY_Z", GLFW_KEY_Z},
+    {"KEY_A", getKeyboardKeyFromGlfw(GLFW_KEY_A)},
+    {"KEY_B", getKeyboardKeyFromGlfw(GLFW_KEY_B)},
+    {"KEY_C", getKeyboardKeyFromGlfw(GLFW_KEY_C)},
+    {"KEY_D", getKeyboardKeyFromGlfw(GLFW_KEY_D)},
+    {"KEY_E", getKeyboardKeyFromGlfw(GLFW_KEY_E)},
+    {"KEY_F", getKeyboardKeyFromGlfw(GLFW_KEY_F)},
+    {"KEY_G", getKeyboardKeyFromGlfw(GLFW_KEY_G)},
+    {"KEY_H", getKeyboardKeyFromGlfw(GLFW_KEY_H)},
+    {"KEY_I", getKeyboardKeyFromGlfw(GLFW_KEY_I)},
+    {"KEY_J", getKeyboardKeyFromGlfw(GLFW_KEY_J)},
+    {"KEY_K", getKeyboardKeyFromGlfw(GLFW_KEY_K)},
+    {"KEY_L", getKeyboardKeyFromGlfw(GLFW_KEY_L)},
+    {"KEY_M", getKeyboardKeyFromGlfw(GLFW_KEY_M)},
+    {"KEY_N", getKeyboardKeyFromGlfw(GLFW_KEY_N)},
+    {"KEY_O", getKeyboardKeyFromGlfw(GLFW_KEY_O)},
+    {"KEY_P", getKeyboardKeyFromGlfw(GLFW_KEY_P)},
+    {"KEY_Q", getKeyboardKeyFromGlfw(GLFW_KEY_Q)},
+    {"KEY_R", getKeyboardKeyFromGlfw(GLFW_KEY_R)},
+    {"KEY_S", getKeyboardKeyFromGlfw(GLFW_KEY_S)},
+    {"KEY_T", getKeyboardKeyFromGlfw(GLFW_KEY_T)},
+    {"KEY_U", getKeyboardKeyFromGlfw(GLFW_KEY_U)},
+    {"KEY_V", getKeyboardKeyFromGlfw(GLFW_KEY_V)},
+    {"KEY_W", getKeyboardKeyFromGlfw(GLFW_KEY_W)},
+    {"KEY_X", getKeyboardKeyFromGlfw(GLFW_KEY_X)},
+    {"KEY_Y", getKeyboardKeyFromGlfw(GLFW_KEY_Y)},
+    {"KEY_Z", getKeyboardKeyFromGlfw(GLFW_KEY_Z)},
 
     // digits
-    {"KEY_1", GLFW_KEY_1},
-    {"KEY_2", GLFW_KEY_2},
-    {"KEY_3", GLFW_KEY_3},
-    {"KEY_4", GLFW_KEY_4},
-    {"KEY_5", GLFW_KEY_5},
-    {"KEY_6", GLFW_KEY_6},
-    {"KEY_7", GLFW_KEY_7},
-    {"KEY_8", GLFW_KEY_8},
-    {"KEY_9", GLFW_KEY_9},
+    {"KEY_1", getKeyboardKeyFromGlfw(GLFW_KEY_1)},
+    {"KEY_2", getKeyboardKeyFromGlfw(GLFW_KEY_2)},
+    {"KEY_3", getKeyboardKeyFromGlfw(GLFW_KEY_3)},
+    {"KEY_4", getKeyboardKeyFromGlfw(GLFW_KEY_4)},
+    {"KEY_5", getKeyboardKeyFromGlfw(GLFW_KEY_5)},
+    {"KEY_6", getKeyboardKeyFromGlfw(GLFW_KEY_6)},
+    {"KEY_7", getKeyboardKeyFromGlfw(GLFW_KEY_7)},
+    {"KEY_8", getKeyboardKeyFromGlfw(GLFW_KEY_8)},
+    {"KEY_9", getKeyboardKeyFromGlfw(GLFW_KEY_9)},
 
     // special
-    {"KEY_comma", GLFW_KEY_COMMA},
-    {"KEY_minus", GLFW_KEY_MINUS},
-    {"KEY_period", GLFW_KEY_PERIOD},
-    {"KEY_slash", GLFW_KEY_SLASH},
-    {"KEY_semicolon", GLFW_KEY_SEMICOLON},
-    {"KEY_equal", GLFW_KEY_EQUAL},
-    {"KEY_left_bracket", GLFW_KEY_LEFT_BRACKET},
-    {"KEY_backslash", GLFW_KEY_BACKSLASH},
-    {"KEY_right_bracket", GLFW_KEY_RIGHT_BRACKET},
-    {"KEY_grave_accent", GLFW_KEY_GRAVE_ACCENT},
+    {"KEY_comma", getKeyboardKeyFromGlfw(GLFW_KEY_COMMA)},
+    {"KEY_minus", getKeyboardKeyFromGlfw(GLFW_KEY_MINUS)},
+    {"KEY_period", getKeyboardKeyFromGlfw(GLFW_KEY_PERIOD)},
+    {"KEY_slash", getKeyboardKeyFromGlfw(GLFW_KEY_SLASH)},
+    {"KEY_semicolon", getKeyboardKeyFromGlfw(GLFW_KEY_SEMICOLON)},
+    {"KEY_equal", getKeyboardKeyFromGlfw(GLFW_KEY_EQUAL)},
+    {"KEY_left_bracket", getKeyboardKeyFromGlfw(GLFW_KEY_LEFT_BRACKET)},
+    {"KEY_backslash", getKeyboardKeyFromGlfw(GLFW_KEY_BACKSLASH)},
+    {"KEY_right_bracket", getKeyboardKeyFromGlfw(GLFW_KEY_RIGHT_BRACKET)},
+    {"KEY_grave_accent", getKeyboardKeyFromGlfw(GLFW_KEY_GRAVE_ACCENT)},
 
     // command keys
-    {"KEY_SPACE", GLFW_KEY_SPACE},
-    {"KEY_ESCAPE", GLFW_KEY_ESCAPE},
-    {"KEY_ENTER", GLFW_KEY_ENTER},
-    {"KEY_TAB", GLFW_KEY_TAB},
-    {"KEY_BACKSPACE", GLFW_KEY_BACKSPACE},
-    {"KEY_INSERT", GLFW_KEY_INSERT},
-    {"KEY_DELETE", GLFW_KEY_DELETE},
-    {"KEY_RIGHT", GLFW_KEY_RIGHT},
-    {"KEY_LEFT", GLFW_KEY_LEFT},
-    {"KEY_DOWN", GLFW_KEY_DOWN},
-    {"KEY_UP", GLFW_KEY_UP},
-    {"KEY_PAGE_UP", GLFW_KEY_PAGE_UP},
-    {"KEY_PAGE_DOWN", GLFW_KEY_PAGE_DOWN},
-    {"KEY_HOME", GLFW_KEY_HOME},
-    {"KEY_END", GLFW_KEY_END},
-    {"KEY_CAPS_LOCK", GLFW_KEY_CAPS_LOCK},
-    {"KEY_SCROLL_LOCK", GLFW_KEY_SCROLL_LOCK},
-    {"KEY_NUM_LOCK", GLFW_KEY_NUM_LOCK},
-    {"KEY_PRINT_SCREEN", GLFW_KEY_PRINT_SCREEN},
-    {"KEY_PAUSE", GLFW_KEY_PAUSE},
-    {"KEY_LEFT_SHIFT", GLFW_KEY_LEFT_SHIFT},
-    {"KEY_LEFT_CONTROL", GLFW_KEY_LEFT_CONTROL},
-    {"KEY_LEFT_ALT", GLFW_KEY_LEFT_ALT},
-    {"KEY_LEFT_SUPER", GLFW_KEY_LEFT_SUPER},
-    {"KEY_RIGHT_SHIFT", GLFW_KEY_RIGHT_SHIFT},
-    {"KEY_RIGHT_CONTROL", GLFW_KEY_RIGHT_CONTROL},
-    {"KEY_RIGHT_ALT", GLFW_KEY_RIGHT_ALT},
-    {"KEY_RIGHT_SUPER", GLFW_KEY_RIGHT_SUPER},
+    {"KEY_SPACE", getKeyboardKeyFromGlfw(GLFW_KEY_SPACE)},
+    {"KEY_ESCAPE", getKeyboardKeyFromGlfw(GLFW_KEY_ESCAPE)},
+    {"KEY_ENTER", getKeyboardKeyFromGlfw(GLFW_KEY_ENTER)},
+    {"KEY_TAB", getKeyboardKeyFromGlfw(GLFW_KEY_TAB)},
+    {"KEY_BACKSPACE", getKeyboardKeyFromGlfw(GLFW_KEY_BACKSPACE)},
+    {"KEY_INSERT", getKeyboardKeyFromGlfw(GLFW_KEY_INSERT)},
+    {"KEY_DELETE", getKeyboardKeyFromGlfw(GLFW_KEY_DELETE)},
+    {"KEY_RIGHT", getKeyboardKeyFromGlfw(GLFW_KEY_RIGHT)},
+    {"KEY_LEFT", getKeyboardKeyFromGlfw(GLFW_KEY_LEFT)},
+    {"KEY_DOWN", getKeyboardKeyFromGlfw(GLFW_KEY_DOWN)},
+    {"KEY_UP", getKeyboardKeyFromGlfw(GLFW_KEY_UP)},
+    {"KEY_PAGE_UP", getKeyboardKeyFromGlfw(GLFW_KEY_PAGE_UP)},
+    {"KEY_PAGE_DOWN", getKeyboardKeyFromGlfw(GLFW_KEY_PAGE_DOWN)},
+    {"KEY_HOME", getKeyboardKeyFromGlfw(GLFW_KEY_HOME)},
+    {"KEY_END", getKeyboardKeyFromGlfw(GLFW_KEY_END)},
+    {"KEY_CAPS_LOCK", getKeyboardKeyFromGlfw(GLFW_KEY_CAPS_LOCK)},
+    {"KEY_SCROLL_LOCK", getKeyboardKeyFromGlfw(GLFW_KEY_SCROLL_LOCK)},
+    {"KEY_NUM_LOCK", getKeyboardKeyFromGlfw(GLFW_KEY_NUM_LOCK)},
+    {"KEY_PRINT_SCREEN", getKeyboardKeyFromGlfw(GLFW_KEY_PRINT_SCREEN)},
+    {"KEY_PAUSE", getKeyboardKeyFromGlfw(GLFW_KEY_PAUSE)},
+    {"KEY_LEFT_SHIFT", getKeyboardKeyFromGlfw(GLFW_KEY_LEFT_SHIFT)},
+    {"KEY_LEFT_CONTROL", getKeyboardKeyFromGlfw(GLFW_KEY_LEFT_CONTROL)},
+    {"KEY_LEFT_ALT", getKeyboardKeyFromGlfw(GLFW_KEY_LEFT_ALT)},
+    {"KEY_LEFT_SUPER", getKeyboardKeyFromGlfw(GLFW_KEY_LEFT_SUPER)},
+    {"KEY_RIGHT_SHIFT", getKeyboardKeyFromGlfw(GLFW_KEY_RIGHT_SHIFT)},
+    {"KEY_RIGHT_CONTROL", getKeyboardKeyFromGlfw(GLFW_KEY_RIGHT_CONTROL)},
+    {"KEY_RIGHT_ALT", getKeyboardKeyFromGlfw(GLFW_KEY_RIGHT_ALT)},
+    {"KEY_RIGHT_SUPER", getKeyboardKeyFromGlfw(GLFW_KEY_RIGHT_SUPER)},
 
     // Mouse
-    {"MOUSE_LEFT", MouseStart + GLFW_MOUSE_BUTTON_LEFT},
-    {"MOUSE_RIGHT", MouseStart + GLFW_MOUSE_BUTTON_RIGHT},
-    {"MOUSE_MIDDLE", MouseStart + GLFW_MOUSE_BUTTON_MIDDLE},
-    {"MOUSE_MOVE", MouseStart + 10},
+    {"MOUSE_LEFT", getMouseButtonFromGlfw(GLFW_MOUSE_BUTTON_LEFT)},
+    {"MOUSE_RIGHT", getMouseButtonFromGlfw(GLFW_MOUSE_BUTTON_RIGHT)},
+    {"MOUSE_MIDDLE", getMouseButtonFromGlfw(GLFW_MOUSE_BUTTON_MIDDLE)},
+    {"MOUSE_MOVE", getMouseMove()},
 
-    // Gamepad
-    {"GAMEPAD_SOUTH", GamepadStart + GLFW_GAMEPAD_BUTTON_CROSS},
-    {"GAMEPAD_EAST", GamepadStart + GLFW_GAMEPAD_BUTTON_CIRCLE},
-    {"GAMEPAD_WEST", GamepadStart + GLFW_GAMEPAD_BUTTON_SQUARE},
-    {"GAMEPAD_NORTH", GamepadStart + GLFW_GAMEPAD_BUTTON_TRIANGLE},
+    // Gamepad button
+    {"GAMEPAD_SOUTH", getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_CROSS)},
+    {"GAMEPAD_EAST", getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_CIRCLE)},
+    {"GAMEPAD_WEST", getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_SQUARE)},
+    {"GAMEPAD_NORTH", getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_TRIANGLE)},
 
-    {"GAMEPAD_BUMPER_LEFT", GamepadStart + GLFW_GAMEPAD_BUTTON_LEFT_BUMPER},
-    {"GAMEPAD_BUMPER_RIGHT", GamepadStart + GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER},
+    {"GAMEPAD_BUMPER_LEFT",
+     getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_LEFT_BUMPER)},
+    {"GAMEPAD_BUMPER_RIGHT",
+     getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER)},
 
-    {"GAMEPAD_THUMB_LEFT", GamepadStart + GLFW_GAMEPAD_BUTTON_LEFT_THUMB},
-    {"GAMEPAD_THUMB_RIGHT", GamepadStart + GLFW_GAMEPAD_BUTTON_RIGHT_THUMB},
+    {"GAMEPAD_THUMB_LEFT",
+     getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_LEFT_THUMB)},
+    {"GAMEPAD_THUMB_RIGHT",
+     getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_RIGHT_THUMB)},
 
-    {"GAMEPAD_DPAD_UP", GamepadStart + GLFW_GAMEPAD_BUTTON_DPAD_UP},
-    {"GAMEPAD_DPAD_RIGHT", GamepadStart + GLFW_GAMEPAD_BUTTON_DPAD_RIGHT},
-    {"GAMEPAD_DPAD_DOWN", GamepadStart + GLFW_GAMEPAD_BUTTON_DPAD_DOWN},
-    {"GAMEPAD_DPAD_LEFT", GamepadStart + GLFW_GAMEPAD_BUTTON_DPAD_LEFT},
+    {"GAMEPAD_DPAD_UP", getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_DPAD_UP)},
+    {"GAMEPAD_DPAD_RIGHT",
+     getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_DPAD_RIGHT)},
+    {"GAMEPAD_DPAD_DOWN",
+     getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_DPAD_DOWN)},
+    {"GAMEPAD_DPAD_LEFT",
+     getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_DPAD_LEFT)},
 
-    {"GAMEPAD_START", GamepadStart + GLFW_GAMEPAD_BUTTON_START},
-    {"GAMEPAD_BACK", GamepadStart + GLFW_GAMEPAD_BUTTON_BACK},
+    {"GAMEPAD_START", getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_START)},
+    {"GAMEPAD_BACK", getGamepadButtonFromGlfw(GLFW_GAMEPAD_BUTTON_BACK)},
 
-    {"GAMEPAD_LEFT_X", GamepadAxisStart + GLFW_GAMEPAD_AXIS_LEFT_X},
-    {"GAMEPAD_LEFT_Y", GamepadAxisStart + GLFW_GAMEPAD_AXIS_LEFT_Y},
-    {"GAMEPAD_RIGHT_X", GamepadAxisStart + GLFW_GAMEPAD_AXIS_RIGHT_Y},
-    {"GAMEPAD_RIGHT_Y", GamepadAxisStart + GLFW_GAMEPAD_AXIS_RIGHT_Y},
+    // Gamepad axis
+    {"GAMEPAD_LEFT_X", getGamepadAxisFromGlfw(GLFW_GAMEPAD_AXIS_LEFT_X)},
+    {"GAMEPAD_LEFT_Y", getGamepadAxisFromGlfw(GLFW_GAMEPAD_AXIS_LEFT_Y)},
+    {"GAMEPAD_RIGHT_X", getGamepadAxisFromGlfw(GLFW_GAMEPAD_AXIS_RIGHT_X)},
+    {"GAMEPAD_RIGHT_Y", getGamepadAxisFromGlfw(GLFW_GAMEPAD_AXIS_RIGHT_Y)},
 
-    {"GAMEPAD_TRIGGER_LEFT", GamepadAxisStart + GLFW_GAMEPAD_AXIS_LEFT_TRIGGER},
+    {"GAMEPAD_TRIGGER_LEFT",
+     getGamepadAxisFromGlfw(GLFW_GAMEPAD_AXIS_LEFT_TRIGGER)},
     {"GAMEPAD_TRIGGER_RIGHT",
-     GamepadAxisStart + GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER},
+     getGamepadAxisFromGlfw(GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER)},
 
     // End
 };
@@ -151,6 +173,22 @@ int get(const String &key) {
 
   return it->second;
 }
+
+bool isGamepadButton(int key) {
+  return key >= GamepadStart && key < GamepadAxisStart;
+}
+
+bool isGamepadAxis(int key) { return key >= GamepadAxisStart; }
+
+bool isMouseMove(int key) { return key == getMouseMove(); }
+
+int getGlfwKeyboardKey(int key) { return key - KeyboardStart; }
+
+int getGlfwMouseButton(int key) { return key - MouseStart; }
+
+int getGlfwGamepadButton(int key) { return key - GamepadStart; }
+
+int getGlfwGamepadAxis(int key) { return key - GamepadAxisStart; }
 
 InputDataType getKeyDataType(const String &key) {
   auto it = InputDataTypeMap.find(key);

--- a/engine/src/quoll/input/KeyMappings.h
+++ b/engine/src/quoll/input/KeyMappings.h
@@ -8,6 +8,20 @@ bool exists(const String &key);
 
 int get(const String &key);
 
+bool isGamepadButton(int key);
+
+bool isGamepadAxis(int key);
+
+bool isMouseMove(int key);
+
+int getGlfwKeyboardKey(int key);
+
+int getGlfwMouseButton(int key);
+
+int getGlfwGamepadButton(int key);
+
+int getGlfwGamepadAxis(int key);
+
 InputDataType getKeyDataType(const String &key);
 
 } // namespace quoll::input

--- a/engine/src/quoll/scene/private/EntitySerializer.cpp
+++ b/engine/src/quoll/scene/private/EntitySerializer.cpp
@@ -287,6 +287,15 @@ YAML::Node EntitySerializer::createComponentsNode(Entity entity) {
     components["environmentLighting"]["source"] = "skybox";
   }
 
+  if (mEntityDatabase.has<InputMapAssetRef>(entity)) {
+    const auto &component = mEntityDatabase.get<InputMapAssetRef>(entity);
+
+    if (mAssetRegistry.getInputMaps().hasAsset(component.handle)) {
+      components["inputMap"]["asset"] =
+          mAssetRegistry.getInputMaps().getAsset(component.handle).uuid;
+    }
+  }
+
   return components;
 }
 

--- a/engine/src/quoll/scene/private/SceneLoader.cpp
+++ b/engine/src/quoll/scene/private/SceneLoader.cpp
@@ -423,6 +423,17 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
     }
   }
 
+  if (node["inputMap"] && node["inputMap"].IsMap()) {
+    auto uuid = node["inputMap"]["asset"].as<Uuid>(Uuid{});
+    auto handle = mAssetRegistry.getInputMaps().findHandleByUuid(uuid);
+
+    if (handle != InputMapAssetHandle::Null) {
+      auto type = mAssetRegistry.getInputMaps().getAsset(handle).type;
+
+      mEntityDatabase.set<InputMapAssetRef>(entity, {handle});
+    }
+  }
+
   return Result<bool>::Ok(true);
 }
 

--- a/engine/src/quoll/window/Window.h
+++ b/engine/src/quoll/window/Window.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "quoll/events/EventSystem.h"
+#include "quoll/input/InputDeviceManager.h"
 
 struct GLFWwindow;
 
@@ -20,10 +21,11 @@ public:
    * @param title Window title
    * @param width Window width
    * @param height Window height
+   * @param deviceManager Device manager
    * @param eventSystem Event system
    */
   Window(StringView title, uint32_t width, uint32_t height,
-         EventSystem &eventSystem);
+         InputDeviceManager &deviceManager, EventSystem &eventSystem);
 
   /**
    * @brief Destroys window
@@ -141,6 +143,16 @@ public:
   void focus();
 
 private:
+  InputStateValue getKeyboardState(int key);
+
+  InputStateValue getMouseState(int key);
+
+  InputStateValue getGamepadState(int jid, int key);
+
+  static void addGamepad(int jid, Window *window);
+
+private:
+  InputDeviceManager &mDeviceManager;
   EventSystem &mEventSystem;
   ::GLFWwindow *mWindowInstance;
 

--- a/engine/tests/quoll-tests/asset/AssetCacheInputMap.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheInputMap.test.cpp
@@ -90,6 +90,16 @@ TEST_F(AssetCacheInputMapTest,
 
   // Control schemes
   {
+    auto res = loadInputMap([](auto &node) {
+      YAML::Node item;
+      item["name"] = "Test scheme";
+
+      node["schemes"].push_back(item);
+    });
+    EXPECT_TRUE(res.hasError());
+  }
+
+  {
     auto res = loadInputMap([](auto &node) { node["schemes"] = "test"; });
     EXPECT_TRUE(res.hasError());
   }
@@ -111,6 +121,17 @@ TEST_F(AssetCacheInputMapTest,
   }
 
   // Commands
+  {
+    auto res = loadInputMap([](auto &node) {
+      YAML::Node item;
+      item["name"] = "Test command";
+      item["type"] = "boolean";
+
+      node["commands"].push_back(item);
+    });
+    EXPECT_TRUE(res.hasError());
+  }
+
   {
     auto res = loadInputMap([](auto &node) { node["commands"] = "test"; });
     EXPECT_TRUE(res.hasError());

--- a/engine/tests/quoll-tests/input/InputMapSystem.test.cpp
+++ b/engine/tests/quoll-tests/input/InputMapSystem.test.cpp
@@ -1,0 +1,386 @@
+#include "quoll/core/Base.h"
+#include "quoll/input/InputMapSystem.h"
+#include "quoll/input/KeyMappings.h"
+
+#include "quoll-tests/Testing.h"
+#include "quoll/asset/AssetRegistry.h"
+
+#include <GLFW/glfw3.h>
+
+class InputMapSystemTest : public ::testing::Test {
+public:
+  InputMapSystemTest() {
+    deviceManager.addDevice({.type = quoll::InputDeviceType::Keyboard,
+                             .name = "Test device",
+                             .index = 0,
+                             .stateFn = [this](int key) {
+                               return inputStates.contains(key)
+                                          ? inputStates.at(key)
+                                          : false;
+                             }});
+  }
+
+  void setInputState(int key, bool value) {
+    inputStates.insert_or_assign(key, value);
+  }
+
+  void setInputState(int key, float value) {
+    inputStates.insert_or_assign(key, value);
+  }
+
+  void setInputState(int key, glm::vec2 value) {
+    inputStates.insert_or_assign(key, value);
+  }
+
+  std::unordered_map<int, quoll::InputStateValue> inputStates;
+
+  quoll::Entity createInputMap() {
+    quoll::AssetData<quoll::InputMapAsset> asset{};
+    asset.data.commands.push_back({"Jump", quoll::InputDataType::Boolean});
+    asset.data.commands.push_back({"Move", quoll::InputDataType::Axis2d});
+    asset.data.commands.push_back({"Look", quoll::InputDataType::Axis2d});
+    asset.data.commands.push_back({"Shoot", quoll::InputDataType::Boolean});
+
+    // Null data for testing purposes
+    asset.data.bindings.push_back({0, 2, quoll::InputMapAxis2dValue{-1, -1}});
+
+    // Jump
+    asset.data.bindings.push_back({0, 0, quoll::input::get("GAMEPAD_SOUTH")});
+    asset.data.bindings.push_back({1, 0, quoll::input::get("KEY_SPACE")});
+
+    // Move
+    asset.data.bindings.push_back(
+        {0, 1,
+         quoll::InputMapAxis2dValue{quoll::input::get("GAMEPAD_LEFT_X"),
+                                    quoll::input::get("GAMEPAD_LEFT_Y")}});
+    asset.data.bindings.push_back(
+        {1, 1,
+         quoll::InputMapAxis2dValue{
+             quoll::InputMapAxisSegment{quoll::input::get("KEY_A"),
+                                        quoll::input::get("KEY_D")},
+             quoll::InputMapAxisSegment{quoll::input::get("KEY_W"),
+                                        quoll::input::get("KEY_S")}}});
+
+    // Look
+    asset.data.bindings.push_back({1, 2, quoll::input::get("MOUSE_MOVE")});
+
+    // Shoot
+    asset.data.bindings.push_back({1, 3, quoll::input::get("MOUSE_LEFT")});
+    asset.data.bindings.push_back(
+        {0, 3, quoll::input::get("GAMEPAD_BUMPER_RIGHT")});
+
+    asset.uuid = quoll::Uuid::generate();
+    auto handle = registry.getInputMaps().addAsset(asset);
+
+    auto entity = db.create();
+    db.set<quoll::InputMapAssetRef>(entity, {handle});
+
+    return entity;
+  }
+
+  quoll::AssetRegistry registry;
+  quoll::InputDeviceManager deviceManager;
+  quoll::InputMapSystem inputMapSystem{deviceManager, registry};
+  quoll::EntityDatabase db;
+};
+
+TEST_F(InputMapSystemTest,
+       CreateInputMapComponentFromAssetRefIfInputMapComponentDoesNotExist) {
+  auto entity = createInputMap();
+
+  inputMapSystem.update(db);
+
+  EXPECT_TRUE(db.has<quoll::InputMap>(entity));
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  EXPECT_EQ(inputMap.commandNameMap.size(), 4);
+  EXPECT_EQ(inputMap.commandNameMap.at("Jump"), 0);
+  EXPECT_EQ(inputMap.commandNameMap.at("Move"), 1);
+  EXPECT_EQ(inputMap.commandNameMap.at("Look"), 2);
+  EXPECT_EQ(inputMap.commandNameMap.at("Shoot"), 3);
+
+  EXPECT_EQ(inputMap.commandDataTypes.size(), 4);
+  EXPECT_EQ(inputMap.commandDataTypes.at(0), quoll::InputDataType::Boolean);
+  EXPECT_EQ(inputMap.commandDataTypes.at(1), quoll::InputDataType::Axis2d);
+  EXPECT_EQ(inputMap.commandDataTypes.at(2), quoll::InputDataType::Axis2d);
+  EXPECT_EQ(inputMap.commandDataTypes.at(3), quoll::InputDataType::Boolean);
+
+  auto &bindings = inputMap.inputKeyToCommandMap;
+  EXPECT_EQ(bindings.size(), 11);
+
+  EXPECT_EQ(bindings.at(quoll::input::get("GAMEPAD_SOUTH")), 0);
+  EXPECT_EQ(bindings.at(quoll::input::get("KEY_SPACE")), 0);
+
+  EXPECT_EQ(bindings.at(quoll::input::get("GAMEPAD_LEFT_X")), 1);
+  EXPECT_EQ(bindings.at(quoll::input::get("GAMEPAD_LEFT_Y")), 1);
+  EXPECT_EQ(bindings.at(quoll::input::get("KEY_A")), 1);
+  EXPECT_EQ(bindings.at(quoll::input::get("KEY_D")), 1);
+  EXPECT_EQ(bindings.at(quoll::input::get("KEY_W")), 1);
+  EXPECT_EQ(bindings.at(quoll::input::get("KEY_S")), 1);
+
+  EXPECT_EQ(bindings.at(quoll::input::get("MOUSE_MOVE")), 2);
+
+  EXPECT_EQ(bindings.at(quoll::input::get("MOUSE_LEFT")), 3);
+  EXPECT_EQ(bindings.at(quoll::input::get("GAMEPAD_BUMPER_RIGHT")), 3);
+
+  auto &keyFields = inputMap.inputKeyFields;
+  EXPECT_EQ(keyFields.at(quoll::input::get("GAMEPAD_LEFT_X")),
+            quoll::InputDataTypeField::X);
+  EXPECT_EQ(keyFields.at(quoll::input::get("GAMEPAD_LEFT_Y")),
+            quoll::InputDataTypeField::Y);
+  EXPECT_EQ(keyFields.at(quoll::input::get("KEY_A")),
+            quoll::InputDataTypeField::X0);
+  EXPECT_EQ(keyFields.at(quoll::input::get("KEY_D")),
+            quoll::InputDataTypeField::X1);
+  EXPECT_EQ(keyFields.at(quoll::input::get("KEY_W")),
+            quoll::InputDataTypeField::Y0);
+  EXPECT_EQ(keyFields.at(quoll::input::get("KEY_S")),
+            quoll::InputDataTypeField::Y1);
+}
+
+TEST_F(InputMapSystemTest, DeleteInputMapComponentIfAssetRefIsDeleted) {
+  auto entity = db.create();
+  db.set<quoll::InputMap>(entity, {});
+
+  inputMapSystem.update(db);
+
+  EXPECT_FALSE(db.has<quoll::InputMap>(entity));
+}
+
+using InputMapSystemBooleanValueTest = InputMapSystemTest;
+
+TEST_F(InputMapSystemBooleanValueTest,
+       SetsValueToTrueWhenBooleanKeyStateIsTrue) {
+  auto key = quoll::input::get("KEY_SPACE");
+  auto entity = createInputMap();
+
+  setInputState(key, true);
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<bool>(inputMap.commandValues.at(command)), true);
+}
+
+TEST_F(InputMapSystemBooleanValueTest,
+       SetsValueToFalseWhenBooleanKeyStateIsFalse) {
+  auto key = GLFW_KEY_SPACE;
+  auto entity = createInputMap();
+
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command =
+      inputMap.inputKeyToCommandMap.at(quoll::input::get("KEY_SPACE"));
+
+  EXPECT_EQ(std::get<bool>(inputMap.commandValues.at(command)), false);
+}
+
+TEST_F(InputMapSystemBooleanValueTest,
+       SetsValueToTrueIfFloatKeyStateIsNotZero) {
+  auto key = quoll::input::get("KEY_SPACE");
+  auto entity = createInputMap();
+
+  setInputState(key, -1.0f);
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<bool>(inputMap.commandValues.at(command)), true);
+}
+
+TEST_F(InputMapSystemBooleanValueTest, SetsValueToFalseIfFloatKeyStateIsZero) {
+  auto key = quoll::input::get("KEY_SPACE");
+  auto entity = createInputMap();
+
+  setInputState(key, 0.0f);
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<bool>(inputMap.commandValues.at(command)), false);
+}
+
+TEST_F(InputMapSystemBooleanValueTest, SetsValueToTrueIfVec2StateIsNotZero) {
+  auto key = quoll::input::get("KEY_SPACE");
+  auto entity = createInputMap();
+
+  setInputState(key, glm::vec2{0.0f, 0.2f});
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<bool>(inputMap.commandValues.at(command)), true);
+}
+
+TEST_F(InputMapSystemBooleanValueTest, SetsValueToFalseIfVec2StateIsZero) {
+  auto key = quoll::input::get("KEY_SPACE");
+  auto entity = createInputMap();
+
+  setInputState(key, glm::vec2{0.0f, 0.0f});
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<bool>(inputMap.commandValues.at(command)), false);
+}
+
+using InputMapSystemAxis2dValueTest = InputMapSystemTest;
+
+TEST_F(InputMapSystemAxis2dValueTest, SetsValueToIncomingAxis2dInput) {
+  auto key = quoll::input::get("MOUSE_MOVE");
+  auto entity = createInputMap();
+
+  setInputState(key, glm::vec2{-0.4f, 0.2f});
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<glm::vec2>(inputMap.commandValues.at(command)),
+            glm::vec2(-0.4f, 0.2f));
+}
+
+TEST_F(InputMapSystemAxis2dValueTest, SetsXValueToIncomingFloatInput) {
+  auto key = quoll::input::get("GAMEPAD_LEFT_X");
+  auto entity = createInputMap();
+
+  setInputState(key, 0.5f);
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<glm::vec2>(inputMap.commandValues.at(command)),
+            glm::vec2(0.5f, 0.0f));
+}
+
+TEST_F(InputMapSystemAxis2dValueTest, SetsYValueToIncomingFloatInput) {
+  auto key = quoll::input::get("GAMEPAD_LEFT_Y");
+  auto entity = createInputMap();
+
+  setInputState(key, -0.8f);
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<glm::vec2>(inputMap.commandValues.at(command)),
+            glm::vec2(0.0f, -0.8f));
+}
+
+TEST_F(InputMapSystemAxis2dValueTest,
+       SetsXValueToNegativeOneIfIncomingBooleanIsX0) {
+  auto key = quoll::input::get("KEY_A");
+  auto entity = createInputMap();
+
+  setInputState(key, true);
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<glm::vec2>(inputMap.commandValues.at(command)),
+            glm::vec2(-1.0f, 0.0f));
+}
+
+TEST_F(InputMapSystemAxis2dValueTest, SetsXValueToOneIfIncomingBooleanIsX1) {
+  auto key = quoll::input::get("KEY_D");
+  auto entity = createInputMap();
+
+  setInputState(key, true);
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<glm::vec2>(inputMap.commandValues.at(command)),
+            glm::vec2(1.0f, 0.0f));
+}
+
+TEST_F(InputMapSystemAxis2dValueTest, SetsYValueToOneIfIncomingBooleanIsY0) {
+  auto key = quoll::input::get("KEY_W");
+  auto entity = createInputMap();
+
+  setInputState(key, true);
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<glm::vec2>(inputMap.commandValues.at(command)),
+            glm::vec2(0.0f, 1.0f));
+}
+
+TEST_F(InputMapSystemAxis2dValueTest,
+       SetsYValueToNegativeOneIfIncomingBooleanIsY1) {
+  auto key = quoll::input::get("KEY_S");
+  auto entity = createInputMap();
+
+  setInputState(key, true);
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(key);
+
+  EXPECT_EQ(std::get<glm::vec2>(inputMap.commandValues.at(command)),
+            glm::vec2(0.0f, -1.0f));
+}
+
+TEST_F(InputMapSystemAxis2dValueTest, ClampsPositiveValueToOne) {
+  auto keyX = quoll::input::get("GAMEPAD_LEFT_X");
+  auto keyY = quoll::input::get("GAMEPAD_LEFT_Y");
+
+  auto entity = createInputMap();
+
+  setInputState(keyX, 2.5f);
+  setInputState(keyY, 2.5f);
+
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(keyX);
+
+  EXPECT_EQ(std::get<glm::vec2>(inputMap.commandValues.at(command)),
+            glm::vec2(1.0f, 1.0f));
+}
+
+TEST_F(InputMapSystemAxis2dValueTest, ClampsNegativeValueToNegativeOne) {
+  auto keyX = quoll::input::get("GAMEPAD_LEFT_X");
+  auto keyY = quoll::input::get("GAMEPAD_LEFT_Y");
+
+  auto entity = createInputMap();
+
+  setInputState(keyX, -2.5f);
+  setInputState(keyY, -2.5f);
+
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(keyX);
+
+  EXPECT_EQ(std::get<glm::vec2>(inputMap.commandValues.at(command)),
+            glm::vec2(-1.0f, -1.0f));
+}
+
+TEST_F(InputMapSystemAxis2dValueTest, AddsMultipleInputValuesTogether) {
+  auto keyX = quoll::input::get("GAMEPAD_LEFT_X");
+  auto keyY = quoll::input::get("GAMEPAD_LEFT_Y");
+
+  auto entity = createInputMap();
+
+  setInputState(keyX, -0.2f);
+  setInputState(keyY, 0.4f);
+
+  inputMapSystem.update(db);
+
+  auto inputMap = db.get<quoll::InputMap>(entity);
+  auto command = inputMap.inputKeyToCommandMap.at(keyX);
+
+  EXPECT_EQ(std::get<glm::vec2>(inputMap.commandValues.at(command)),
+            glm::vec2(-0.2f, 0.4f));
+}

--- a/engine/tests/quoll-tests/scene/private/EntitySerializer.test.cpp
+++ b/engine/tests/quoll-tests/scene/private/EntitySerializer.test.cpp
@@ -131,7 +131,7 @@ TEST_F(EntitySerializerTest,
   entityDatabase.set<quoll::Sprite>(entity, {NonExistentMeshHandle});
 
   auto node = entitySerializer.createComponentsNode(entity);
-  EXPECT_FALSE(node["mesh"]);
+  EXPECT_FALSE(node["sprite"]);
 }
 
 TEST_F(EntitySerializerTest, CreatesSpriteFieldIfTextureAssetIsInRegistry) {
@@ -993,4 +993,36 @@ TEST_F(EntitySerializerTest,
   EXPECT_TRUE(node["environmentLighting"]);
   EXPECT_EQ(node["environmentLighting"]["source"].as<quoll::String>(""),
             "skybox");
+}
+
+TEST_F(EntitySerializerTest,
+       DoesNotCreateInputMapFieldIfNoInputMapRefComponent) {
+  auto entity = entityDatabase.create();
+  auto node = entitySerializer.createComponentsNode(entity);
+  EXPECT_FALSE(node["inputMap"]);
+}
+
+TEST_F(EntitySerializerTest,
+       DoesNotCreateInputMapFieldIfInputMapAssetDoesNotExist) {
+  auto entity = entityDatabase.create();
+  entityDatabase.set<quoll::InputMapAssetRef>(entity,
+                                              {quoll::InputMapAssetHandle{25}});
+
+  auto node = entitySerializer.createComponentsNode(entity);
+  EXPECT_FALSE(node["inputMap"]);
+}
+
+TEST_F(EntitySerializerTest,
+       CreatesInputMapFieldIfComponentExistsAndAssetIsValid) {
+  quoll::AssetData<quoll::InputMapAsset> asset{};
+  asset.uuid = quoll::Uuid("inputMap.asset");
+
+  auto handle = assetRegistry.getInputMaps().addAsset(asset);
+
+  auto entity = entityDatabase.create();
+  entityDatabase.set<quoll::InputMapAssetRef>(entity, {handle});
+
+  auto node = entitySerializer.createComponentsNode(entity);
+  EXPECT_TRUE(node["inputMap"]);
+  EXPECT_EQ(node["inputMap"]["asset"].as<quoll::String>(""), "inputMap.asset");
 }

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -36,7 +36,8 @@ void Runtime::start() {
 
   quoll::Scene scene;
   quoll::EventSystem eventSystem;
-  quoll::Window window(mConfig.name, Width, Height, eventSystem);
+  quoll::InputDeviceManager deviceManager;
+  quoll::Window window(mConfig.name, Width, Height, deviceManager, eventSystem);
   quoll::AssetCache assetCache(std::filesystem::current_path() / "assets",
                                true);
 

--- a/scripts/generate-key-mappings.py
+++ b/scripts/generate-key-mappings.py
@@ -1,6 +1,6 @@
 def glfw(k):
     upper_k = f'{k}'.upper()
-    return f'GLFW_KEY_{upper_k}'
+    return f'getKeyboardKeyFromGlfw(GLFW_KEY_{upper_k})'
 
 def print_map(key, glfw_key):
     print('{"', f'KEY_{key}', '", ', glfw(glfw_key), '},', sep='')


### PR DESCRIPTION
- Create input map and input map asset ref components
- Add UI to create, update, and delete input map
- Add device manager that tracks all enabled devices
- Map incoming system inputs to logical commands and store command values
- Add input map system to editor and runtime
- Recognize joystics in GLFW
- Show debug information about captured inputs in input map entity panel
- Disallow duplicate scheme and command names in input map asset