### PR TITLE
Add input map schemes

### DIFF
--- a/engine/src/quoll/input/InputMap.h
+++ b/engine/src/quoll/input/InputMap.h
@@ -15,6 +15,29 @@ struct InputMapAssetRef {
    * Asset handle
    */
   InputMapAssetHandle handle = InputMapAssetHandle::Null;
+
+  /**
+   * Default scheme
+   */
+  size_t defaultScheme = 0;
+};
+
+/**
+ * @brief Binding table for input map
+ */
+struct InputMapBindingTable {
+  /**
+   * Input key to command map
+   */
+  std::unordered_map<int, size_t> inputKeyToCommandMap;
+
+  /**
+   * Used to identify what part of a value
+   * the key represents
+   *
+   * Used non-boolean value types
+   */
+  std::unordered_map<int, InputDataTypeField> inputKeyFields;
 };
 
 /**
@@ -32,22 +55,24 @@ struct InputMap {
   std::unordered_map<String, size_t> commandNameMap;
 
   /**
-   * Input key to command map
-   */
-  std::unordered_map<int, size_t> inputKeyToCommandMap;
-
-  /**
    * Command values
    */
   std::vector<std::variant<bool, glm::vec2>> commandValues;
 
   /**
-   * Used to identify what part of a value
-   * the key represents
-   *
-   * Used non-boolean value types
+   * Binding tables based on scheme
    */
