### PR TITLE
Fix camera aspect ratio in editor

### DIFF
--- a/editor/src/quoll/editor/core/EditorSimulator.cpp
+++ b/editor/src/quoll/editor/core/EditorSimulator.cpp
@@ -8,7 +8,6 @@ EditorSimulator::EditorSimulator(InputDeviceManager &deviceManager,
                                  AssetRegistry &assetRegistry,
                                  EditorCamera &editorCamera)
     : mInputMapSystem(deviceManager, assetRegistry),
-      mCameraAspectRatioUpdater(window),
       mScriptingSystem(eventSystem, assetRegistry),
       mAnimationSystem(assetRegistry),
       mPhysicsSystem(PhysicsSystem::createPhysxBackend(eventSystem)),

--- a/editor/src/quoll/editor/core/EditorSimulator.h
+++ b/editor/src/quoll/editor/core/EditorSimulator.h
@@ -57,6 +57,15 @@ public:
    */
   inline PhysicsSystem &getPhysicsSystem() { return mPhysicsSystem; }
 
+  /**
+   * @brief Get camera aspect ratio updater
+   *
+   * @return Camera aspect ratio updater
+   */
+  inline CameraAspectRatioUpdater &getCameraAspectRatioUpdater() {
+    return mCameraAspectRatioUpdater;
+  }
+
 private:
   /**
    * @brief Cleanup simulation database

--- a/editor/src/quoll/editor/editor-scene/EditorCamera.cpp
+++ b/editor/src/quoll/editor/editor-scene/EditorCamera.cpp
@@ -58,7 +58,7 @@ EditorCamera::EditorCamera(EventSystem &eventSystem, Window &window)
         }
 
         static constexpr float MinOOBThreshold = 2.0f;
-        const auto &size = mWindow.getWindowSize();
+        const auto &size = mWindow.getFramebufferSize();
 
         float minX = 0;
         float maxX = static_cast<float>(size.x);

--- a/editor/src/quoll/editor/screens/EditorScreen.cpp
+++ b/editor/src/quoll/editor/screens/EditorScreen.cpp
@@ -144,7 +144,7 @@ void EditorScreen::start(const Project &rawProject) {
 
   mousePicking.setFramebufferSize(mWindow.getFramebufferSize());
 
-  mWindow.addResizeHandler([&](auto width, auto height) {
+  mWindow.addFramebufferResizeHandler([&](auto width, auto height) {
     renderer.setFramebufferSize({width, height});
     mousePicking.setFramebufferSize({width, height});
     presenter.enqueueFramebufferUpdate();
@@ -224,7 +224,8 @@ void EditorScreen::start(const Project &rawProject) {
     logViewer.render(userLogStorage);
 
     bool mouseClicked =
-        ui.renderSceneView(context, renderer.getSceneTexture(), editorCamera);
+        ui.renderSceneView(context, renderer.getSceneTexture(), editorCamera,
+                           simulator.getCameraAspectRatioUpdater());
 
     StatusBar::render(editorCamera);
 

--- a/editor/src/quoll/editor/screens/ProjectSelectorScreen.cpp
+++ b/editor/src/quoll/editor/screens/ProjectSelectorScreen.cpp
@@ -55,10 +55,11 @@ std::optional<Project> ProjectSelectorScreen::start() {
     return RendererTextures{imguiPassData.imguiColor, imguiPassData.imguiColor};
   });
 
-  auto resizeHandler = mWindow.addResizeHandler([&](auto width, auto height) {
-    renderer.setFramebufferSize({width, height});
-    presenter.enqueueFramebufferUpdate();
-  });
+  auto resizeHandler =
+      mWindow.addFramebufferResizeHandler([&](auto width, auto height) {
+        renderer.setFramebufferSize({width, height});
+        presenter.enqueueFramebufferUpdate();
+      });
 
   mainLoop.setUpdateFn([&project, this](float dt) {
     mEventSystem.poll();

--- a/editor/src/quoll/editor/ui/UIRoot.cpp
+++ b/editor/src/quoll/editor/ui/UIRoot.cpp
@@ -55,13 +55,16 @@ void UIRoot::render(WorkspaceContext &context) {
 
 bool UIRoot::renderSceneView(WorkspaceContext &context,
                              rhi::TextureHandle sceneTexture,
-                             EditorCamera &editorCamera) {
+                             EditorCamera &editorCamera,
+                             CameraAspectRatioUpdater &aspectRatioUpdater) {
   if (auto _ = SceneView(sceneTexture)) {
     const auto &pos = ImGui::GetItemRectMin();
     const auto &size = ImGui::GetItemRectSize();
 
     editorCamera.setViewport(pos.x, pos.y, size.x, size.y,
                              ImGui::IsItemHovered());
+    aspectRatioUpdater.setViewportSize(
+        {static_cast<uint32_t>(size.x), static_cast<uint32_t>(size.y)});
 
     bool isItemClicked = ImGui::IsItemClicked(ImGuiMouseButton_Left);
 

--- a/editor/src/quoll/editor/ui/UIRoot.h
+++ b/editor/src/quoll/editor/ui/UIRoot.h
@@ -3,6 +3,7 @@
 #include "quoll/animation/AnimationSystem.h"
 #include "quoll/physics/PhysicsSystem.h"
 #include "quoll/renderer/Renderer.h"
+#include "quoll/scene/CameraAspectRatioUpdater.h"
 
 #include "Toolbar.h"
 #include "SceneHierarchyPanel.h"
@@ -50,12 +51,14 @@ public:
    * @param context Workspace context
    * @param sceneTexture Scene texture
    * @param editorCamera Editor camera
+   * @param aspectRatioUpdater Aspect ratio updater
    * @retval true Entity is clicked
    * @retval false Entity is not clicked
    */
   bool renderSceneView(WorkspaceContext &context,
                        rhi::TextureHandle sceneTexture,
-                       EditorCamera &editorCamera);
+                       EditorCamera &editorCamera,
+                       CameraAspectRatioUpdater &aspectRatioUpdater);
 
   /**
    * @brief Get asset browser panel

--- a/engine/src/quoll/loop/MainLoop.cpp
+++ b/engine/src/quoll/loop/MainLoop.cpp
@@ -51,7 +51,7 @@ void MainLoop::run() {
       accumulator -= TimeDelta;
     }
 
-    const auto &size = mWindow.getWindowSize();
+    const auto &size = mWindow.getFramebufferSize();
     if (size.x > 0 && size.y > 0) {
       mRenderFn();
     }

--- a/engine/src/quoll/scene/CameraAspectRatioUpdater.cpp
+++ b/engine/src/quoll/scene/CameraAspectRatioUpdater.cpp
@@ -3,20 +3,21 @@
 
 namespace quoll {
 
-CameraAspectRatioUpdater::CameraAspectRatioUpdater(Window &window)
-    : mWindow(window) {}
-
 void CameraAspectRatioUpdater::update(EntityDatabase &entityDatabase) {
   QUOLL_PROFILE_EVENT("CameraAspectRatioUpdater::update");
-  const auto &size = mWindow.getWindowSize();
 
-  if (size.x <= 0 || size.y <= 0)
+  if (mSize.x <= 0 || mSize.y <= 0)
     return;
 
   for (auto [_, lens, _1] :
        entityDatabase.view<PerspectiveLens, AutoAspectRatio>()) {
-    lens.aspectRatio = static_cast<float>(size.x) / static_cast<float>(size.y);
+    lens.aspectRatio =
+        static_cast<float>(mSize.x) / static_cast<float>(mSize.y);
   }
+}
+
+void CameraAspectRatioUpdater::setViewportSize(glm::uvec2 size) {
+  mSize = size;
 }
 
 } // namespace quoll

--- a/engine/src/quoll/scene/CameraAspectRatioUpdater.h
+++ b/engine/src/quoll/scene/CameraAspectRatioUpdater.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "quoll/window/Window.h"
 #include "quoll/entity/EntityDatabase.h"
 
 namespace quoll {
@@ -14,21 +13,21 @@ namespace quoll {
 class CameraAspectRatioUpdater {
 public:
   /**
-   * @brief Create camera aspect ratio updater
-   *
-   * @param window Window
-   */
-  CameraAspectRatioUpdater(Window &window);
-
-  /**
    * @brief Update aspect ratios
    *
    * @param entityDatabase Entity database
    */
   void update(EntityDatabase &entityDatabase);
 