-  std::unordered_map<int, InputDataTypeField> inputKeyFields;
+  std::vector<InputMapBindingTable> schemes;
+
+  /**
+   * Scheme name to internal scheme key map
+   */
+  std::unordered_map<String, size_t> schemeNameMap;
+
+  /**
+   * Currently active scheme
+   */
+  size_t activeScheme = 0;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/input/InputMapScriptingInterface.cpp
+++ b/engine/src/quoll/input/InputMapScriptingInterface.cpp
@@ -127,7 +127,7 @@ int InputMapScriptingInterface::LuaInterface::getCommandValueAxis2d(
 
   if (!scope.is<LuaTable>(1)) {
     Engine::getUserLogger().error()
-        << LuaMessages::noEntityTable(getName(), "get_command_value_boolean");
+        << LuaMessages::noEntityTable(getName(), "get_command_value_axis_2d");
 
     scope.set(0.0f);
     scope.set(0.0f);
@@ -136,7 +136,7 @@ int InputMapScriptingInterface::LuaInterface::getCommandValueAxis2d(
 
   if (!scope.is<uint32_t>(2)) {
     Engine::getUserLogger().error() << LuaMessages::invalidArguments<uint32_t>(
-        getName(), "get_command_value_boolean");
+        getName(), "get_command_value_axis_2d");
 
     scope.set(0.0f);
     scope.set(0.0f);
@@ -184,6 +184,52 @@ int InputMapScriptingInterface::LuaInterface::getCommandValueAxis2d(
   }
 
   return 2;
+}
+
+int InputMapScriptingInterface::LuaInterface::setScheme(void *state) {
+  LuaScope scope(state);
+
+  if (!scope.is<LuaTable>(1)) {
+    Engine::getUserLogger().error()
+        << LuaMessages::noEntityTable(getName(), "set_scheme");
+
+    return 0;
+  }
+
+  if (!scope.is<String>(2)) {
+    Engine::getUserLogger().error()
+        << LuaMessages::invalidArguments<String>(getName(), "set_scheme");
+
+    return 0;
+  }
+
+  auto entityTable = scope.get<LuaTable>(1);
+  entityTable.get("id");
+  Entity entity = scope.get<Entity>();
+  scope.pop(1);
+
+  auto name = scope.get<String>(2);
+  scope.pop(2);
+
+  EntityDatabase &entityDatabase = *static_cast<EntityDatabase *>(
+      scope.getGlobal<LuaUserData>("__privateDatabase").pointer);
+
+  if (!entityDatabase.has<InputMap>(entity)) {
+    Engine::getUserLogger().error()
+        << LuaMessages::componentDoesNotExist(getName(), entity);
+    return 0;
+  }
+
+  auto &inputMap = entityDatabase.get<InputMap>(entity);
+  if (!inputMap.schemeNameMap.contains(name)) {
+    Engine::getUserLogger().error()
+        << "Input scheme \"" << name << "\" does not exist";
+    return 0;
+  }
+
+  inputMap.activeScheme = inputMap.schemeNameMap.at(name);
+
+  return 0;
 }
 
 } // namespace quoll

--- a/engine/src/quoll/input/InputMapScriptingInterface.h
+++ b/engine/src/quoll/input/InputMapScriptingInterface.h
@@ -35,7 +35,7 @@ public:
   static int getCommandValueBoolean(void *state);
 
   /**
-   * @brief Set static friction
+   * @brief Get axis 2d command value
    *
    * @param state Lua state
    * @return Number of arguments
@@ -43,13 +43,22 @@ public:
   static int getCommandValueAxis2d(void *state);
 
   /**
+   * @brief Set scheme
+   *
+   * @param state Lua state
+   * @return Number of arguments
+   */
+  static int setScheme(void *state);
+
+  /**
    * @brief Interface fields
    */
-  static constexpr std::array<InterfaceField, 4> Fields{
+  static constexpr std::array<InterfaceField, 5> Fields{
       InterfaceField{"get_command", getCommand},
       InterfaceField{"get_value_boolean", getCommandValueBoolean},
       InterfaceField{"get_value_axis_2d", getCommandValueAxis2d},
-      InterfaceField{"is_pressed", getCommandValueBoolean}};
+      InterfaceField{"is_pressed", getCommandValueBoolean},
+      InterfaceField{"set_scheme", setScheme}};
 
   /**
    * @brief Get component name in scripts

--- a/engine/src/quoll/input/InputMapSystem.h
+++ b/engine/src/quoll/input/InputMapSystem.h
@@ -31,7 +31,7 @@ public:
   void update(EntityDatabase &entityDatabase);
 
 private:
-  InputMap createInputMap(InputMapAsset &asset);
+  InputMap createInputMap(InputMapAsset &asset, size_t defaultScheme);
 
 private:
   InputDeviceManager &mDeviceManager;

--- a/engine/src/quoll/scene/private/EntitySerializer.cpp
+++ b/engine/src/quoll/scene/private/EntitySerializer.cpp
@@ -293,6 +293,7 @@ YAML::Node EntitySerializer::createComponentsNode(Entity entity) {
     if (mAssetRegistry.getInputMaps().hasAsset(component.handle)) {
       components["inputMap"]["asset"] =
           mAssetRegistry.getInputMaps().getAsset(component.handle).uuid;
+      components["inputMap"]["defaultScheme"] = component.defaultScheme;
     }
   }
 

--- a/engine/src/quoll/scene/private/SceneLoader.cpp
+++ b/engine/src/quoll/scene/private/SceneLoader.cpp
@@ -425,12 +425,13 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
 
   if (node["inputMap"] && node["inputMap"].IsMap()) {
     auto uuid = node["inputMap"]["asset"].as<Uuid>(Uuid{});
+    auto defaultScheme = node["inputMap"]["defaultScheme"].as<size_t>(0);
     auto handle = mAssetRegistry.getInputMaps().findHandleByUuid(uuid);
 
     if (handle != InputMapAssetHandle::Null) {
       auto type = mAssetRegistry.getInputMaps().getAsset(handle).type;
 
-      mEntityDatabase.set<InputMapAssetRef>(entity, {handle});
+      mEntityDatabase.set<InputMapAssetRef>(entity, {handle, defaultScheme});
     }
   }
 

--- a/engine/tests/fixtures/scripting-system-component-tester.lua
+++ b/engine/tests/fixtures/scripting-system-component-tester.lua
@@ -856,7 +856,6 @@ function input_get_value_boolean_table()
     input_command_value = entity.input:get_value_boolean({})
 end
 
-
 --- get_value_axis_2d
 function input_get_value_axis_2d()
     command = entity.input:get_command("Test")
@@ -897,4 +896,17 @@ function input_get_value_axis_2d_table()
     input_command_value_x, input_command_value_y = entity.input:get_value_axis_2d({})
 end
  
+--- set_scheme
+function input_set_scheme()
+    entity.input:set_scheme("Test scheme")
+end
 
+function input_set_scheme_invalid()
+    entity.input.set_scheme("Test scheme")
+    entity.input:set_scheme()
+    entity.input:set_scheme(10)
+    entity.input:set_scheme(true)
+    entity.input:set_scheme(nil)
+    entity.input:set_scheme({})
+    entity.input:set_scheme(entity_query_get_first_by_name)
+end

--- a/engine/tests/quoll-tests/scene/private/EntitySerializer.test.cpp
+++ b/engine/tests/quoll-tests/scene/private/EntitySerializer.test.cpp
@@ -1020,9 +1020,10 @@ TEST_F(EntitySerializerTest,
   auto handle = assetRegistry.getInputMaps().addAsset(asset);
 
   auto entity = entityDatabase.create();
-  entityDatabase.set<quoll::InputMapAssetRef>(entity, {handle});
+  entityDatabase.set<quoll::InputMapAssetRef>(entity, {handle, 0});
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_TRUE(node["inputMap"]);
   EXPECT_EQ(node["inputMap"]["asset"].as<quoll::String>(""), "inputMap.asset");
+  EXPECT_EQ(node["inputMap"]["defaultScheme"].as<uint32_t>(999), 0);
 }


### PR DESCRIPTION
- Add default scheme to input map component
- Save and load default scheme for input map
- Add default scheme control in editor
- Switch all bindings based on default scheme
- Add scripting interface to switch current scheme