+  /**
+   * @brief Set viewport size
+   *
+   * @param size Viewport size
+   */
+  void setViewportSize(glm::uvec2 size);
+
 private:
-  Window &mWindow;
+  glm::uvec2 mSize{};
 };
 
 } // namespace quoll

--- a/engine/src/quoll/window/Window.cpp
+++ b/engine/src/quoll/window/Window.cpp
@@ -178,7 +178,7 @@ bool Window::shouldClose() { return glfwWindowShouldClose(mWindowInstance); }
 
 void Window::pollEvents() { glfwPollEvents(); }
 
-uint32_t Window::addResizeHandler(
+uint32_t Window::addFramebufferResizeHandler(
     const std::function<void(uint32_t, uint32_t)> &handler) {
   uint32_t id = static_cast<uint32_t>(mResizeHandlers.size());
 

--- a/engine/src/quoll/window/Window.h
+++ b/engine/src/quoll/window/Window.h
@@ -84,13 +84,13 @@ public:
   void pollEvents();
 
   /**
-   * @brief Add resize handler
+   * @brief Add framebuffer resize handler
    *
-   * @param handler Resize handler
-   * @return Resize handler ID
+   * @param handler Framebuffer resize handler
+   * @return Framebuffer resize handler ID
    */
-  uint32_t
-  addResizeHandler(const std::function<void(uint32_t, uint32_t)> &handler);
+  uint32_t addFramebufferResizeHandler(
+      const std::function<void(uint32_t, uint32_t)> &handler);
 
   /**
    * @brief Remove resize handler


### PR DESCRIPTION
- Pass width and height to the aspect ratio updater
- Pass scene viewport size to the camera aspect ratio
- Use framebuffer size for all operations in engine
- Rename resize handler to framebuffer resize handler
- Enable input map system in runtime