### PR TITLE
Shorten primitive type names in the engine

### DIFF
--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -6,8 +6,8 @@
 #include "quoll/editor/screens/ProjectSelectorScreen.h"
 
 int main() {
-  static constexpr uint32_t InitialWidth = 1024;
-  static constexpr uint32_t InitialHeight = 768;
+  static constexpr u32 InitialWidth = 1024;
+  static constexpr u32 InitialHeight = 768;
 
   quoll::Engine::setPath(std::filesystem::current_path() / "engine");
 

--- a/editor/src/quoll/editor/actions/EditorGridActions.cpp
+++ b/editor/src/quoll/editor/actions/EditorGridActions.cpp
@@ -15,7 +15,7 @@ ActionExecutorResult SetGridLines::onExecute(WorkspaceState &state,
 
 bool SetGridLines::predicate(WorkspaceState &state,
                              AssetRegistry &assetRegistry) {
-  return state.grid.x != static_cast<uint32_t>(mShow);
+  return state.grid.x != static_cast<u32>(mShow);
 }
 
 bool SetGridAxisLines::isShown(WorkspaceState &state) {
@@ -32,7 +32,7 @@ ActionExecutorResult SetGridAxisLines::onExecute(WorkspaceState &state,
 
 bool SetGridAxisLines::predicate(WorkspaceState &state,
                                  AssetRegistry &assetRegistry) {
-  return state.grid.y != static_cast<uint32_t>(mShow);
+  return state.grid.y != static_cast<u32>(mShow);
 }
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/actions/EntityMeshRendererActions.cpp
+++ b/editor/src/quoll/editor/actions/EntityMeshRendererActions.cpp
@@ -4,7 +4,7 @@
 namespace quoll::editor {
 
 EntitySetMeshRendererMaterial::EntitySetMeshRendererMaterial(
-    Entity entity, size_t slot, MaterialAssetHandle handle)
+    Entity entity, usize slot, MaterialAssetHandle handle)
     : mEntity(entity), mSlot(slot), mNewMaterial(handle) {}
 
 ActionExecutorResult

--- a/editor/src/quoll/editor/actions/EntityMeshRendererActions.h
+++ b/editor/src/quoll/editor/actions/EntityMeshRendererActions.h
@@ -19,7 +19,7 @@ public:
    * @param slot Material slot
    * @param handle New material
    */
-  EntitySetMeshRendererMaterial(Entity entity, size_t slot,
+  EntitySetMeshRendererMaterial(Entity entity, usize slot,
                                 MaterialAssetHandle handle);
 
   /**
@@ -54,7 +54,7 @@ public:
 
 private:
   Entity mEntity;
-  size_t mSlot;
+  usize mSlot;
   MaterialAssetHandle mOldMaterial = MaterialAssetHandle::Null;
   MaterialAssetHandle mNewMaterial;
 };

--- a/editor/src/quoll/editor/actions/EntitySkeletonActions.cpp
+++ b/editor/src/quoll/editor/actions/EntitySkeletonActions.cpp
@@ -23,7 +23,7 @@ EntityToggleSkeletonDebugBones::onExecute(WorkspaceState &state,
   auto numBones = skeleton.numJoints * 2;
   skeletonDebug.bones.reserve(numBones);
 
-  for (uint32_t joint = 0; joint < skeleton.numJoints; ++joint) {
+  for (u32 joint = 0; joint < skeleton.numJoints; ++joint) {
     skeletonDebug.bones.push_back(skeleton.jointParents.at(joint));
     skeletonDebug.bones.push_back(joint);
   }

--- a/editor/src/quoll/editor/actions/EntitySkinnedMeshRendererActions.cpp
+++ b/editor/src/quoll/editor/actions/EntitySkinnedMeshRendererActions.cpp
@@ -4,7 +4,7 @@
 namespace quoll::editor {
 
 EntitySetSkinnedMeshRendererMaterial::EntitySetSkinnedMeshRendererMaterial(
-    Entity entity, size_t slot, MaterialAssetHandle handle)
+    Entity entity, usize slot, MaterialAssetHandle handle)
     : mEntity(entity), mSlot(slot), mNewMaterial(handle) {}
 
 ActionExecutorResult

--- a/editor/src/quoll/editor/actions/EntitySkinnedMeshRendererActions.h
+++ b/editor/src/quoll/editor/actions/EntitySkinnedMeshRendererActions.h
@@ -19,7 +19,7 @@ public:
    * @param slot Material slot
    * @param handle New material
    */
-  EntitySetSkinnedMeshRendererMaterial(Entity entity, size_t slot,
+  EntitySetSkinnedMeshRendererMaterial(Entity entity, usize slot,
                                        MaterialAssetHandle handle);
 
   /**
@@ -54,7 +54,7 @@ public:
 
 private:
   Entity mEntity;
-  size_t mSlot;
+  usize mSlot;
   MaterialAssetHandle mOldMaterial = MaterialAssetHandle::Null;
   MaterialAssetHandle mNewMaterial;
 };

--- a/editor/src/quoll/editor/asset/AssetManager.cpp
+++ b/editor/src/quoll/editor/asset/AssetManager.cpp
@@ -67,7 +67,7 @@ static Path getUniquePath(Path path) {
 
   auto tmpPath = path;
 
-  uint32_t index = 1;
+  u32 index = 1;
   while (std::filesystem::exists(tmpPath)) {
     String uniqueSuffix = "-" + std::to_string(index++);
     tmpPath = path;
@@ -348,9 +348,9 @@ Result<UUIDMap> AssetManager::loadSourceIfChanged(const Path &sourceAssetPath) {
 
 Result<UUIDMap> AssetManager::loadSourceTexture(const Path &sourceAssetPath,
                                                 const UUIDMap &uuids) {
-  int32_t width = 0;
-  int32_t height = 0;
-  int32_t channels = 0;
+  i32 width = 0;
+  i32 height = 0;
+  i32 channels = 0;
 
   if (sourceAssetPath.extension() == ".ktx2") {
     auto uuid = getOrCreateUuidFromMap(uuids, "root");
@@ -562,7 +562,7 @@ Result<Path> AssetManager::createMetaFile(const Path &sourceAssetPath,
     node["uuid"][pair.first] = pair.second;
   }
 
-  node["revision"] = static_cast<uint32_t>(revision);
+  node["revision"] = static_cast<u32>(revision);
 
   std::ofstream stream(metaFilePath);
   stream << node;
@@ -591,7 +591,7 @@ bool AssetManager::isAssetChanged(const Path &assetFilePath) const {
   stream.close();
 
   auto sourceAssetHash = node["sourceHash"].as<String>("");
-  auto revision = AssetRevision{node["revision"].as<uint32_t>(0)};
+  auto revision = AssetRevision{node["revision"].as<u32>(0)};
 
   if (!node["uuid"] || !node["uuid"].IsMap()) {
     return {};

--- a/editor/src/quoll/editor/asset/HDRIImporter.h
+++ b/editor/src/quoll/editor/asset/HDRIImporter.h
@@ -65,8 +65,7 @@ private:
    * @param height Equirectangular image height
    * @return Cubemap
    */
-  CubemapData convertEquirectangularToCubemap(float *data, uint32_t width,
-                                              uint32_t height);
+  CubemapData convertEquirectangularToCubemap(f32 *data, u32 width, u32 height);
 
   /**
    * @brief Generate irradiance map

--- a/editor/src/quoll/editor/asset/ImageLoader.h
+++ b/editor/src/quoll/editor/asset/ImageLoader.h
@@ -44,7 +44,7 @@ public:
    * @param format Texture format
    * @return Uuid of newly created texture
    */
-  Result<Uuid> loadFromMemory(void *data, uint32_t width, uint32_t height,
+  Result<Uuid> loadFromMemory(void *data, u32 width, u32 height,
                               const Uuid &uuid, const String &name,
                               bool generateMipMaps, rhi::Format format);
 
@@ -57,7 +57,7 @@ private:
    * @param format Texture format
    * @return Texture data with mip maps
    */
-  std::vector<uint8_t>
+  std::vector<u8>
   generateMipMapsFromTextureData(void *data,
                                  const std::vector<TextureAssetLevel> &levels,
                                  rhi::Format format);

--- a/editor/src/quoll/editor/asset/SceneWriter.cpp
+++ b/editor/src/quoll/editor/asset/SceneWriter.cpp
@@ -66,9 +66,9 @@ void SceneWriter::updateSceneYaml(
     if (mEntityIdCache.find(id) == mEntityIdCache.end()) {
       node["entities"].push_back(updatedNode.getData());
     } else {
-      size_t i = 0;
+      usize i = 0;
       for (; i < node["entities"].size() &&
-             node["entities"][i]["id"].as<uint64_t>(0) != id;
+             node["entities"][i]["id"].as<u64>(0) != id;
            ++i) {
       }
 
@@ -117,19 +117,19 @@ void SceneWriter::removeEntityFromSceneYaml(
 
   auto id = mScene.entityDatabase.get<Id>(entity).id;
 
-  size_t i = 0;
+  usize i = 0;
   for (; i < node["entities"].size() &&
-         node["entities"][i]["id"].as<uint64_t>(0) != id;
+         node["entities"][i]["id"].as<u64>(0) != id;
        ++i) {
   }
 
   node["entities"].remove(i);
 
-  if (mRoot["zones"][0]["startingCamera"].as<uint64_t>(0) == id) {
+  if (mRoot["zones"][0]["startingCamera"].as<u64>(0) == id) {
     mRoot["zones"][0]["startingCamera"] = YAML::Node(YAML::NodeType::Null);
   }
 
-  if (mRoot["zones"][0]["environment"].as<uint64_t>(0) == id) {
+  if (mRoot["zones"][0]["environment"].as<u64>(0) == id) {
     mRoot["zones"][0]["environment"] = YAML::Node(YAML::NodeType::Null);
   }
 
@@ -168,6 +168,6 @@ void SceneWriter::save() {
   mStream.close();
 }
 
-uint64_t SceneWriter::generateId() { return mLastId++; }
+u64 SceneWriter::generateId() { return mLastId++; }
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/asset/SceneWriter.h
+++ b/editor/src/quoll/editor/asset/SceneWriter.h
@@ -91,7 +91,7 @@ private:
    *
    * @return Generated ID
    */
-  uint64_t generateId();
+  u64 generateId();
 
 private:
   Scene &mScene;
@@ -101,9 +101,9 @@ private:
   std::fstream mStream;
   YAML::Node mRoot;
 
-  std::unordered_map<uint64_t, Entity> mEntityIdCache;
+  std::unordered_map<u64, Entity> mEntityIdCache;
 
-  uint64_t mLastId = 1;
+  u64 mLastId = 1;
 };
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/asset/gltf/GLTFImportData.h
+++ b/editor/src/quoll/editor/asset/gltf/GLTFImportData.h
@@ -18,7 +18,7 @@ template <class THandle> struct GLTFToAsset {
   /**
    * GLTF index to asset handle map
    */
-  std::map<size_t, THandle> map;
+  std::map<usize, THandle> map;
 };
 
 /**
@@ -31,12 +31,12 @@ struct SkeletonData {
   /**
    * GLTF joint to engine specific joint I
    */
-  std::unordered_map<uint32_t, uint32_t> gltfToNormalizedJointMap;
+  std::unordered_map<u32, u32> gltfToNormalizedJointMap;
 
   /**
    * Joints that are associated with skins
    */
-  std::unordered_map<uint32_t, uint32_t> jointSkinMap;
+  std::unordered_map<u32, u32> jointSkinMap;
 
   /**
    * Skin map
@@ -54,12 +54,12 @@ struct AnimationData {
   /**
    * Node to animator map
    */
-  std::map<uint32_t, AnimatorAssetHandle> nodeAnimatorMap;
+  std::map<u32, AnimatorAssetHandle> nodeAnimatorMap;
 
   /**
    * Skin to animator map
    */
-  std::map<uint32_t, AnimatorAssetHandle> skinAnimatorMap;
+  std::map<u32, AnimatorAssetHandle> skinAnimatorMap;
 };
 
 /**

--- a/editor/src/quoll/editor/asset/gltf/LightStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/LightStep.cpp
@@ -19,20 +19,20 @@ void loadLights(GLTFImportData &importData) {
       DirectionalLight component{};
       for (auto i = 0;
            i < static_cast<glm::vec4::length_type>(light.color.size()); ++i) {
-        component.color[i] = static_cast<float>(light.color.at(i));
+        component.color[i] = static_cast<f32>(light.color.at(i));
       }
 
-      component.intensity = static_cast<float>(light.intensity);
+      component.intensity = static_cast<f32>(light.intensity);
 
       importData.directionalLights.map.insert_or_assign(i, component);
     } else if (light.type == "point") {
       PointLight component{};
       for (auto i = 0; i < glm::vec4::length_type(light.color.size()); ++i) {
-        component.color[i] = static_cast<float>(light.color.at(i));
+        component.color[i] = static_cast<f32>(light.color.at(i));
       }
 
-      component.intensity = static_cast<float>(light.intensity);
-      component.range = static_cast<float>(light.range);
+      component.intensity = static_cast<f32>(light.intensity);
+      component.range = static_cast<f32>(light.range);
 
       importData.pointLights.map.insert_or_assign(i, component);
     }

--- a/editor/src/quoll/editor/asset/gltf/MaterialStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/MaterialStep.cpp
@@ -15,7 +15,7 @@ void loadMaterials(GLTFImportData &importData) {
   const auto &model = importData.model;
   const auto &textures = importData.textures;
 
-  for (size_t i = 0; i < model.materials.size(); ++i) {
+  for (usize i = 0; i < model.materials.size(); ++i) {
     auto &gltfMaterial = model.materials.at(i);
 
     auto assetName = gltfMaterial.name.empty() ? "material" + std::to_string(i)
@@ -33,7 +33,7 @@ void loadMaterials(GLTFImportData &importData) {
           importData, gltfMaterial.pbrMetallicRoughness.baseColorTexture.index,
           GLTFTextureColorSpace::Srgb, true);
     }
-    material.data.baseColorTextureCoord = static_cast<int8_t>(
+    material.data.baseColorTextureCoord = static_cast<i8>(
         gltfMaterial.pbrMetallicRoughness.baseColorTexture.texCoord);
     auto &colorFactor = gltfMaterial.pbrMetallicRoughness.baseColorFactor;
     material.data.baseColorFactor = glm::vec4{colorFactor[0], colorFactor[1],
@@ -45,12 +45,12 @@ void loadMaterials(GLTFImportData &importData) {
           gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture.index,
           GLTFTextureColorSpace::Linear, false);
     }
-    material.data.metallicRoughnessTextureCoord = static_cast<int8_t>(
+    material.data.metallicRoughnessTextureCoord = static_cast<i8>(
         gltfMaterial.pbrMetallicRoughness.baseColorTexture.texCoord);
     material.data.metallicFactor =
-        static_cast<float>(gltfMaterial.pbrMetallicRoughness.metallicFactor);
+        static_cast<f32>(gltfMaterial.pbrMetallicRoughness.metallicFactor);
     material.data.roughnessFactor =
-        static_cast<float>(gltfMaterial.pbrMetallicRoughness.roughnessFactor);
+        static_cast<f32>(gltfMaterial.pbrMetallicRoughness.roughnessFactor);
 
     if (gltfMaterial.normalTexture.index >= 0) {
       material.data.normalTexture =
@@ -58,9 +58,9 @@ void loadMaterials(GLTFImportData &importData) {
                       GLTFTextureColorSpace::Linear, false);
     }
     material.data.normalTextureCoord =
-        static_cast<int8_t>(gltfMaterial.normalTexture.texCoord);
+        static_cast<i8>(gltfMaterial.normalTexture.texCoord);
     material.data.normalScale =
-        static_cast<float>(gltfMaterial.normalTexture.scale);
+        static_cast<f32>(gltfMaterial.normalTexture.scale);
 
     if (gltfMaterial.occlusionTexture.index >= 0) {
       material.data.occlusionTexture =
@@ -68,9 +68,9 @@ void loadMaterials(GLTFImportData &importData) {
                       GLTFTextureColorSpace::Linear, false);
     }
     material.data.occlusionTextureCoord =
-        static_cast<int8_t>(gltfMaterial.occlusionTexture.texCoord);
+        static_cast<i8>(gltfMaterial.occlusionTexture.texCoord);
     material.data.occlusionStrength =
-        static_cast<float>(gltfMaterial.occlusionTexture.strength);
+        static_cast<f32>(gltfMaterial.occlusionTexture.strength);
 
     if (gltfMaterial.emissiveTexture.index >= 0) {
       material.data.emissiveTexture =
@@ -78,7 +78,7 @@ void loadMaterials(GLTFImportData &importData) {
                       GLTFTextureColorSpace::Srgb, false);
     }
     material.data.emissiveTextureCoord =
-        static_cast<int8_t>(gltfMaterial.emissiveTexture.texCoord);
+        static_cast<i8>(gltfMaterial.emissiveTexture.texCoord);
     auto &emissiveFactor = gltfMaterial.emissiveFactor;
     material.data.emissiveFactor =
         glm::vec3{emissiveFactor[0], emissiveFactor[1], emissiveFactor[2]};
@@ -91,7 +91,7 @@ void loadMaterials(GLTFImportData &importData) {
       auto strength = emissiveStrengthExt->second.Get("emissiveStrength");
       if (strength.IsReal()) {
         material.data.emissiveFactor *=
-            static_cast<float>(strength.GetNumberAsDouble());
+            static_cast<f32>(strength.GetNumberAsDouble());
       }
     }
 

--- a/editor/src/quoll/editor/asset/gltf/MeshStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/MeshStep.cpp
@@ -16,7 +16,7 @@ namespace quoll::editor {
  * @param[out] normals Normals
  */
 void generateNormals(const std::vector<glm::vec3> &positions,
-                     const std::vector<uint32_t> &indices,
+                     const std::vector<u32> &indices,
                      std::vector<glm::vec3> &normals) {
   for (auto &n : normals) {
     n.x = 0.0f;
@@ -24,7 +24,7 @@ void generateNormals(const std::vector<glm::vec3> &positions,
     n.z = 0.0f;
   }
 
-  for (size_t i = 0; i < indices.size(); i += 3) {
+  for (usize i = 0; i < indices.size(); i += 3) {
     auto i0 = indices.at(i);
     auto i1 = indices.at(i + 1);
     auto i2 = indices.at(i + 2);
@@ -72,7 +72,7 @@ void generateNormals(const std::vector<glm::vec3> &positions,
 void generateTangents(const std::vector<glm::vec3> &vertices,
                       const std::vector<glm::vec3> &normals,
                       const std::vector<glm::vec2> &texCoords,
-                      const std::vector<uint32_t> &indices,
+                      const std::vector<u32> &indices,
                       std::vector<glm::vec4> &tangents) {
   MikktspaceAdapter adapter;
 
@@ -86,9 +86,9 @@ void generateTangents(const std::vector<glm::vec3> &vertices,
  * @param indices Indices
  */
 void optimizeMeshes(BaseGeometryAsset &g) {
-  static constexpr float OverdrawThreshold = 1.05f;
+  static constexpr f32 OverdrawThreshold = 1.05f;
 
-  size_t vertexSize = g.positions.size();
+  usize vertexSize = g.positions.size();
 
   meshopt_optimizeVertexCache(g.indices.data(), g.indices.data(),
                               g.indices.size(), vertexSize);
@@ -96,7 +96,7 @@ void optimizeMeshes(BaseGeometryAsset &g) {
                            &g.positions.at(0).x, vertexSize, sizeof(glm::vec3),
                            OverdrawThreshold);
 
-  std::vector<uint32_t> remap(g.positions.size());
+  std::vector<u32> remap(g.positions.size());
   meshopt_optimizeVertexFetchRemap(remap.data(), g.indices.data(),
                                    g.indices.size(), g.positions.size());
 
@@ -148,9 +148,9 @@ Result<bool> loadStandardMeshAttributes(const String &primitiveName,
 
   auto &&positionMeta =
       getBufferMetaForAccessor(model, primitive.attributes.at("POSITION"));
-  size_t vertexSize = positionMeta.accessor.count;
+  usize vertexSize = positionMeta.accessor.count;
 
-  // According to spec, position attribute can only be vec3<float>
+  // According to spec, position attribute can only be vec3<f32>
   if (positionMeta.accessor.type == TINYGLTF_TYPE_VEC3 &&
       positionMeta.accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT) {
     geometry.positions.resize(vertexSize);
@@ -160,7 +160,7 @@ Result<bool> loadStandardMeshAttributes(const String &primitiveName,
     geometry.texCoords1.resize(vertexSize);
 
     auto *data = reinterpret_cast<const glm::vec3 *>(positionMeta.rawData);
-    for (size_t i = 0; i < vertexSize; ++i) {
+    for (usize i = 0; i < vertexSize; ++i) {
       geometry.positions.at(i) = data[i];
     }
   } else {
@@ -174,22 +174,22 @@ Result<bool> loadStandardMeshAttributes(const String &primitiveName,
     if (indexMeta.accessor.componentType ==
             TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT &&
         indexMeta.accessor.type == TINYGLTF_TYPE_SCALAR) {
-      const auto *data = reinterpret_cast<const uint32_t *>(indexMeta.rawData);
-      for (size_t i = 0; i < indexMeta.accessor.count; ++i) {
+      const auto *data = reinterpret_cast<const u32 *>(indexMeta.rawData);
+      for (usize i = 0; i < indexMeta.accessor.count; ++i) {
         indices[i] = data[i];
       }
     } else if (indexMeta.accessor.componentType ==
                    TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT &&
                indexMeta.accessor.type == TINYGLTF_TYPE_SCALAR) {
-      const auto *data = reinterpret_cast<const uint16_t *>(indexMeta.rawData);
-      for (size_t i = 0; i < indexMeta.accessor.count; ++i) {
+      const auto *data = reinterpret_cast<const u16 *>(indexMeta.rawData);
+      for (usize i = 0; i < indexMeta.accessor.count; ++i) {
         indices[i] = data[i];
       }
     } else if (indexMeta.accessor.componentType ==
                    TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE &&
                indexMeta.accessor.type == TINYGLTF_TYPE_SCALAR) {
-      const auto *data = reinterpret_cast<const uint8_t *>(indexMeta.rawData);
-      for (size_t i = 0; i < indexMeta.accessor.count; ++i) {
+      const auto *data = reinterpret_cast<const u8 *>(indexMeta.rawData);
+      for (usize i = 0; i < indexMeta.accessor.count; ++i) {
         indices[i] = data[i];
       }
     } else {
@@ -198,12 +198,12 @@ Result<bool> loadStandardMeshAttributes(const String &primitiveName,
     }
   } else {
     indices.resize(geometry.positions.size());
-    for (size_t i = 0; i < geometry.positions.size(); ++i) {
-      indices.at(i) = static_cast<uint32_t>(i);
+    for (usize i = 0; i < geometry.positions.size(); ++i) {
+      indices.at(i) = static_cast<u32>(i);
     }
   }
 
-  // According to spec, normal attribute can only be vec3<float> and
+  // According to spec, normal attribute can only be vec3<f32> and
   // all attributes of a primitive must have the same number of items
   bool validNormals =
       primitive.attributes.find("NORMAL") != primitive.attributes.end();
@@ -219,7 +219,7 @@ Result<bool> loadStandardMeshAttributes(const String &primitiveName,
 
     if (validNormals) {
       auto *data = reinterpret_cast<const glm::vec3 *>(normalMeta.rawData);
-      for (size_t i = 0; i < vertexSize; ++i) {
+      for (usize i = 0; i < vertexSize; ++i) {
         geometry.normals.at(i) = data[i];
       }
     }
@@ -239,17 +239,17 @@ Result<bool> loadStandardMeshAttributes(const String &primitiveName,
     // the same number of items
     if (uvMeta.accessor.type == TINYGLTF_TYPE_VEC2 &&
         uvMeta.accessor.count == vertexSize) {
-      // UV coordinates can be float, ubyte, and ushort
+      // UV coordinates can be f32, ubyte, and ushort
       if (uvMeta.accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT) {
         auto *data = reinterpret_cast<const glm::vec2 *>(uvMeta.rawData);
-        for (size_t i = 0; i < vertexSize; ++i) {
+        for (usize i = 0; i < vertexSize; ++i) {
           geometry.texCoords0.at(i) = data[i];
         }
       } else if (uvMeta.accessor.componentType ==
                      TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE ||
                  uvMeta.accessor.componentType ==
                      TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT) {
-        // TODO: Convert integer coordinates to float
+        // TODO: Convert integer coordinates to f32
         warnings.push_back("Integer based texture coordinates are not "
                            "supported for TEXCOORD0");
       }
@@ -265,24 +265,24 @@ Result<bool> loadStandardMeshAttributes(const String &primitiveName,
     // the same number of items
     if (uvMeta.accessor.type == TINYGLTF_TYPE_VEC2 &&
         uvMeta.accessor.count == vertexSize) {
-      // UV coordinates can be float, ubyte, and ushort
+      // UV coordinates can be f32, ubyte, and ushort
       if (uvMeta.accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT) {
         auto *data = reinterpret_cast<const glm::vec2 *>(uvMeta.rawData);
-        for (size_t i = 0; i < vertexSize; ++i) {
+        for (usize i = 0; i < vertexSize; ++i) {
           geometry.texCoords1.at(i) = data[i];
         }
       } else if (uvMeta.accessor.componentType ==
                      TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE ||
                  uvMeta.accessor.componentType ==
                      TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT) {
-        // TODO: Convert integer coordinates to float
+        // TODO: Convert integer coordinates to f32
         warnings.push_back("Integer based texture coordinates are not "
                            "supported for TEXCOORD1");
       }
     }
   }
 
-  // According to spec, tangent attribute can only be vec4<float> and
+  // According to spec, tangent attribute can only be vec4<f32> and
   // all attributes of a primitive must have the same number of items
   bool validTangents =
       primitive.attributes.find("TANGENT") != primitive.attributes.end();
@@ -298,7 +298,7 @@ Result<bool> loadStandardMeshAttributes(const String &primitiveName,
 
     if (validTangents) {
       auto *data = reinterpret_cast<const glm::vec4 *>(tangentMeta.rawData);
-      for (size_t i = 0; i < vertexSize; ++i) {
+      for (usize i = 0; i < vertexSize; ++i) {
         geometry.tangents.at(i) = data[i];
       }
     }
@@ -336,14 +336,14 @@ Result<bool> loadSkinnedMeshAttributes(const String &primitiveName,
         const auto *data =
             reinterpret_cast<const glm::u8vec4 *>(jointMeta.rawData);
 
-        for (size_t i = 0; i < jointMeta.accessor.count; ++i) {
+        for (usize i = 0; i < jointMeta.accessor.count; ++i) {
           geometry.joints.at(i) = data[i];
         }
       } else if (jointMeta.accessor.componentType ==
                  TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT) {
         const auto *data =
             reinterpret_cast<const glm::u16vec4 *>(jointMeta.rawData);
-        for (size_t i = 0; i < jointMeta.accessor.count; ++i) {
+        for (usize i = 0; i < jointMeta.accessor.count; ++i) {
           geometry.joints.at(i) = data[i];
         }
       } else {
@@ -370,7 +370,7 @@ Result<bool> loadSkinnedMeshAttributes(const String &primitiveName,
       const auto *data =
           reinterpret_cast<const glm::vec4 *>(weightsMeta.rawData);
 
-      for (size_t i = 0; i < weightsMeta.accessor.count; ++i) {
+      for (usize i = 0; i < weightsMeta.accessor.count; ++i) {
         geometry.weights.at(i) = data[i];
       }
     }
@@ -417,7 +417,7 @@ void loadMeshes(GLTFImportData &importData) {
     std::vector<MaterialAssetHandle> materials;
     AssetData<MeshAsset> mesh;
 
-    for (size_t p = 0; p < gltfMesh.primitives.size(); ++p) {
+    for (usize p = 0; p < gltfMesh.primitives.size(); ++p) {
       auto primitiveName = assetName + ", primitive #" + std::to_string(p);
 
       const auto &primitive = gltfMesh.primitives.at(p);

--- a/editor/src/quoll/editor/asset/gltf/PrefabStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/PrefabStep.cpp
@@ -61,21 +61,21 @@ void loadPrefabs(GLTFImportData &importData) {
         auto index = data.Get("light").GetNumberAsInt();
         hasValidLight =
             index >= 0 &&
-            (importData.directionalLights.map.find(static_cast<size_t>(
-                 index)) != importData.directionalLights.map.end() ||
-             importData.pointLights.map.find(static_cast<size_t>(index)) !=
+            (importData.directionalLights.map.find(static_cast<usize>(index)) !=
+                 importData.directionalLights.map.end() ||
+             importData.pointLights.map.find(static_cast<usize>(index)) !=
                  importData.pointLights.map.end());
       }
     }
 
-    auto localEntityId = static_cast<uint32_t>(nodeIndex);
+    auto localEntityId = static_cast<u32>(nodeIndex);
 
     PrefabTransformData transform{};
     auto data = loadTransformData(node);
     transform.position = data.localPosition;
     transform.rotation = data.localRotation;
     transform.scale = data.localScale;
-    transform.parent = static_cast<int32_t>(parentIndex);
+    transform.parent = static_cast<i32>(parentIndex);
 
     prefab.data.transforms.push_back({localEntityId, transform});
 
@@ -117,8 +117,8 @@ void loadPrefabs(GLTFImportData &importData) {
 
     if (hasValidLight) {
       const auto &light = itExtLight->second;
-      size_t lightIndex =
-          static_cast<size_t>(light.Get("light").GetNumberAsInt());
+      usize lightIndex =
+          static_cast<usize>(light.Get("light").GetNumberAsInt());
 
       if (importData.directionalLights.map.find(lightIndex) !=
           importData.directionalLights.map.end()) {

--- a/editor/src/quoll/editor/asset/gltf/SkeletonStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/SkeletonStep.cpp
@@ -10,15 +10,15 @@ void loadSkeletons(GLTFImportData &importData) {
   auto &assetCache = importData.assetCache;
   const auto &model = importData.model;
 
-  for (uint32_t si = 0; si < static_cast<uint32_t>(model.skins.size()); ++si) {
+  for (u32 si = 0; si < static_cast<u32>(model.skins.size()); ++si) {
     const auto &skin = model.skins.at(si);
 
     auto skeletonName =
         skin.name.empty() ? "skeleton" + std::to_string(si) : skin.name;
     skeletonName += ".skel";
 
-    std::unordered_map<uint32_t, int> jointParents;
-    std::unordered_map<uint32_t, uint32_t> normalizedJointMap;
+    std::unordered_map<u32, int> jointParents;
+    std::unordered_map<u32, u32> normalizedJointMap;
 
     auto &&ibMeta = getBufferMetaForAccessor(model, skin.inverseBindMatrices);
 
@@ -50,14 +50,14 @@ void loadSkeletons(GLTFImportData &importData) {
 
     {
       const auto *data = reinterpret_cast<const glm::mat4 *>(ibMeta.rawData);
-      for (size_t i = 0; i < ibMeta.accessor.count; ++i) {
+      for (usize i = 0; i < ibMeta.accessor.count; ++i) {
         inverseBindMatrices.at(i) = data[i];
       }
     }
 
     bool skeletonValid = true;
-    for (uint32_t i = 0;
-         i < static_cast<uint32_t>(skin.joints.size()) && skeletonValid; ++i) {
+    for (u32 i = 0; i < static_cast<u32>(skin.joints.size()) && skeletonValid;
+         ++i) {
       const auto &joint = skin.joints.at(i);
 
       skeletonValid =
@@ -79,12 +79,12 @@ void loadSkeletons(GLTFImportData &importData) {
     if (!skeletonValid)
       continue;
 
-    for (uint32_t j = 0; j < static_cast<uint32_t>(model.nodes.size()); ++j) {
+    for (u32 j = 0; j < static_cast<u32>(model.nodes.size()); ++j) {
       if (normalizedJointMap.find(j) == normalizedJointMap.end()) {
         continue;
       }
 
-      uint32_t nJ = normalizedJointMap.at(j);
+      u32 nJ = normalizedJointMap.at(j);
 
       const auto &node = model.nodes.at(j);
       for (auto &child : node.children) {
@@ -92,12 +92,12 @@ void loadSkeletons(GLTFImportData &importData) {
           continue;
         }
 
-        uint32_t nChild = normalizedJointMap.at(child);
+        u32 nChild = normalizedJointMap.at(child);
         jointParents.at(nChild) = static_cast<int>(nJ);
       }
     }
 
-    uint32_t numJoints = static_cast<uint32_t>(skin.joints.size());
+    u32 numJoints = static_cast<u32>(skin.joints.size());
 
     auto assetName =
         skin.name.empty() ? "skeleton" + std::to_string(si) : skin.name;
@@ -110,7 +110,7 @@ void loadSkeletons(GLTFImportData &importData) {
     asset.uuid = getOrCreateGLTFUuid(importData, skeletonName);
 
     for (auto &joint : skin.joints) {
-      uint32_t nJoint = normalizedJointMap.at(joint);
+      u32 nJoint = normalizedJointMap.at(joint);
       int parent = jointParents.at(nJoint);
       const auto &node = model.nodes.at(joint);
       const auto &data = loadTransformData(node);
@@ -128,7 +128,7 @@ void loadSkeletons(GLTFImportData &importData) {
     auto handle = assetCache.loadSkeleton(asset.uuid);
 
     importData.skeletons.skeletonMap.map.insert_or_assign(
-        static_cast<size_t>(si), handle.getData());
+        static_cast<usize>(si), handle.getData());
 
     importData.outputUuids.insert_or_assign(assetName,
                                             assetCache.getRegistry()

--- a/editor/src/quoll/editor/asset/gltf/TextureUtils.cpp
+++ b/editor/src/quoll/editor/asset/gltf/TextureUtils.cpp
@@ -4,7 +4,7 @@
 
 namespace quoll::editor {
 
-TextureAssetHandle loadTexture(GLTFImportData &importData, size_t index,
+TextureAssetHandle loadTexture(GLTFImportData &importData, usize index,
                                GLTFTextureColorSpace colorSpace,
                                bool generateMipMaps) {
   if (importData.textures.map.find(index) != importData.textures.map.end()) {

--- a/editor/src/quoll/editor/asset/gltf/TextureUtils.h
+++ b/editor/src/quoll/editor/asset/gltf/TextureUtils.h
@@ -15,7 +15,7 @@ enum class GLTFTextureColorSpace { Linear, Srgb };
  * @param generateMipMaps Generate mip maps
  * @return Texture asset handle
  */
-TextureAssetHandle loadTexture(GLTFImportData &importData, size_t index,
+TextureAssetHandle loadTexture(GLTFImportData &importData, usize index,
                                GLTFTextureColorSpace colorSpace,
                                bool generateMipMaps);
 

--- a/editor/src/quoll/editor/asset/gltf/TransformUtils.cpp
+++ b/editor/src/quoll/editor/asset/gltf/TransformUtils.cpp
@@ -20,7 +20,7 @@ void decomposeMatrix(const glm::mat4 &matrix, glm::vec3 &position,
 TransformData loadTransformData(const tinygltf::Node &node) {
   TransformData data{};
 
-  static constexpr size_t TransformMatrixSize = 6;
+  static constexpr usize TransformMatrixSize = 6;
 
   glm::mat4 finalTransform = glm::mat4{1.0f};
   if (node.matrix.size() == TransformMatrixSize) {

--- a/editor/src/quoll/editor/asset/gltf/mikktspace/MikktspaceAdapter.cpp
+++ b/editor/src/quoll/editor/asset/gltf/mikktspace/MikktspaceAdapter.cpp
@@ -19,7 +19,7 @@ MikktspaceAdapter::MikktspaceAdapter() {
 void MikktspaceAdapter::generate(const std::vector<glm::vec3> &positions,
                                  const std::vector<glm::vec3> &normals,
                                  const std::vector<glm::vec2> &texCoords,
-                                 const std::vector<uint32_t> &indices,
+                                 const std::vector<u32> &indices,
                                  std::vector<glm::vec4> &tangents) {
   MeshData data{positions, normals, texCoords, indices, tangents};
 
@@ -38,7 +38,7 @@ int MikktspaceAdapter::getNumFaces(const SMikkTSpaceContext *pContext) {
 }
 
 void MikktspaceAdapter::getPosition(const SMikkTSpaceContext *context,
-                                    float outAttribute[], const int faceIndex,
+                                    f32 outAttribute[], const int faceIndex,
                                     const int vertexIndex) {
   auto index = getVertexIndex(context, faceIndex, vertexIndex);
   const auto &p = getMeshData(context).positions.at(index);
@@ -49,7 +49,7 @@ void MikktspaceAdapter::getPosition(const SMikkTSpaceContext *context,
 }
 
 void MikktspaceAdapter::getNormal(const SMikkTSpaceContext *context,
-                                  float outAttribute[], const int faceIndex,
+                                  f32 outAttribute[], const int faceIndex,
                                   const int vertexIndex) {
   auto index = getVertexIndex(context, faceIndex, vertexIndex);
   const auto &n = getMeshData(context).normals.at(index);
@@ -60,7 +60,7 @@ void MikktspaceAdapter::getNormal(const SMikkTSpaceContext *context,
 }
 
 void MikktspaceAdapter::getTexCoord(const SMikkTSpaceContext *context,
-                                    float outAttribute[], const int faceIndex,
+                                    f32 outAttribute[], const int faceIndex,
                                     const int vertexIndex) {
   auto index = getVertexIndex(context, faceIndex, vertexIndex);
   const auto &tc = getMeshData(context).texCoords.at(index);
@@ -70,7 +70,7 @@ void MikktspaceAdapter::getTexCoord(const SMikkTSpaceContext *context,
 }
 
 void MikktspaceAdapter::setTSpaceBasic(const SMikkTSpaceContext *context,
-                                       const float tangents[], const float sign,
+                                       const f32 tangents[], const f32 sign,
                                        const int faceIndex,
                                        const int vertexIndex) {
   auto index = getVertexIndex(context, faceIndex, vertexIndex);
@@ -83,10 +83,10 @@ void MikktspaceAdapter::setTSpaceBasic(const SMikkTSpaceContext *context,
 }
 // NOLINTEND(cppcoreguidelines-avoid-c-arrays)
 
-size_t MikktspaceAdapter::getVertexIndex(const SMikkTSpaceContext *context,
-                                         int faceIndex, int vertexIndex) {
+usize MikktspaceAdapter::getVertexIndex(const SMikkTSpaceContext *context,
+                                        int faceIndex, int vertexIndex) {
   auto &meshData = getMeshData(context);
-  size_t index = static_cast<size_t>(faceIndex * 3 + vertexIndex);
+  usize index = static_cast<usize>(faceIndex * 3 + vertexIndex);
 
   return meshData.indices.at(index);
 }

--- a/editor/src/quoll/editor/asset/gltf/mikktspace/MikktspaceAdapter.h
+++ b/editor/src/quoll/editor/asset/gltf/mikktspace/MikktspaceAdapter.h
@@ -4,7 +4,7 @@
 
 namespace quoll::editor {
 
-static constexpr uint32_t TriangleVertices = 3;
+static constexpr u32 TriangleVertices = 3;
 
 /**
  * @brief Mikktspace adapter
@@ -14,7 +14,7 @@ class MikktspaceAdapter {
     const std::vector<glm::vec3> &positions;
     const std::vector<glm::vec3> &normals;
     const std::vector<glm::vec2> &texCoords;
-    const std::vector<uint32_t> &indices;
+    const std::vector<u32> &indices;
     std::vector<glm::vec4> &tangents;
   };
 
@@ -36,7 +36,7 @@ public:
   void generate(const std::vector<glm::vec3> &positions,
                 const std::vector<glm::vec3> &normals,
                 const std::vector<glm::vec2> &texCoords,
-                const std::vector<uint32_t> &indices,
+                const std::vector<u32> &indices,
                 std::vector<glm::vec4> &tangents);
 
 private:
@@ -70,9 +70,8 @@ private:
    * @param faceIndex Face index
    * @param vertexIndex Relative vertex index
    */
-  static void getPosition(const SMikkTSpaceContext *context,
-                          float outAttribute[], const int faceIndex,
-                          const int vertexIndex);
+  static void getPosition(const SMikkTSpaceContext *context, f32 outAttribute[],
+                          const int faceIndex, const int vertexIndex);
 
   /**
    * @brief Get normal
@@ -82,7 +81,7 @@ private:
    * @param faceIndex Face index
    * @param vertexIndex Relative vertex index
    */
-  static void getNormal(const SMikkTSpaceContext *context, float outAttribute[],
+  static void getNormal(const SMikkTSpaceContext *context, f32 outAttribute[],
                         const int faceIndex, const int vertexIndex);
 
   /**
@@ -93,9 +92,8 @@ private:
    * @param faceIndex Face index
    * @param vertexIndex Relative vertex index
    */
-  static void getTexCoord(const SMikkTSpaceContext *context,
-                          float outAttribute[], const int faceIndex,
-                          const int vertexIndex);
+  static void getTexCoord(const SMikkTSpaceContext *context, f32 outAttribute[],
+                          const int faceIndex, const int vertexIndex);
 
   /**
    * @brief Set tangent space
@@ -107,7 +105,7 @@ private:
    * @param vertexIndex Relative vertex index
    */
   static void setTSpaceBasic(const SMikkTSpaceContext *context,
-                             const float tangents[], const float sign,
+                             const f32 tangents[], const f32 sign,
                              const int faceIndex, const int vertexIndex);
 
   // NOLINTEND(cppcoreguidelines-avoid-c-arrays)
@@ -130,8 +128,8 @@ private:
    * @param vertexIndex Vertex index relative to face
    * @return Vertex index
    */
-  static size_t getVertexIndex(const SMikkTSpaceContext *context, int faceIndex,
-                               int vertexIndex);
+  static usize getVertexIndex(const SMikkTSpaceContext *context, int faceIndex,
+                              int vertexIndex);
 
 private:
   SMikkTSpaceInterface mInterface{};

--- a/editor/src/quoll/editor/core/EditorRenderer.cpp
+++ b/editor/src/quoll/editor/core/EditorRenderer.cpp
@@ -126,7 +126,7 @@ void EditorRenderer::attach(RenderGraph &graph,
          {},
          "object icons"});
 
-    static const float WireframeLineHeight = 3.0f;
+    static const f32 WireframeLineHeight = 3.0f;
 
     auto collidableShapePipeline = mRenderStorage.addPipeline(
         {mRenderStorage.getShader("collidable-shape.vert"),
@@ -152,10 +152,10 @@ void EditorRenderer::attach(RenderGraph &graph,
     editorDebugPass.setExecutor([editorGridPipeline, skeletonLinesPipeline,
                                  objectIconsPipeline, collidableShapePipeline,
                                  this](rhi::RenderCommandList &commandList,
-                                       uint32_t frameIndex) {
+                                       u32 frameIndex) {
       auto &frameData = mFrameData.at(frameIndex);
 
-      std::array<uint32_t, 1> offsets{0};
+      std::array<u32, 1> offsets{0};
       // Collidable shapes
       if (frameData.isCollidableEntitySelected() &&
           frameData.getCollidableShapeType() != PhysicsGeometryType::Plane) {
@@ -168,7 +168,7 @@ void EditorRenderer::attach(RenderGraph &graph,
 
         auto type = frameData.getCollidableShapeType();
 
-        std::array<uint64_t, 1> offsets{0};
+        std::array<u64, 1> offsets{0};
 
         if (type == PhysicsGeometryType::Box) {
           commandList.bindVertexBuffers(
@@ -194,7 +194,7 @@ void EditorRenderer::attach(RenderGraph &graph,
             editorGridPipeline, 0,
             frameData.getBindlessParams().getDescriptor(), offsets);
 
-        static constexpr uint32_t GridPlaneNumVertices = 6;
+        static constexpr u32 GridPlaneNumVertices = 6;
         commandList.draw(GridPlaneNumVertices, 0);
       }
 
@@ -209,8 +209,8 @@ void EditorRenderer::attach(RenderGraph &graph,
 
         const auto &numBones = frameData.getBoneCounts();
 
-        for (size_t i = 0; i < numBones.size(); ++i) {
-          commandList.draw(numBones.at(i), 0, 1, static_cast<uint32_t>(i));
+        for (usize i = 0; i < numBones.size(); ++i) {
+          commandList.draw(numBones.at(i), 0, 1, static_cast<u32>(i));
         }
       }
 
@@ -226,14 +226,14 @@ void EditorRenderer::attach(RenderGraph &graph,
             objectIconsPipeline, 1,
             frameData.getBindlessParams().getDescriptor(), offsets);
 
-        uint32_t previousInstance = 0;
+        u32 previousInstance = 0;
         for (auto &[icon, count] : frameData.getGizmoCounts()) {
           glm::uvec4 uIcon{
               rhi::castHandleToUint(icon),
               rhi::castHandleToUint(mRenderStorage.getDefaultSampler()), 0, 0};
           commandList.pushConstants(objectIconsPipeline,
-                                    rhi::ShaderStage::Fragment, 0,
-                                    sizeof(uint32_t), glm::value_ptr(uIcon));
+                                    rhi::ShaderStage::Fragment, 0, sizeof(u32),
+                                    glm::value_ptr(uIcon));
 
           commandList.draw(4, 0, count, previousInstance);
 
@@ -265,7 +265,7 @@ void EditorRenderer::attach(RenderGraph &graph,
     outlinePass.write(scenePassData.sceneColorResolved, AttachmentType::Resolve,
                       glm::vec4(0.0));
 
-    static constexpr uint32_t MaskAll = 0xFF;
+    static constexpr u32 MaskAll = 0xFF;
     rhi::PipelineDepthStencil outlineWritePipelineStencil{
         .depthTest = true,
         .depthWrite = true,
@@ -438,19 +438,18 @@ void EditorRenderer::attach(RenderGraph &graph,
          outlineGeometryStencilWritePipeline, outlineGeometryPipeline,
          outlineSkinnedGeometryStencilWritePipeline,
          outlineSkinnedGeometryPipeline,
-         this](rhi::RenderCommandList &commandList, uint32_t frameIndex) {
+         this](rhi::RenderCommandList &commandList, u32 frameIndex) {
           static constexpr glm::vec4 OutlineColor{1.0f, 0.26f, 0.0f, 1.0f};
-          static constexpr float OutlineScale = 1.02f;
-          static constexpr float OutlineScale2D = 1.06f;
+          static constexpr f32 OutlineScale = 1.02f;
+          static constexpr f32 OutlineScale2D = 1.06f;
 
           auto &frameData = mFrameData.at(frameIndex);
 
-          auto spriteEnd =
-              static_cast<uint32_t>(frameData.getOutlineSpriteEnd());
-          auto textEnd = static_cast<uint32_t>(frameData.getOutlineTextEnd());
-          auto meshEnd = static_cast<uint32_t>(frameData.getOutlineMeshEnd());
+          auto spriteEnd = static_cast<u32>(frameData.getOutlineSpriteEnd());
+          auto textEnd = static_cast<u32>(frameData.getOutlineTextEnd());
+          auto meshEnd = static_cast<u32>(frameData.getOutlineMeshEnd());
           auto skinnedMeshEnd =
-              static_cast<uint32_t>(frameData.getOutlineSkinnedMeshEnd());
+              static_cast<u32>(frameData.getOutlineSkinnedMeshEnd());
 
           renderSpriteOutlines(commandList, frameData,
                                outlineSpriteStencilWritePipeline, 0, spriteEnd,
@@ -485,7 +484,7 @@ void EditorRenderer::attach(RenderGraph &graph,
 void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
                                      Entity camera, WorkspaceState &state,
                                      AssetRegistry &assetRegistry,
-                                     uint32_t frameIndex) {
+                                     u32 frameIndex) {
   auto &frameData = mFrameData.at(frameIndex);
 
   QUOLL_PROFILE_EVENT("EditorRenderer::update");
@@ -524,9 +523,9 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
           entityDatabase.get<WorldTransform>(state.selectedEntity);
 
       std::vector<SceneRendererFrameData::GlyphData> glyphs(text.text.length());
-      float advanceX = 0;
-      float advanceY = 0;
-      for (size_t i = 0; i < text.text.length(); ++i) {
+      f32 advanceX = 0;
+      f32 advanceY = 0;
+      for (usize i = 0; i < text.text.length(); ++i) {
         char c = text.text.at(i);
 
         if (c == '\n') {
@@ -582,7 +581,7 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
 
   for (auto [entity, world, camera] :
        entityDatabase.view<WorldTransform, PerspectiveLens>()) {
-    static constexpr float NinetyDegreesInRadians = glm::pi<float>() / 2.0f;
+    static constexpr f32 NinetyDegreesInRadians = glm::pi<f32>() / 2.0f;
 
     frameData.addGizmo(IconRegistry::getIcon(EditorIcon::Camera),
                        glm::rotate(world.worldTransform, NinetyDegreesInRadians,
@@ -595,10 +594,9 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
 void EditorRenderer::renderSpriteOutlines(rhi::RenderCommandList &commandList,
                                           EditorRendererFrameData &frameData,
                                           rhi::PipelineHandle pipeline,
-                                          uint32_t instanceStart,
-                                          uint32_t instanceEnd, glm::vec4 color,
-                                          float scale) {
-  std::array<uint32_t, 1> offsets{0};
+                                          u32 instanceStart, u32 instanceEnd,
+                                          glm::vec4 color, f32 scale) {
+  std::array<u32, 1> offsets{0};
 
   commandList.bindPipeline(pipeline);
   commandList.bindDescriptor(
@@ -625,10 +623,9 @@ void EditorRenderer::renderSpriteOutlines(rhi::RenderCommandList &commandList,
 void EditorRenderer::renderTextOutlines(rhi::RenderCommandList &commandList,
                                         EditorRendererFrameData &frameData,
                                         rhi::PipelineHandle pipeline,
-                                        uint32_t instanceStart,
-                                        uint32_t instanceEnd, glm::vec4 color,
-                                        float scale) {
-  std::array<uint32_t, 1> offsets{0};
+                                        u32 instanceStart, u32 instanceEnd,
+                                        glm::vec4 color, f32 scale) {
+  std::array<u32, 1> offsets{0};
 
   commandList.bindPipeline(pipeline);
   commandList.bindDescriptor(
@@ -642,8 +639,8 @@ void EditorRenderer::renderTextOutlines(rhi::RenderCommandList &commandList,
     glm::uvec4 index;
   };
 
-  static constexpr uint32_t QuadNumVertices = 6;
-  for (size_t i = 0; i < frameData.getTextOutlines().size(); ++i) {
+  static constexpr u32 QuadNumVertices = 6;
+  for (usize i = 0; i < frameData.getTextOutlines().size(); ++i) {
     const auto &text = frameData.getTextOutlines().at(i);
 
     PushConstants pc{};
@@ -658,18 +655,17 @@ void EditorRenderer::renderTextOutlines(rhi::RenderCommandList &commandList,
         pipeline, rhi::ShaderStage::Vertex | rhi::ShaderStage::Fragment, 0,
         sizeof(PushConstants), &pc);
 
-    commandList.draw(QuadNumVertices * static_cast<uint32_t>(text.length), 0, 1,
-                     static_cast<uint32_t>(i));
+    commandList.draw(QuadNumVertices * static_cast<u32>(text.length), 0, 1,
+                     static_cast<u32>(i));
   }
 }
 
 void EditorRenderer::renderMeshOutlines(rhi::RenderCommandList &commandList,
                                         EditorRendererFrameData &frameData,
                                         rhi::PipelineHandle pipeline,
-                                        uint32_t instanceStart,
-                                        uint32_t instanceEnd, glm::vec4 color,
-                                        float scale) {
-  std::array<uint32_t, 1> offsets{0};
+                                        u32 instanceStart, u32 instanceEnd,
+                                        glm::vec4 color, f32 scale) {
+  std::array<u32, 1> offsets{0};
 
   commandList.bindPipeline(pipeline);
   commandList.bindDescriptor(
@@ -690,7 +686,7 @@ void EditorRenderer::renderMeshOutlines(rhi::RenderCommandList &commandList,
       pipeline, rhi::ShaderStage::Vertex | rhi::ShaderStage::Fragment, 0,
       sizeof(PushConstants), &pc);
 
-  for (uint32_t instanceIndex = instanceStart; instanceIndex < instanceEnd;
+  for (u32 instanceIndex = instanceStart; instanceIndex < instanceEnd;
        ++instanceIndex) {
     const auto &outline = frameData.getMeshOutlines().at(instanceIndex);
 
@@ -698,17 +694,17 @@ void EditorRenderer::renderMeshOutlines(rhi::RenderCommandList &commandList,
                                   outline.vertexBufferOffsets);
     commandList.bindIndexBuffer(outline.indexBuffer, rhi::IndexType::Uint32);
 
-    for (size_t i = 0; i < outline.indexCounts.size(); ++i) {
+    for (usize i = 0; i < outline.indexCounts.size(); ++i) {
       commandList.drawIndexed(
           outline.indexCounts.at(i), outline.indexOffsets.at(i),
-          static_cast<int32_t>(outline.vertexOffsets.at(i)), 1, instanceIndex);
+          static_cast<i32>(outline.vertexOffsets.at(i)), 1, instanceIndex);
     }
   }
 }
 
 void EditorRenderer::createCollidableShapes() {
   // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
-  static constexpr float Pi = glm::pi<float>();
+  static constexpr f32 Pi = glm::pi<f32>();
 
   using V = glm::vec3;
 
@@ -742,37 +738,37 @@ void EditorRenderer::createCollidableShapes() {
          CollidableBoxVertices.size() * sizeof(glm::vec3),
          static_cast<const void *>(CollidableBoxVertices.data())});
     mCollidableCube.vertexCount =
-        static_cast<uint32_t>(CollidableBoxVertices.size());
+        static_cast<u32>(CollidableBoxVertices.size());
   }
 
-  using CalculationFn = std::function<float(float)>;
+  using CalculationFn = std::function<f32(f32)>;
 
-  static constexpr float Radius = 1.0f;
+  static constexpr f32 Radius = 1.0f;
 
-  auto cSinCenter = [](float center) {
-    return [center](float angle) { return Radius * sin(angle) + center; };
+  auto cSinCenter = [](f32 center) {
+    return [center](f32 angle) { return Radius * sin(angle) + center; };
   };
-  auto cCosCenter = [](float center) {
-    return [center](float angle) { return Radius * cos(angle) + center; };
+  auto cCosCenter = [](f32 center) {
+    return [center](f32 angle) { return Radius * cos(angle) + center; };
   };
 
   auto cSin = cSinCenter(0.0f);
   auto cCos = cCosCenter(0.0f);
-  auto cZero = [](float angle) { return 0.0f; };
+  auto cZero = [](f32 angle) { return 0.0f; };
 
   // Sphere shape
   {
-    auto drawUnitCircle = [](std::vector<glm::vec3> &vertices,
-                             uint32_t numSegments, CalculationFn cX,
-                             CalculationFn cY, CalculationFn cZ) {
-      const float SegmentDelta = 2.0f * Pi / static_cast<float>(numSegments);
-      float segmentAngle = SegmentDelta;
+    auto drawUnitCircle = [](std::vector<glm::vec3> &vertices, u32 numSegments,
+                             CalculationFn cX, CalculationFn cY,
+                             CalculationFn cZ) {
+      const f32 SegmentDelta = 2.0f * Pi / static_cast<f32>(numSegments);
+      f32 segmentAngle = SegmentDelta;
 
       V start{cX(0.0f), cY(0.0f), cZ(0.0f)};
 
       vertices.push_back(start);
 
-      for (uint32_t i = 0; i < numSegments; ++i) {
+      for (u32 i = 0; i < numSegments; ++i) {
         V vertex{cX(segmentAngle), cY(segmentAngle), cZ(segmentAngle)};
 
         vertices.push_back(vertex);
@@ -784,7 +780,7 @@ void EditorRenderer::createCollidableShapes() {
       vertices.push_back(start);
     };
 
-    static constexpr uint32_t NumSegments = 12;
+    static constexpr u32 NumSegments = 12;
     std::vector<glm::vec3> CollidableSphereVertices;
 
     drawUnitCircle(CollidableSphereVertices, NumSegments, cZero, cSin, cCos);
@@ -795,35 +791,34 @@ void EditorRenderer::createCollidableShapes() {
          CollidableSphereVertices.size() * sizeof(glm::vec3),
          static_cast<const void *>(CollidableSphereVertices.data())});
     mCollidableSphere.vertexCount =
-        static_cast<uint32_t>(CollidableSphereVertices.size());
+        static_cast<u32>(CollidableSphereVertices.size());
   }
 
   // Capsule shape
   {
-    auto drawUnitHalfCircle = [](std::vector<glm::vec3> &vertices,
-                                 uint32_t numSegments, CalculationFn cX,
-                                 CalculationFn cY, CalculationFn cZ,
-                                 float circleAngle) {
-      const float SegmentDelta = circleAngle / static_cast<float>(numSegments);
-      float segmentAngle = SegmentDelta;
+    auto drawUnitHalfCircle =
+        [](std::vector<glm::vec3> &vertices, u32 numSegments, CalculationFn cX,
+           CalculationFn cY, CalculationFn cZ, f32 circleAngle) {
+          const f32 SegmentDelta = circleAngle / static_cast<f32>(numSegments);
+          f32 segmentAngle = SegmentDelta;
 
-      V start{cX(0.0f), cY(0.0f), cZ(0.0f)};
+          V start{cX(0.0f), cY(0.0f), cZ(0.0f)};
 
-      vertices.push_back(start);
+          vertices.push_back(start);
 
-      for (uint32_t i = 0; i < numSegments; ++i) {
-        V v{cX(segmentAngle), cY(segmentAngle), cZ(segmentAngle)};
+          for (u32 i = 0; i < numSegments; ++i) {
+            V v{cX(segmentAngle), cY(segmentAngle), cZ(segmentAngle)};
 
-        vertices.push_back(v);
-        vertices.push_back(v);
+            vertices.push_back(v);
+            vertices.push_back(v);
 
-        segmentAngle += SegmentDelta;
-      }
+            segmentAngle += SegmentDelta;
+          }
 
-      vertices.push_back(vertices.at(vertices.size() - 1));
-    };
+          vertices.push_back(vertices.at(vertices.size() - 1));
+        };
 
-    static constexpr uint32_t NumSegments = 12;
+    static constexpr u32 NumSegments = 12;
     std::vector<glm::vec3> CollidableCapsuleVertices;
 
     drawUnitHalfCircle(CollidableCapsuleVertices, NumSegments, cCos,
@@ -853,7 +848,7 @@ void EditorRenderer::createCollidableShapes() {
          CollidableCapsuleVertices.size() * sizeof(glm::vec3),
          static_cast<const void *>(CollidableCapsuleVertices.data())});
     mCollidableCapsule.vertexCount =
-        static_cast<uint32_t>(CollidableCapsuleVertices.size());
+        static_cast<u32>(CollidableCapsuleVertices.size());
   }
 
   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)

--- a/editor/src/quoll/editor/core/EditorRenderer.h
+++ b/editor/src/quoll/editor/core/EditorRenderer.h
@@ -29,7 +29,7 @@ class EditorRenderer {
      *
      * Used when recording draw command
      */
-    uint32_t vertexCount = 0;
+    u32 vertexCount = 0;
   };
 
 public:
@@ -62,24 +62,23 @@ public:
    */
   void updateFrameData(EntityDatabase &entityDatabase, Entity camera,
                        WorkspaceState &state, AssetRegistry &assetRegistry,
-                       uint32_t frameIndex);
+                       u32 frameIndex);
 
 private:
   void renderSpriteOutlines(rhi::RenderCommandList &commandList,
                             EditorRendererFrameData &frameData,
-                            rhi::PipelineHandle pipeline,
-                            uint32_t instanceStart, uint32_t instanceEnd,
-                            glm::vec4 color, float scale);
+                            rhi::PipelineHandle pipeline, u32 instanceStart,
+                            u32 instanceEnd, glm::vec4 color, f32 scale);
 
   void renderTextOutlines(rhi::RenderCommandList &commandList,
                           EditorRendererFrameData &frameData,
-                          rhi::PipelineHandle pipeline, uint32_t instanceStart,
-                          uint32_t instanceEnd, glm::vec4 color, float scale);
+                          rhi::PipelineHandle pipeline, u32 instanceStart,
+                          u32 instanceEnd, glm::vec4 color, f32 scale);
 
   void renderMeshOutlines(rhi::RenderCommandList &commandList,
                           EditorRendererFrameData &frameData,
-                          rhi::PipelineHandle pipeline, uint32_t instanceStart,
-                          uint32_t instanceEnd, glm::vec4 color, float scale);
+                          rhi::PipelineHandle pipeline, u32 instanceStart,
+                          u32 instanceEnd, glm::vec4 color, f32 scale);
 
   /**
    * @brief Create buffers for collidable shapes

--- a/editor/src/quoll/editor/core/EditorRendererFrameData.cpp
+++ b/editor/src/quoll/editor/core/EditorRendererFrameData.cpp
@@ -5,10 +5,10 @@
 
 namespace quoll::editor {
 
-static constexpr size_t MaxNumJoints = 32;
+static constexpr usize MaxNumJoints = 32;
 
 EditorRendererFrameData::EditorRendererFrameData(RenderStorage &renderStorage,
-                                                 size_t reservedSpace)
+                                                 usize reservedSpace)
     : mReservedSpace(reservedSpace),
       mBindlessParams(renderStorage.getDevice()
                           ->getDeviceInformation()
@@ -89,10 +89,10 @@ void EditorRendererFrameData::addSkeleton(
     const glm::mat4 &worldTransform,
     const std::vector<glm::mat4> &boneTransforms) {
   mSkeletonTransforms.push_back(worldTransform);
-  mNumBones.push_back(static_cast<uint32_t>(boneTransforms.size()));
+  mNumBones.push_back(static_cast<u32>(boneTransforms.size()));
 
   auto *currentSkeleton = mSkeletonVector.get() + (mLastSkeleton * MaxNumBones);
-  size_t dataSize = std::min(boneTransforms.size(), MaxNumBones);
+  usize dataSize = std::min(boneTransforms.size(), MaxNumBones);
   memcpy(currentSkeleton, boneTransforms.data(), dataSize * sizeof(glm::mat4));
 
   mLastSkeleton++;
@@ -123,8 +123,8 @@ void EditorRendererFrameData::addTextOutline(
 
   SceneRendererFrameData::TextItem textData{};
   textData.fontTexture = fontTexture;
-  textData.glyphStart = static_cast<uint32_t>(mTextGlyphOutlines.size());
-  textData.length = static_cast<uint32_t>(glyphs.size());
+  textData.glyphStart = static_cast<u32>(mTextGlyphOutlines.size());
+  textData.length = static_cast<u32>(glyphs.size());
 
   for (auto &glyph : glyphs) {
     mTextGlyphOutlines.push_back(glyph);
@@ -153,16 +153,16 @@ void EditorRendererFrameData::addMeshOutline(const MeshAsset &mesh,
 
   mOutlineTransforms.push_back(worldTransform);
 
-  uint32_t lastIndexOffset = 0;
-  uint32_t lastVertexOffset = 0;
-  for (size_t i = 0; i < outline.indexCounts.size(); ++i) {
+  u32 lastIndexOffset = 0;
+  u32 lastVertexOffset = 0;
+  for (usize i = 0; i < outline.indexCounts.size(); ++i) {
     outline.indexCounts.at(i) =
-        static_cast<uint32_t>(mesh.geometries.at(i).indices.size());
-    outline.indexOffsets.at(i) = static_cast<uint32_t>(lastIndexOffset);
+        static_cast<u32>(mesh.geometries.at(i).indices.size());
+    outline.indexOffsets.at(i) = static_cast<u32>(lastIndexOffset);
     outline.vertexOffsets.at(i) = lastVertexOffset;
     lastIndexOffset += outline.indexCounts.at(i);
     lastVertexOffset +=
-        static_cast<uint32_t>(mesh.geometries.at(i).positions.size());
+        static_cast<u32>(mesh.geometries.at(i).positions.size());
   }
 
   mMeshOutlines.push_back(outline);
@@ -189,22 +189,22 @@ void EditorRendererFrameData::addSkinnedMeshOutline(
 
   mOutlineTransforms.push_back(worldTransform);
 
-  uint32_t lastIndexOffset = 0;
-  uint32_t lastVertexOffset = 0;
-  for (size_t i = 0; i < outline.indexCounts.size(); ++i) {
+  u32 lastIndexOffset = 0;
+  u32 lastVertexOffset = 0;
+  for (usize i = 0; i < outline.indexCounts.size(); ++i) {
     outline.indexCounts.at(i) =
-        static_cast<uint32_t>(mesh.geometries.at(i).indices.size());
-    outline.indexOffsets.at(i) = static_cast<uint32_t>(lastIndexOffset);
+        static_cast<u32>(mesh.geometries.at(i).indices.size());
+    outline.indexOffsets.at(i) = static_cast<u32>(lastIndexOffset);
     outline.vertexOffsets.at(i) = lastVertexOffset;
     lastIndexOffset += outline.indexCounts.at(i);
     lastVertexOffset +=
-        static_cast<uint32_t>(mesh.geometries.at(i).positions.size());
+        static_cast<u32>(mesh.geometries.at(i).positions.size());
   }
 
   mMeshOutlines.push_back(outline);
 
-  size_t currentOffset = mLastOutlineSkeleton * MaxNumJoints;
-  size_t newSize = currentOffset + MaxNumJoints;
+  usize currentOffset = mLastOutlineSkeleton * MaxNumJoints;
+  usize newSize = currentOffset + MaxNumJoints;
 
   // Resize skeletons if new skeleton does not fit
   if (mOutlineSkeletonCapacity < newSize) {
@@ -217,7 +217,7 @@ void EditorRendererFrameData::addSkinnedMeshOutline(
   }
 
   auto *currentSkeleton = mOutlineSkeletons.get() + currentOffset;
-  size_t dataSize = std::min(skeleton.size(), MaxNumJoints);
+  usize dataSize = std::min(skeleton.size(), MaxNumJoints);
   memcpy(currentSkeleton, skeleton.data(), dataSize * sizeof(glm::mat4));
   mLastOutlineSkeleton++;
 
@@ -291,7 +291,7 @@ void EditorRendererFrameData::setCollidable(
   mCollidableEntityParams.center =
       glm::vec4(collidable.geometryDesc.center, 0.0f);
   mCollidableEntityParams.type.x =
-      static_cast<uint32_t>(collidable.geometryDesc.type);
+      static_cast<u32>(collidable.geometryDesc.type);
 
   if (collidable.geometryDesc.type == PhysicsGeometryType::Box) {
     const auto &params =

--- a/editor/src/quoll/editor/core/EditorRendererFrameData.h
+++ b/editor/src/quoll/editor/core/EditorRendererFrameData.h
@@ -23,12 +23,12 @@ public:
   /**
    * @brief Maximum number of debug bones
    */
-  static constexpr size_t MaxNumBones = 64;
+  static constexpr usize MaxNumBones = 64;
 
   /**
    * @brief Default reserved space for buffers
    */
-  static constexpr size_t DefaultReservedSpace = 2000;
+  static constexpr usize DefaultReservedSpace = 2000;
 
   /**
    * @brief Collidable entity data for buffers
@@ -70,7 +70,7 @@ public:
     /**
      * Vertex buffer binding offsets
      */
-    std::vector<uint64_t> vertexBufferOffsets;
+    std::vector<u64> vertexBufferOffsets;
 
     /**
      * Index buffer
@@ -79,15 +79,15 @@ public:
     /**
      * Index buffer
      */
-    std::vector<uint32_t> indexCounts;
+    std::vector<u32> indexCounts;
     /**
      * Index offsets
      */
-    std::vector<uint32_t> indexOffsets;
+    std::vector<u32> indexOffsets;
     /**
      * Vertex offsets
      */
-    std::vector<uint32_t> vertexOffsets;
+    std::vector<u32> vertexOffsets;
   };
 
 public:
@@ -98,7 +98,7 @@ public:
    * @param reservedSpace Reserved space for buffer data
    */
   EditorRendererFrameData(RenderStorage &renderStorage,
-                          size_t reservedSpace = DefaultReservedSpace);
+                          usize reservedSpace = DefaultReservedSpace);
 
   /**
    * @brief Add skeleton
@@ -132,9 +132,7 @@ public:
    *
    * @return Number of bones
    */
-  inline const std::vector<uint32_t> &getBoneCounts() const {
-    return mNumBones;
-  }
+  inline const std::vector<u32> &getBoneCounts() const { return mNumBones; }
 
   /**
    * @brief Set active camera
@@ -238,28 +236,28 @@ public:
    *
    * @return Last sprite index
    */
-  inline size_t getOutlineSpriteEnd() const { return mOutlineSpriteEnd; }
+  inline usize getOutlineSpriteEnd() const { return mOutlineSpriteEnd; }
 
   /**
    * @brief Get last text index in outline data
    *
    * @return Last text index
    */
-  inline size_t getOutlineTextEnd() const { return mOutlineTextEnd; }
+  inline usize getOutlineTextEnd() const { return mOutlineTextEnd; }
 
   /**
    * @brief Get last mesh index in outline data
    *
    * @return Last mesh index
    */
-  inline size_t getOutlineMeshEnd() const { return mOutlineMeshEnd; }
+  inline usize getOutlineMeshEnd() const { return mOutlineMeshEnd; }
 
   /**
    * @brief Get last skinned mesh index in outline data
    *
    * @return Last skinned mesh index
    */
-  inline size_t getOutlineSkinnedMeshEnd() const {
+  inline usize getOutlineSkinnedMeshEnd() const {
     return mOutlineSkinnedMeshEnd;
   }
 
@@ -277,7 +275,7 @@ public:
    *
    * @return Gizmo counts per icon
    */
-  inline const std::unordered_map<rhi::TextureHandle, uint32_t> &
+  inline const std::unordered_map<rhi::TextureHandle, u32> &
   getGizmoCounts() const {
     return mGizmoCounts;
   }
@@ -343,26 +341,26 @@ public:
   void createBindlessParamsRange();
 
 private:
-  size_t mReservedSpace = 0;
+  usize mReservedSpace = 0;
 
   // Outlines
   std::vector<glm::mat4> mOutlineTransforms;
   rhi::Buffer mOutlineTransformsBuffer;
 
-  size_t mOutlineSpriteEnd = 0;
+  usize mOutlineSpriteEnd = 0;
 
-  size_t mOutlineTextEnd = 0;
+  usize mOutlineTextEnd = 0;
   std::vector<SceneRendererFrameData::TextItem> mTextOutlines;
   std::vector<SceneRendererFrameData::GlyphData> mTextGlyphOutlines;
   rhi::Buffer mOutlineTextGlyphsBuffer;
 
-  size_t mOutlineMeshEnd = 0;
+  usize mOutlineMeshEnd = 0;
   std::vector<MeshOutline> mMeshOutlines;
 
-  size_t mOutlineSkinnedMeshEnd = 0;
+  usize mOutlineSkinnedMeshEnd = 0;
   std::unique_ptr<glm::mat4> mOutlineSkeletons;
-  size_t mLastOutlineSkeleton = 0;
-  size_t mOutlineSkeletonCapacity = 0;
+  usize mLastOutlineSkeleton = 0;
+  usize mOutlineSkeletonCapacity = 0;
   rhi::Buffer mOutlineSkeletonsBuffer;
 
   // Camera
@@ -374,16 +372,16 @@ private:
   rhi::Buffer mEditorGridBuffer;
 
   // Skeleton bones
-  size_t mLastSkeleton = 0;
+  usize mLastSkeleton = 0;
   std::vector<glm::mat4> mSkeletonTransforms;
   std::unique_ptr<glm::mat4> mSkeletonVector;
-  std::vector<uint32_t> mNumBones;
+  std::vector<u32> mNumBones;
   rhi::Buffer mSkeletonTransformsBuffer;
   rhi::Buffer mSkeletonBoneTransformsBuffer;
 
   // Gizmos
   std::vector<glm::mat4> mGizmoTransforms;
-  std::unordered_map<rhi::TextureHandle, uint32_t> mGizmoCounts;
+  std::unordered_map<rhi::TextureHandle, u32> mGizmoCounts;
   rhi::Buffer mGizmoTransformsBuffer;
 
   // Collidable shape

--- a/editor/src/quoll/editor/core/EditorSimulator.cpp
+++ b/editor/src/quoll/editor/core/EditorSimulator.cpp
@@ -13,7 +13,7 @@ EditorSimulator::EditorSimulator(InputDeviceManager &deviceManager,
       mPhysicsSystem(PhysicsSystem::createPhysxBackend(eventSystem)),
       mEditorCamera(editorCamera), mAudioSystem(assetRegistry) {}
 
-void EditorSimulator::update(float dt, WorkspaceState &state) {
+void EditorSimulator::update(f32 dt, WorkspaceState &state) {
   if (state.mode != mMode) {
     // Reobserve changes when switching from
     // edit to simulation mode
@@ -49,7 +49,7 @@ void EditorSimulator::observeChanges(EntityDatabase &simulationDatabase) {
   mAudioSystem.observeChanges(simulationDatabase);
 }
 
-void EditorSimulator::updateEditor(float dt, WorkspaceState &state) {
+void EditorSimulator::updateEditor(f32 dt, WorkspaceState &state) {
   auto &entityDatabase = state.scene.entityDatabase;
   mEntityDeleter.update(state.scene);
 
@@ -60,7 +60,7 @@ void EditorSimulator::updateEditor(float dt, WorkspaceState &state) {
   mSceneUpdater.update(entityDatabase);
 }
 
-void EditorSimulator::updateSimulation(float dt, WorkspaceState &state) {
+void EditorSimulator::updateSimulation(f32 dt, WorkspaceState &state) {
   auto &entityDatabase = state.simulationScene.entityDatabase;
   mEntityDeleter.update(state.simulationScene);
 

--- a/editor/src/quoll/editor/core/EditorSimulator.h
+++ b/editor/src/quoll/editor/core/EditorSimulator.h
@@ -48,7 +48,7 @@ public:
    * @param dt Time delta
    * @param state Workspace state
    */
-  void update(float dt, WorkspaceState &state);
+  void update(f32 dt, WorkspaceState &state);
 
   /**
    * @brief Get physics system
@@ -87,7 +87,7 @@ private:
    * @param dt Time delta
    * @param state Workspace state
    */
-  void updateEditor(float dt, WorkspaceState &scene);
+  void updateEditor(f32 dt, WorkspaceState &scene);
 
   /**
    * @brief Simulation updater
@@ -95,10 +95,10 @@ private:
    * @param dt Time delta
    * @param state Workspace state
    */
-  void updateSimulation(float dt, WorkspaceState &scene);
+  void updateSimulation(f32 dt, WorkspaceState &scene);
 
 private:
-  std::function<void(float, WorkspaceState &)> mUpdater;
+  std::function<void(f32, WorkspaceState &)> mUpdater;
 
   EditorCamera &mEditorCamera;
   CameraAspectRatioUpdater mCameraAspectRatioUpdater;

--- a/editor/src/quoll/editor/core/MousePickingGraph.h
+++ b/editor/src/quoll/editor/core/MousePickingGraph.h
@@ -39,7 +39,7 @@ public:
    * @param frameIndex Frame index
    */
   void execute(rhi::RenderCommandList &commandList, const glm::vec2 &mousePos,
-               uint32_t frameIndex);
+               u32 frameIndex);
 
   /**
    * @brief Get selected entity
@@ -65,7 +65,7 @@ public:
    * @retval true Selection is performed in current frame
    * @retval false Selection is not performed in current frame
    */
-  inline bool isSelectionPerformedInFrame(uint32_t frameIndex) const {
+  inline bool isSelectionPerformedInFrame(u32 frameIndex) const {
     return frameIndex == mFrameIndex;
   }
 
@@ -99,7 +99,7 @@ private:
   glm::uvec2 mFramebufferSize{};
   bool mResized = true;
 
-  uint32_t mFrameIndex = std::numeric_limits<uint32_t>::max();
+  u32 mFrameIndex = std::numeric_limits<u32>::max();
 };
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/editor-scene/EditorCamera.cpp
+++ b/editor/src/quoll/editor/editor-scene/EditorCamera.cpp
@@ -57,13 +57,13 @@ EditorCamera::EditorCamera(EventSystem &eventSystem, Window &window)
           return;
         }
 
-        static constexpr float MinOOBThreshold = 2.0f;
+        static constexpr f32 MinOOBThreshold = 2.0f;
         const auto &size = mWindow.getFramebufferSize();
 
-        float minX = 0;
-        float maxX = static_cast<float>(size.x);
-        float minY = 0;
-        float maxY = static_cast<float>(size.y);
+        f32 minX = 0;
+        f32 maxX = static_cast<f32>(size.x);
+        f32 minY = 0;
+        f32 maxY = static_cast<f32>(size.y);
 
         bool outOfBounds = false;
 
@@ -142,8 +142,7 @@ void EditorCamera::update(WorkspaceState &state) {
 
   lens.aspectRatio = mWidth / mHeight;
 
-  const float fovY =
-      2.0f * atanf(lens.sensorSize.y / (2.0f * lens.focalLength));
+  const f32 fovY = 2.0f * atanf(lens.sensorSize.y / (2.0f * lens.focalLength));
 
   camera.projectionMatrix =
       glm::perspective(fovY, lens.aspectRatio, lens.near, lens.far);
@@ -151,22 +150,22 @@ void EditorCamera::update(WorkspaceState &state) {
   camera.viewMatrix = glm::lookAt(lookAt.eye, lookAt.center, lookAt.up);
   camera.projectionViewMatrix = camera.projectionMatrix * camera.viewMatrix;
 
-  static constexpr float Ev100ForOneExposure = -0.263034f;
+  static constexpr f32 Ev100ForOneExposure = -0.263034f;
   camera.exposure.x = Ev100ForOneExposure;
 }
 
 glm::vec2 EditorCamera::scaleToViewport(const glm::vec2 &pos) const {
-  float scaleX = static_cast<float>(mWindow.getFramebufferSize().x) / mWidth;
-  float scaleY = static_cast<float>(mWindow.getFramebufferSize().y) / mHeight;
+  f32 scaleX = static_cast<f32>(mWindow.getFramebufferSize().x) / mWidth;
+  f32 scaleY = static_cast<f32>(mWindow.getFramebufferSize().y) / mHeight;
 
-  float rX = pos.x - mX;
-  float rY = pos.y - mY;
+  f32 rX = pos.x - mX;
+  f32 rY = pos.y - mY;
 
   return glm::vec2(rX * scaleX, rY * scaleY);
 }
 
 void EditorCamera::pan(CameraLookAt &lookAt) {
-  static constexpr float PanSpeed = 0.03f;
+  static constexpr f32 PanSpeed = 0.03f;
 
   glm::vec2 mousePos = mWindow.getCurrentMousePosition();
   glm::vec3 right = glm::normalize(
@@ -182,15 +181,15 @@ void EditorCamera::pan(CameraLookAt &lookAt) {
 }
 
 void EditorCamera::rotate(CameraLookAt &lookAt) {
-  static constexpr float TwoPi = 2.0f * glm::pi<float>();
+  static constexpr f32 TwoPi = 2.0f * glm::pi<f32>();
 
   glm::vec2 mousePos = mWindow.getCurrentMousePosition();
   const auto &size = mWindow.getFramebufferSize();
 
   glm ::vec2 screenToSphere{// horizontal = 2pi
-                            (TwoPi / static_cast<float>(size.x)),
+                            (TwoPi / static_cast<f32>(size.x)),
                             // vertical = pi
-                            (glm::pi<float>() / static_cast<float>(size.y))};
+                            (glm::pi<f32>() / static_cast<f32>(size.y))};
 
   // Convert mouse position difference to angle
   // difference for arcball
@@ -210,7 +209,7 @@ void EditorCamera::rotate(CameraLookAt &lookAt) {
 
 void EditorCamera::zoom(CameraLookAt &lookAt) {
   glm::vec2 mousePos = mWindow.getCurrentMousePosition();
-  float zoomFactor = (mousePos.y - mPrevMousePos.y) * ZoomSpeed;
+  f32 zoomFactor = (mousePos.y - mPrevMousePos.y) * ZoomSpeed;
 
   glm::vec3 change = glm::vec3(lookAt.eye - lookAt.center) * zoomFactor;
   lookAt.center += change;
@@ -228,7 +227,7 @@ void EditorCamera::zoomWheel(CameraLookAt &lookAt) {
   mInputState = InputState::None;
 }
 
-void EditorCamera::setViewport(float x, float y, float width, float height,
+void EditorCamera::setViewport(f32 x, f32 y, f32 width, f32 height,
                                bool captureMouse) {
   mX = x;
   mY = y;

--- a/editor/src/quoll/editor/editor-scene/EditorCamera.h
+++ b/editor/src/quoll/editor/editor-scene/EditorCamera.h
@@ -32,7 +32,7 @@ public:
   /**
    * Zoom speed when scrolling
    */
-  static constexpr float ZoomSpeed = 0.03f;
+  static constexpr f32 ZoomSpeed = 0.03f;
 
   /**
    * Default sensor size
@@ -42,17 +42,17 @@ public:
   /**
    * Default focal length
    */
-  static constexpr float DefaultFocalLength = 16.0f;
+  static constexpr f32 DefaultFocalLength = 16.0f;
 
   /**
    * Default near perspective plane
    */
-  static constexpr float DefaultNear = 0.1f;
+  static constexpr f32 DefaultNear = 0.1f;
 
   /**
    * Default far perspective plane
    */
-  static constexpr float DefaultFar = 1000.0f;
+  static constexpr f32 DefaultFar = 1000.0f;
 
   /**
    * Default camera position
@@ -115,8 +115,7 @@ public:
    * @param height Viewport height
    * @param captureMouse Capture mouse for camera controls
    */
-  void setViewport(float x, float y, float width, float height,
-                   bool captureMouse);
+  void setViewport(f32 x, f32 y, f32 width, f32 height, bool captureMouse);
 
   /**
    * @brief Check if position is within viewport
@@ -175,11 +174,11 @@ private:
   void zoomWheel(CameraLookAt &lookAt);
 
 private:
-  float mX = 0.0f;
-  float mY = 0.0f;
-  float mWidth = 1.0f;
-  float mHeight = 1.0f;
-  float mWheelOffset = 0.0f;
+  f32 mX = 0.0f;
+  f32 mY = 0.0f;
+  f32 mWidth = 1.0f;
+  f32 mHeight = 1.0f;
+  f32 mWheelOffset = 0.0f;
   bool mCaptureMouse = false;
 
   InputState mInputState = InputState::None;

--- a/editor/src/quoll/editor/screens/EditorScreen.cpp
+++ b/editor/src/quoll/editor/screens/EditorScreen.cpp
@@ -190,13 +190,12 @@ void EditorScreen::start(const Project &rawProject) {
 
   mWindow.maximize();
 
-  mainLoop.setUpdateFn(
-      [&state, &workspace, &simulator, this](float dt) mutable {
-        workspace.update();
-        mEventSystem.poll();
-        simulator.update(dt, state);
-        return true;
-      });
+  mainLoop.setUpdateFn([&state, &workspace, &simulator, this](f32 dt) mutable {
+    workspace.update();
+    mEventSystem.poll();
+    simulator.update(dt, state);
+    return true;
+  });
 
   LogViewer logViewer;
   mainLoop.setRenderFn([&]() {
@@ -213,7 +212,7 @@ void EditorScreen::start(const Project &rawProject) {
     renderer.rebuildIfSettingsChanged();
 
     // TODO: Why is -2.0f needed here
-    static const float IconSize = ImGui::GetFrameHeight() - 2.0f;
+    static const f32 IconSize = ImGui::GetFrameHeight() - 2.0f;
 
     imguiRenderer.beginRendering();
     ImGuizmo::BeginFrame();
@@ -244,7 +243,7 @@ void EditorScreen::start(const Project &rawProject) {
 
     const auto &renderFrame = mDevice->beginFrame();
 
-    if (renderFrame.frameIndex < std::numeric_limits<uint32_t>::max()) {
+    if (renderFrame.frameIndex < std::numeric_limits<u32>::max()) {
       imguiRenderer.updateFrameData(renderFrame.frameIndex);
       sceneRenderer.updateFrameData(scene.entityDatabase, state.activeCamera,
                                     renderFrame.frameIndex);

--- a/editor/src/quoll/editor/screens/ProjectSelectorScreen.cpp
+++ b/editor/src/quoll/editor/screens/ProjectSelectorScreen.cpp
@@ -61,7 +61,7 @@ std::optional<Project> ProjectSelectorScreen::start() {
         presenter.enqueueFramebufferUpdate();
       });
 
-  mainLoop.setUpdateFn([&project, this](float dt) {
+  mainLoop.setUpdateFn([&project, this](f32 dt) {
     mEventSystem.poll();
     return !project.has_value();
   });
@@ -88,9 +88,9 @@ std::optional<Project> ProjectSelectorScreen::start() {
     debugLayer.render();
 
     static constexpr ImVec2 CenterWindowPivot(0.5f, 0.5f);
-    static constexpr float ActionButtonWidth = 240.0f;
-    static constexpr float ActionButtonHeight = 40.0f;
-    static constexpr float WindowPadding = 20.0f;
+    static constexpr f32 ActionButtonWidth = 240.0f;
+    static constexpr f32 ActionButtonHeight = 40.0f;
+    static constexpr f32 WindowPadding = 20.0f;
     static constexpr ImVec2 ActionButtonSize{ActionButtonWidth,
                                              ActionButtonHeight};
 
@@ -130,7 +130,7 @@ std::optional<Project> ProjectSelectorScreen::start() {
 
     const auto &renderFrame = mDevice->beginFrame();
 
-    if (renderFrame.frameIndex < std::numeric_limits<uint32_t>::max()) {
+    if (renderFrame.frameIndex < std::numeric_limits<u32>::max()) {
       imgui.updateFrameData(renderFrame.frameIndex);
       renderer.execute(renderFrame.commandList, renderFrame.frameIndex);
 

--- a/editor/src/quoll/editor/ui/AssetBrowser.cpp
+++ b/editor/src/quoll/editor/ui/AssetBrowser.cpp
@@ -12,11 +12,11 @@
 
 namespace quoll::editor {
 
-static constexpr uint32_t ItemWidth = 90;
-static constexpr uint32_t ItemHeight = 100;
+static constexpr u32 ItemWidth = 90;
+static constexpr u32 ItemHeight = 100;
 static constexpr ImVec2 IconSize(80.0f, 80.0f);
-static constexpr float ImagePadding = ((ItemWidth * 1.0f) - IconSize.x) / 2.0f;
-static constexpr uint32_t TextWidth = ItemWidth - 8;
+static constexpr f32 ImagePadding = ((ItemWidth * 1.0f) - IconSize.x) / 2.0f;
+static constexpr u32 TextWidth = ItemWidth - 8;
 
 /**
  * @brief Imgui text callback user data
@@ -129,7 +129,7 @@ void AssetBrowser::render(WorkspaceContext &context) {
 
   if (auto _ = widgets::Window("Asset Browser")) {
     const auto &size = ImGui::GetContentRegionAvail();
-    auto itemsPerRow = static_cast<int32_t>(size.x / ItemWidth);
+    auto itemsPerRow = static_cast<i32>(size.x / ItemWidth);
 
     if (itemsPerRow == 0)
       itemsPerRow = 1;
@@ -154,7 +154,7 @@ void AssetBrowser::render(WorkspaceContext &context) {
 
     if (ImGui::BeginTable("CurrentDir", itemsPerRow,
                           ImGuiTableFlags_NoPadInnerX)) {
-      size_t i = 0;
+      usize i = 0;
 
       for (; i < mEntries.size(); ++i) {
         const auto &entry = mEntries.at(i);
@@ -168,7 +168,7 @@ void AssetBrowser::render(WorkspaceContext &context) {
         ImGui::TableNextColumn();
 
         String id = "###" + std::to_string(entry.asset) + "-" +
-                    std::to_string(static_cast<uint32_t>(entry.assetType));
+                    std::to_string(static_cast<u32>(entry.assetType));
         if (ImGui::Selectable(id.c_str(), mSelected == i,
                               ImGuiSelectableFlags_AllowDoubleClick,
                               ImVec2(ItemWidth, ItemHeight))) {
@@ -212,7 +212,7 @@ void AssetBrowser::render(WorkspaceContext &context) {
           if (ImGui::BeginDragDropSource()) {
             ImGui::SetDragDropPayload(
                 getAssetTypeString(entry.assetType).c_str(), &entry.asset,
-                sizeof(uint32_t));
+                sizeof(u32));
             renderEntry(entry);
             ImGui::EndDragDropSource();
           }
@@ -378,15 +378,15 @@ void AssetBrowser::handleCreateEntry(AssetManager &assetManager) {
 void AssetBrowser::renderEntry(const Entry &entry) {
 
   {
-    float initialCursorPos = ImGui::GetCursorPosX();
+    f32 initialCursorPos = ImGui::GetCursorPosX();
     ImGui::SetCursorPosX(initialCursorPos + ImagePadding);
     imgui::image(entry.preview, IconSize);
     ImGui::SetCursorPosX(initialCursorPos);
   }
 
   {
-    float initialCursorPos = ImGui::GetCursorPosX();
-    const float centerPos =
+    f32 initialCursorPos = ImGui::GetCursorPosX();
+    const f32 centerPos =
         initialCursorPos + (ItemWidth * 1.0f - entry.textWidth) * 0.5f;
     ImGui::SetCursorPosX(centerPos);
     ImGui::Text("%s", entry.truncatedName.c_str());
@@ -455,7 +455,7 @@ void AssetBrowser::fetchPrefab(PrefabAssetHandle handle,
     entry.name = removePrefabName(asset.name);
     entry.assetType = asset.type;
     entry.uuid = asset.uuid;
-    entry.asset = static_cast<uint32_t>(handle);
+    entry.asset = static_cast<u32>(handle);
     setDefaultProps(entry, assetManager.getAssetRegistry());
 
     return entry;

--- a/editor/src/quoll/editor/ui/AssetBrowser.h
+++ b/editor/src/quoll/editor/ui/AssetBrowser.h
@@ -22,12 +22,12 @@ class AssetBrowser {
     Uuid uuid;
     String name;
     String truncatedName;
-    float textWidth = 0.0f;
+    f32 textWidth = 0.0f;
     bool isDirectory = false;
     EditorIcon icon = EditorIcon::Unknown;
     rhi::TextureHandle preview = rhi::TextureHandle::Null;
     AssetType assetType = AssetType::None;
-    uint32_t asset = 0;
+    u32 asset = 0;
     bool isEditable = false;
   };
 
@@ -72,7 +72,7 @@ private:
   std::vector<Entry> mEntries;
   Path mCurrentDirectory;
   Path mPrefabDirectory;
-  size_t mSelected = std::numeric_limits<size_t>::max();
+  usize mSelected = std::numeric_limits<usize>::max();
 
   AssetLoadStatusDialog mStatusDialog{"AssetLoadStatus"};
   MaterialViewer mMaterialViewer;

--- a/editor/src/quoll/editor/ui/EntityPanel.cpp
+++ b/editor/src/quoll/editor/ui/EntityPanel.cpp
@@ -81,7 +81,7 @@ static bool ImguiMultilineInputText(const String &label, String &value,
 static void dndEnvironmentAsset(widgets::Section &section, Entity entity,
                                 const EnvironmentSkybox &skybox,
                                 ActionExecutor &actionExecutor) {
-  static constexpr float DropBorderWidth = 3.5f;
+  static constexpr f32 DropBorderWidth = 3.5f;
   auto &g = *ImGui::GetCurrentContext();
 
   ImVec2 dropMin(section.getClipRect().Min.x + DropBorderWidth,
@@ -210,7 +210,7 @@ void EntityPanel::renderDirectionalLight(Scene &scene,
 
     sendAction |= ImGui::IsItemDeactivatedAfterEdit();
 
-    float intensity = component.intensity;
+    f32 intensity = component.intensity;
     if (widgets::Input("Intensity", intensity, false)) {
       if (!mDirectionalLightAction) {
         mDirectionalLightAction = std::make_unique<EntitySetDirectionalLight>(
@@ -255,7 +255,7 @@ void EntityPanel::renderDirectionalLight(Scene &scene,
         sendAction = true;
       }
 
-      float splitLambda = component.splitLambda;
+      f32 splitLambda = component.splitLambda;
       if (widgets::Input("Split lambda", splitLambda, false)) {
         splitLambda = glm::clamp(splitLambda, 0.0f, 1.0f);
 
@@ -266,14 +266,14 @@ void EntityPanel::renderDirectionalLight(Scene &scene,
         sendAction = true;
       }
 
-      int32_t numCascades = static_cast<int32_t>(component.numCascades);
+      i32 numCascades = static_cast<i32>(component.numCascades);
       ImGui::Text("Number of cascades");
       if (ImGui::DragInt("###NumberOfCascades", &numCascades, 0.5f, 1,
-                         static_cast<int32_t>(component.MaxCascades))) {
+                         static_cast<i32>(component.MaxCascades))) {
         mCascadedShadowMapAction = std::make_unique<EntitySetCascadedShadowMap>(
             mSelectedEntity, component);
 
-        component.numCascades = static_cast<uint32_t>(numCascades);
+        component.numCascades = static_cast<u32>(numCascades);
       }
 
       sendAction |= ImGui::IsItemDeactivatedAfterEdit();
@@ -316,7 +316,7 @@ void EntityPanel::renderPointLight(Scene &scene,
 
     sendAction |= ImGui::IsItemDeactivatedAfterEdit();
 
-    float intensity = component.intensity;
+    f32 intensity = component.intensity;
     if (widgets::Input("Intensity (in candelas)", intensity, false)) {
       mPointLightAction =
           std::make_unique<EntitySetPointLight>(mSelectedEntity, component);
@@ -326,7 +326,7 @@ void EntityPanel::renderPointLight(Scene &scene,
       sendAction = true;
     }
 
-    float range = component.range;
+    f32 range = component.range;
     if (widgets::Input("Range", range, false)) {
       if (!mPointLightAction) {
         mPointLightAction =
@@ -362,7 +362,7 @@ void EntityPanel::renderCamera(WorkspaceState &state, Scene &scene,
 
     bool sendAction = false;
 
-    float near = component.near;
+    f32 near = component.near;
     if (widgets::Input("Near", near, false)) {
       if (near < 0.0f) {
         near = 0.0f;
@@ -378,7 +378,7 @@ void EntityPanel::renderCamera(WorkspaceState &state, Scene &scene,
       sendAction = true;
     }
 
-    float far = component.far;
+    f32 far = component.far;
     if (widgets::Input("Far", far, false)) {
       if (far < 0.0f) {
         far = 0.0f;
@@ -406,7 +406,7 @@ void EntityPanel::renderCamera(WorkspaceState &state, Scene &scene,
       sendAction = true;
     }
 
-    float focalLength = component.focalLength;
+    f32 focalLength = component.focalLength;
     if (widgets::Input("Focal length (mm)", focalLength, false)) {
       focalLength = std::max(focalLength, 0.0f);
 
@@ -419,7 +419,7 @@ void EntityPanel::renderCamera(WorkspaceState &state, Scene &scene,
       sendAction = true;
     }
 
-    float aperture = component.aperture;
+    f32 aperture = component.aperture;
     if (widgets::Input("Aperture", aperture, false)) {
       if (aperture < 0.0f) {
         aperture = 0.0f;
@@ -434,7 +434,7 @@ void EntityPanel::renderCamera(WorkspaceState &state, Scene &scene,
       sendAction = true;
     }
 
-    float shutterSpeed = 1.0f / component.shutterSpeed;
+    f32 shutterSpeed = 1.0f / component.shutterSpeed;
     if (widgets::Input("Shutter speed (1/s)", shutterSpeed, false)) {
       if (shutterSpeed < 0.0f) {
         shutterSpeed = 0.0f;
@@ -449,7 +449,7 @@ void EntityPanel::renderCamera(WorkspaceState &state, Scene &scene,
       sendAction = true;
     }
 
-    uint32_t sensitivity = component.sensitivity;
+    u32 sensitivity = component.sensitivity;
     if (widgets::Input("Sensitivity (ISO)", sensitivity, false)) {
       if (!mPerspectiveLensAction) {
         mPerspectiveLensAction = std::make_unique<EntitySetPerspectiveLens>(
@@ -466,8 +466,8 @@ void EntityPanel::renderCamera(WorkspaceState &state, Scene &scene,
     }
 
     ImGui::Text("Aspect Ratio");
-    static constexpr float MinCustomAspectRatio = 0.01f;
-    static constexpr float MaxCustomAspectRatio = 1000.0f;
+    static constexpr f32 MinCustomAspectRatio = 0.01f;
+    static constexpr f32 MaxCustomAspectRatio = 1000.0f;
 
     bool hasViewportAspectRatio =
         scene.entityDatabase.has<AutoAspectRatio>(mSelectedEntity);
@@ -490,7 +490,7 @@ void EntityPanel::renderCamera(WorkspaceState &state, Scene &scene,
 
     if (!hasViewportAspectRatio) {
       ImGui::Text("Custom aspect ratio");
-      float aspectRatio = component.aspectRatio;
+      f32 aspectRatio = component.aspectRatio;
       if (ImGui::DragFloat("###CustomAspectRatio", &aspectRatio,
                            MinCustomAspectRatio, MinCustomAspectRatio,
                            MaxCustomAspectRatio, "%.2f")) {
@@ -644,8 +644,7 @@ void EntityPanel::renderMesh(Scene &scene, AssetRegistry &assetRegistry,
 
       if (auto table = widgets::Table("TableMesh", 2)) {
         table.row("Name", asset.name);
-        table.row("Geometries",
-                  static_cast<uint32_t>(asset.data.geometries.size()));
+        table.row("Geometries", static_cast<u32>(asset.data.geometries.size()));
       }
     }
 
@@ -663,8 +662,7 @@ void EntityPanel::renderMesh(Scene &scene, AssetRegistry &assetRegistry,
 
       if (auto table = widgets::Table("TableSkinnedMesh", 2)) {
         table.row("Name", asset.name);
-        table.row("Geometries",
-                  static_cast<uint32_t>(asset.data.geometries.size()));
+        table.row("Geometries", static_cast<u32>(asset.data.geometries.size()));
       }
     }
 
@@ -687,12 +685,12 @@ void EntityPanel::renderMeshRenderer(Scene &scene, AssetRegistry &assetRegistry,
         scene.entityDatabase.get<MeshRenderer>(mSelectedEntity);
 
     if (auto table = widgets::Table("TableMaterials", 2)) {
-      for (size_t i = 0; i < renderer.materials.size(); ++i) {
+      for (usize i = 0; i < renderer.materials.size(); ++i) {
         const auto &asset =
             assetRegistry.getMaterials().getAsset(renderer.materials.at(i));
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
-        ImGui::Text("Slot %d", static_cast<uint32_t>(i));
+        ImGui::Text("Slot %d", static_cast<u32>(i));
         ImGui::TableNextColumn();
         ImGui::Button(asset.name.c_str());
         if (ImGui::BeginDragDropTarget()) {
@@ -749,12 +747,12 @@ void EntityPanel::renderSkinnedMeshRenderer(Scene &scene,
         scene.entityDatabase.get<SkinnedMeshRenderer>(mSelectedEntity);
 
     if (auto table = widgets::Table("TableMaterials", 2)) {
-      for (size_t i = 0; i < renderer.materials.size(); ++i) {
+      for (usize i = 0; i < renderer.materials.size(); ++i) {
         const auto &asset =
             assetRegistry.getMaterials().getAsset(renderer.materials.at(i));
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
-        ImGui::Text("Slot %d", static_cast<uint32_t>(i));
+        ImGui::Text("Slot %d", static_cast<u32>(i));
         ImGui::TableNextColumn();
         ImGui::Button(asset.name.c_str());
         if (ImGui::BeginDragDropTarget()) {
@@ -816,7 +814,7 @@ void EntityPanel::renderSkeleton(Scene &scene, AssetRegistry &assetRegistry,
     if (auto table = widgets::Table("TableSkinnedMesh", 2)) {
       table.row("Name", asset.name);
       table.row("Number of joints",
-                static_cast<uint32_t>(skeleton.jointNames.size()));
+                static_cast<u32>(skeleton.jointNames.size()));
     }
 
     if (ImGui::Checkbox("Show bones", &showBones)) {
@@ -853,7 +851,7 @@ void EntityPanel::renderJointAttachment(Scene &scene,
 
       auto label = attachment.joint >= 0 &&
                            attachment.joint <
-                               static_cast<int16_t>(skeleton.jointNames.size())
+                               static_cast<i16>(skeleton.jointNames.size())
                        ? skeleton.jointNames.at(attachment.joint)
                        : "Select joint";
 
@@ -862,10 +860,10 @@ void EntityPanel::renderJointAttachment(Scene &scene,
       }
 
       if (ImGui::BeginPopup("SetJointAttachment")) {
-        for (size_t i = 0; i < skeleton.jointNames.size(); ++i) {
+        for (usize i = 0; i < skeleton.jointNames.size(); ++i) {
           if (ImGui::Selectable(skeleton.jointNames.at(i).c_str())) {
             auto newAttachment = attachment;
-            newAttachment.joint = static_cast<int16_t>(i);
+            newAttachment.joint = static_cast<i16>(i);
 
             actionExecutor
                 .execute<EntityDefaultUpdateComponent<JointAttachment>>(
@@ -932,7 +930,7 @@ void EntityPanel::renderAnimation(WorkspaceState &state, Scene &scene,
             assetRegistry.getAnimations().getAsset(currentState.animation).data;
 
         ImGui::Text("Time");
-        float animationTime = component.normalizedTime * animationAsset.time;
+        f32 animationTime = component.normalizedTime * animationAsset.time;
         if (ImGui::SliderFloat("###AnimationTime", &animationTime, 0.0f,
                                animationAsset.time)) {
           component.normalizedTime = animationTime / animationAsset.time;
@@ -1042,7 +1040,7 @@ void EntityPanel::renderCollidable(Scene &scene,
     } else if (collidable.geometryDesc.type == PhysicsGeometryType::Sphere) {
       auto &sphere =
           std::get<PhysicsGeometrySphere>(collidable.geometryDesc.params);
-      float radius = sphere.radius;
+      f32 radius = sphere.radius;
 
       if (widgets::Input("Radius", radius, false)) {
         if (!mCollidableAction) {
@@ -1055,8 +1053,8 @@ void EntityPanel::renderCollidable(Scene &scene,
     } else if (collidable.geometryDesc.type == PhysicsGeometryType::Capsule) {
       auto &capsule =
           std::get<PhysicsGeometryCapsule>(collidable.geometryDesc.params);
-      float radius = capsule.radius;
-      float halfHeight = capsule.halfHeight;
+      f32 radius = capsule.radius;
+      f32 halfHeight = capsule.halfHeight;
 
       if (widgets::Input("Radius", radius, false)) {
         if (!mCollidableAction) {
@@ -1100,7 +1098,7 @@ void EntityPanel::renderCollidable(Scene &scene,
     {
       auto &material = collidable.materialDesc;
 
-      float dynamicFriction = material.dynamicFriction;
+      f32 dynamicFriction = material.dynamicFriction;
 
       if (widgets::Input("Dynamic friction", dynamicFriction, false)) {
         if (!mCollidableAction) {
@@ -1111,7 +1109,7 @@ void EntityPanel::renderCollidable(Scene &scene,
         material.dynamicFriction = dynamicFriction;
       }
 
-      float restitution = material.restitution;
+      f32 restitution = material.restitution;
       if (widgets::Input("Restitution", restitution, false)) {
         if (restitution > 1.0f) {
           restitution = 1.0f;
@@ -1125,7 +1123,7 @@ void EntityPanel::renderCollidable(Scene &scene,
         material.restitution = restitution;
       }
 
-      float staticFriction = material.staticFriction;
+      f32 staticFriction = material.staticFriction;
       if (widgets::Input("Static friction", staticFriction, false)) {
         if (!mCollidableAction) {
           mCollidableAction = std::make_unique<EntitySetCollidable>(
@@ -1160,7 +1158,7 @@ void EntityPanel::renderRigidBody(Scene &scene,
     auto &rigidBody = scene.entityDatabase.get<RigidBody>(mSelectedEntity);
 
     bool sendAction = false;
-    float mass = rigidBody.dynamicDesc.mass;
+    f32 mass = rigidBody.dynamicDesc.mass;
     if (widgets::Input("Mass", mass, false)) {
       if (!mRigidBodyAction) {
         mRigidBodyAction =
@@ -1215,7 +1213,7 @@ void EntityPanel::renderText(Scene &scene, AssetRegistry &assetRegistry,
 
     const auto &fonts = assetRegistry.getFonts().getAssets();
 
-    static constexpr float ContentInputHeight = 100.0f;
+    static constexpr f32 ContentInputHeight = 100.0f;
     bool sendAction = false;
 
     ImGui::Text("Content");
@@ -1234,7 +1232,7 @@ void EntityPanel::renderText(Scene &scene, AssetRegistry &assetRegistry,
       sendAction = true;
     }
 
-    float lineHeight = text.lineHeight;
+    f32 lineHeight = text.lineHeight;
     if (widgets::Input("Line height", lineHeight, false)) {
       if (!mTextAction) {
         mTextAction = std::make_unique<EntitySetText>(mSelectedEntity, text);
@@ -1381,7 +1379,7 @@ void EntityPanel::renderScripting(Scene &scene, AssetRegistry &assetRegistry,
                     : PrefabAssetHandle::Null;
 
             const auto width = ImGui::GetWindowContentRegionWidth();
-            const float halfWidth = width * 0.5f;
+            const f32 halfWidth = width * 0.5f;
             if (value == PrefabAssetHandle::Null) {
               ImGui::Button("Drag prefab here", ImVec2(width, halfWidth));
             } else {
@@ -1407,7 +1405,7 @@ void EntityPanel::renderScripting(Scene &scene, AssetRegistry &assetRegistry,
                     : TextureAssetHandle::Null;
 
             const auto width = ImGui::GetWindowContentRegionWidth();
-            const float halfWidth = width * 0.5f;
+            const f32 halfWidth = width * 0.5f;
             if (value == TextureAssetHandle::Null) {
               ImGui::Button("Drag texture here", ImVec2(width, halfWidth));
             } else {
@@ -1449,8 +1447,8 @@ void EntityPanel::renderInput(Scene &scene, AssetRegistry &assetRegistry,
   static const String SectionName = String(fa::Keyboard) + "  Input map";
 
   if (auto section = widgets::Section(SectionName.c_str())) {
-    float width = section.getClipRect().GetWidth();
-    const float height = width * 0.2f;
+    f32 width = section.getClipRect().GetWidth();
+    const f32 height = width * 0.2f;
 
     auto &component =
         scene.entityDatabase.get<InputMapAssetRef>(mSelectedEntity);
@@ -1464,7 +1462,7 @@ void EntityPanel::renderInput(Scene &scene, AssetRegistry &assetRegistry,
       ImGui::Button("Drag input map here", ImVec2(width, height));
     }
 
-    static constexpr float DropBorderWidth = 3.5f;
+    static constexpr f32 DropBorderWidth = 3.5f;
     auto &g = *ImGui::GetCurrentContext();
 
     ImVec2 dropMin(section.getClipRect().Min.x + DropBorderWidth,
@@ -1494,7 +1492,7 @@ void EntityPanel::renderInput(Scene &scene, AssetRegistry &assetRegistry,
 
       ImGui::Text("Default scheme");
       if (ImGui::BeginCombo("##DefaultScheme", schemeName)) {
-        for (size_t i = 0; i < asset.data.schemes.size(); ++i) {
+        for (usize i = 0; i < asset.data.schemes.size(); ++i) {
           const auto *name = asset.data.schemes.at(i).name.c_str();
           bool selectable = i == component.defaultScheme;
 
@@ -1554,8 +1552,8 @@ void EntityPanel::renderSkybox(Scene &scene, AssetRegistry &assetRegistry,
   static const String SectionName = String(fa::Cloud) + "  Skybox";
 
   if (auto section = widgets::Section(SectionName.c_str())) {
-    float width = section.getClipRect().GetWidth();
-    const float height = width * 0.5f;
+    f32 width = section.getClipRect().GetWidth();
+    const f32 height = width * 0.5f;
 
     auto &skybox = scene.entityDatabase.get<EnvironmentSkybox>(mSelectedEntity);
 
@@ -1772,7 +1770,7 @@ void EntityPanel::renderAddComponent(Scene &scene, AssetRegistry &assetRegistry,
 void EntityPanel::handleDragAndDrop(Scene &scene, AssetRegistry &assetRegistry,
                                     ActionExecutor &actionExecutor) {
   const auto width = ImGui::GetWindowContentRegionWidth();
-  const float halfWidth = width * 0.5f;
+  const f32 halfWidth = width * 0.5f;
 
   ImGui::Button("Drag asset here", ImVec2(width, halfWidth));
 

--- a/editor/src/quoll/editor/ui/Inspector.cpp
+++ b/editor/src/quoll/editor/ui/Inspector.cpp
@@ -43,7 +43,7 @@ void Inspector::render(WorkspaceState &state, AssetRegistry &assetRegistry,
         stack.pushColor(ImGuiCol_HeaderHovered, SelectionColor);
         stack.pushColor(ImGuiCol_HeaderActive, SelectionColor);
 
-        for (size_t i = 0; i < mTabs.size(); ++i) {
+        for (usize i = 0; i < mTabs.size(); ++i) {
           const auto &tab = mTabs.at(i);
           bool selected = mSelectedIndex == i;
 

--- a/editor/src/quoll/editor/ui/Inspector.h
+++ b/editor/src/quoll/editor/ui/Inspector.h
@@ -34,7 +34,7 @@ public:
 
 private:
   EntityPanel mEntityPanel;
-  size_t mSelectedIndex = 0;
+  usize mSelectedIndex = 0;
 
   std::vector<Tab> mTabs;
 };

--- a/editor/src/quoll/editor/ui/LogViewer.cpp
+++ b/editor/src/quoll/editor/ui/LogViewer.cpp
@@ -17,8 +17,8 @@ void LogViewer::render(LogMemoryStorage &userLogs) {
 }
 
 void LogViewer::renderLogContainer(const String &name,
-                                   LogMemoryStorage &logStorage,
-                                   size_t &logSize, float width) {
+                                   LogMemoryStorage &logStorage, usize &logSize,
+                                   f32 width) {
   ImGui::PushID(name.c_str());
   ImGui::BeginGroup();
   auto flags = ImGuiWindowFlags_HorizontalScrollbar |

--- a/editor/src/quoll/editor/ui/LogViewer.h
+++ b/editor/src/quoll/editor/ui/LogViewer.h
@@ -26,10 +26,10 @@ private:
    * @param width Container width
    */
   void renderLogContainer(const String &name, LogMemoryStorage &logStorage,
-                          size_t &logSize, float width);
+                          usize &logSize, f32 width);
 
 private:
-  size_t mUserLogSize = 0;
+  usize mUserLogSize = 0;
 };
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/ui/SceneGizmos.cpp
+++ b/editor/src/quoll/editor/ui/SceneGizmos.cpp
@@ -43,13 +43,13 @@ calculateLocalTransformFromWorld(WorkspaceState &state, Entity entity,
   const auto &parentWorld =
       entityDatabase.get<WorldTransform>(parent).worldTransform;
 
-  int16_t jointId = -1;
+  i16 jointId = -1;
   if (entityDatabase.has<JointAttachment>(entity) &&
       entityDatabase.has<Skeleton>(parent)) {
     jointId = entityDatabase.get<JointAttachment>(entity).joint;
   }
 
-  if (jointId >= 0 && jointId < std::numeric_limits<uint8_t>::max()) {
+  if (jointId >= 0 && jointId < std::numeric_limits<u8>::max()) {
     const auto &jointTransform =
         entityDatabase.get<Skeleton>(parent).jointWorldTransforms.at(jointId);
 

--- a/editor/src/quoll/editor/ui/SceneHierarchyPanel.cpp
+++ b/editor/src/quoll/editor/ui/SceneHierarchyPanel.cpp
@@ -62,7 +62,7 @@ static String getNodeName(const String &name, Entity entity,
 void SceneHierarchyPanel::render(WorkspaceState &state,
                                  ActionExecutor &actionExecutor) {
 
-  float paddingY = ImGui::GetStyle().WindowPadding.y;
+  f32 paddingY = ImGui::GetStyle().WindowPadding.y;
   StyleStack stack;
   stack.pushStyle(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
 
@@ -74,7 +74,7 @@ void SceneHierarchyPanel::render(WorkspaceState &state,
 void SceneHierarchyPanel::renderRoot(WorkspaceState &state,
                                      ActionExecutor &actionExecutor) {
   static constexpr ImVec2 TreeNodeItemPadding{4.0f, 8.0f};
-  static constexpr float TreeNodeIndentSpacing = 10.0f;
+  static constexpr f32 TreeNodeIndentSpacing = 10.0f;
 
   auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
                                                         : state.scene;
@@ -105,7 +105,7 @@ void SceneHierarchyPanel::renderRoot(WorkspaceState &state,
   }
 
   if (open) {
-    uint32_t index = 0;
+    u32 index = 0;
     for (auto [entity, transform] :
          scene.entityDatabase.view<LocalTransform>()) {
       if (scene.entityDatabase.has<Parent>(entity)) {
@@ -120,17 +120,16 @@ void SceneHierarchyPanel::renderRoot(WorkspaceState &state,
   }
 }
 
-uint32_t SceneHierarchyPanel::renderEntity(Entity entity, uint32_t index,
-                                           int flags, WorkspaceState &state,
-                                           ActionExecutor &actionExecutor) {
-  uint32_t innerIndex = index;
+u32 SceneHierarchyPanel::renderEntity(Entity entity, u32 index, int flags,
+                                      WorkspaceState &state,
+                                      ActionExecutor &actionExecutor) {
+  u32 innerIndex = index;
   auto &scene = state.mode == WorkspaceMode::Simulation ? state.simulationScene
                                                         : state.scene;
 
-  String name =
-      scene.entityDatabase.has<Name>(entity)
-          ? scene.entityDatabase.get<Name>(entity).name
-          : "Entity #" + std::to_string(static_cast<uint32_t>(entity));
+  String name = scene.entityDatabase.has<Name>(entity)
+                    ? scene.entityDatabase.get<Name>(entity).name
+                    : "Entity #" + std::to_string(static_cast<u32>(entity));
 
   bool isLeaf = !scene.entityDatabase.has<Children>(entity);
 
@@ -162,7 +161,7 @@ uint32_t SceneHierarchyPanel::renderEntity(Entity entity, uint32_t index,
                            Theme::getColor(ThemeColor::Neutral200));
     }
 
-    ImGui::PushID(static_cast<int32_t>(entity));
+    ImGui::PushID(static_cast<i32>(entity));
     if (ImGui::TreeNodeEx(nodeName.c_str(), treeNodeFlags)) {
       open = !isLeaf;
     }

--- a/editor/src/quoll/editor/ui/SceneHierarchyPanel.h
+++ b/editor/src/quoll/editor/ui/SceneHierarchyPanel.h
@@ -42,8 +42,8 @@ private:
    * @param actionExecutor Action executor
    * @return Calculated index
    */
-  uint32_t renderEntity(Entity entity, uint32_t index, int flags,
-                        WorkspaceState &state, ActionExecutor &actionExecutor);
+  u32 renderEntity(Entity entity, u32 index, int flags, WorkspaceState &state,
+                   ActionExecutor &actionExecutor);
 
 private:
   Entity mRightClickedEntity = Entity::Null;

--- a/editor/src/quoll/editor/ui/ShortcutsManager.cpp
+++ b/editor/src/quoll/editor/ui/ShortcutsManager.cpp
@@ -10,7 +10,7 @@ void ShortcutsManager::add(Shortcut shortcut, ActionCreator *actionCreator) {
 
 void ShortcutsManager::process(int key, int mods,
                                ActionExecutor &actionExecutor) {
-  for (size_t i = 0; i < mShortcuts.size(); ++i) {
+  for (usize i = 0; i < mShortcuts.size(); ++i) {
     const auto &shortcut = mShortcuts.at(i);
 
     if (shortcut == Shortcut(key, mods)) {

--- a/editor/src/quoll/editor/ui/StyleStack.cpp
+++ b/editor/src/quoll/editor/ui/StyleStack.cpp
@@ -16,30 +16,30 @@ StyleStack::~StyleStack() {
     mPushedStyles = 0;
   }
 
-  for (uint32_t i = 0; i < mPushedFonts; ++i) {
+  for (u32 i = 0; i < mPushedFonts; ++i) {
     ImGui::PopFont();
   }
 }
 
-void StyleStack::pushColor(uint32_t colorIndex, const glm::vec4 &color) {
+void StyleStack::pushColor(u32 colorIndex, const glm::vec4 &color) {
   pushColor(colorIndex, ImVec4(color.x, color.y, color.z, color.w));
 }
 
-void StyleStack::pushColor(uint32_t colorIndex, const ImVec4 &color) {
+void StyleStack::pushColor(u32 colorIndex, const ImVec4 &color) {
   ImGui::PushStyleColor(static_cast<ImGuiCol>(colorIndex), color);
   mPushedColors++;
 }
 
-void StyleStack::pushStyle(uint32_t styleIndex, float value) {
+void StyleStack::pushStyle(u32 styleIndex, f32 value) {
   ImGui::PushStyleVar(static_cast<ImGuiStyleVar>(styleIndex), value);
   mPushedStyles++;
 }
 
-void StyleStack::pushStyle(uint32_t styleIndex, const glm::vec2 &value) {
+void StyleStack::pushStyle(u32 styleIndex, const glm::vec2 &value) {
   pushStyle(styleIndex, ImVec2(value.x, value.y));
 }
 
-void StyleStack::pushStyle(uint32_t styleIndex, const ImVec2 &value) {
+void StyleStack::pushStyle(u32 styleIndex, const ImVec2 &value) {
   ImGui::PushStyleVar(static_cast<ImGuiStyleVar>(styleIndex), value);
   mPushedStyles++;
 }

--- a/editor/src/quoll/editor/ui/StyleStack.h
+++ b/editor/src/quoll/editor/ui/StyleStack.h
@@ -33,7 +33,7 @@ public:
    * @param colorIndex Color index
    * @param color Color value
    */
-  void pushColor(uint32_t colorIndex, const glm::vec4 &color);
+  void pushColor(u32 colorIndex, const glm::vec4 &color);
 
   /**
    * @brief Push color to the stack
@@ -41,7 +41,7 @@ public:
    * @param colorIndex Color index
    * @param color Color value
    */
-  void pushColor(uint32_t colorIndex, const ImVec4 &color);
+  void pushColor(u32 colorIndex, const ImVec4 &color);
 
   /**
    * @brief Push style to the stack
@@ -49,7 +49,7 @@ public:
    * @param styleIndex Style index
    * @param value Style value
    */
-  void pushStyle(uint32_t styleIndex, float value);
+  void pushStyle(u32 styleIndex, f32 value);
 
   /**
    * @brief Push style to the stack
@@ -57,7 +57,7 @@ public:
    * @param styleIndex Style index
    * @param value Style value
    */
-  void pushStyle(uint32_t styleIndex, const glm::vec2 &value);
+  void pushStyle(u32 styleIndex, const glm::vec2 &value);
 
   /**
    * @brief Push style to the stack
@@ -65,7 +65,7 @@ public:
    * @param styleIndex Style index
    * @param value Style value
    */
-  void pushStyle(uint32_t styleIndex, const ImVec2 &value);
+  void pushStyle(u32 styleIndex, const ImVec2 &value);
 
   /**
    * @brief Push style to the stack
@@ -75,9 +75,9 @@ public:
   void pushFont(ImFont *font);
 
 private:
-  uint32_t mPushedColors = 0;
-  uint32_t mPushedStyles = 0;
-  uint32_t mPushedFonts = 0;
+  u32 mPushedColors = 0;
+  u32 mPushedStyles = 0;
+  u32 mPushedFonts = 0;
 };
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/ui/Theme.cpp
+++ b/editor/src/quoll/editor/ui/Theme.cpp
@@ -19,7 +19,7 @@ namespace quoll::editor {
  * @param value Srgb value
  * @return Linear value
  */
-static constexpr float SrgbToLinear(float value) {
+static constexpr f32 SrgbToLinear(f32 value) {
   if (value <= 0.0031308f) {
     return value / 12.92f;
   }
@@ -43,9 +43,9 @@ static ImVec4 SrgbToLinear(int r, int g, int b, int a = 255) {
           color.w};
 }
 
-static constexpr float FontSize = 18.0f;
+static constexpr f32 FontSize = 18.0f;
 
-static constexpr size_t NumFonts = 2;
+static constexpr usize NumFonts = 2;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static std::array<ImFont *, NumFonts> Fonts{};
@@ -180,7 +180,7 @@ static void addFonts() {
   Fonts.at(1) =
       io.Fonts->AddFontFromFileTTF(boldFontPath.string().c_str(), FontSize);
 
-  for (size_t i = 0; i < Fonts.size(); ++i) {
+  for (usize i = 0; i < Fonts.size(); ++i) {
     ImFontConfig config;
     config.MergeMode = true;
     config.GlyphMinAdvanceX = FontSize;

--- a/editor/src/quoll/editor/ui/Theme.h
+++ b/editor/src/quoll/editor/ui/Theme.h
@@ -48,7 +48,7 @@ struct ThemeStyles {
   /**
    * Child rounding
    */
-  float childRounding = 0.0f;
+  f32 childRounding = 0.0f;
 };
 
 /**

--- a/editor/src/quoll/editor/ui/Toolbar.h
+++ b/editor/src/quoll/editor/ui/Toolbar.h
@@ -28,7 +28,7 @@ public:
   /**
    * @brief Toolbar height
    */
-  static constexpr float Height = 60.0f;
+  static constexpr f32 Height = 60.0f;
 
 public:
   /**

--- a/editor/src/quoll/editor/ui/UIRoot.cpp
+++ b/editor/src/quoll/editor/ui/UIRoot.cpp
@@ -67,7 +67,7 @@ bool UIRoot::renderSceneView(WorkspaceContext &context,
     uiCanvasUpdater.setViewport(pos.x, pos.y, size.x, size.y);
 
     aspectRatioUpdater.setViewportSize(
-        {static_cast<uint32_t>(size.x), static_cast<uint32_t>(size.y)});
+        {static_cast<u32>(size.x), static_cast<u32>(size.y)});
 
     bool isItemClicked = ImGui::IsItemClicked(ImGuiMouseButton_Left);
 

--- a/editor/src/quoll/editor/ui/Widgets.cpp
+++ b/editor/src/quoll/editor/ui/Widgets.cpp
@@ -14,12 +14,12 @@ struct XBounds {
   /**
    * Start bound
    */
-  float start = 0.0f;
+  f32 start = 0.0f;
 
   /**
    * End bound
    */
-  float end = 0.0f;
+  f32 end = 0.0f;
 };
 
 /**
@@ -28,9 +28,9 @@ struct XBounds {
  * @param padding Horizontal padding
  * @return Horizontal bounds
  */
-static XBounds calculateSectionBoundsX(float padding) {
+static XBounds calculateSectionBoundsX(f32 padding) {
   auto *window = ImGui::GetCurrentWindow();
-  float windowStart = ImGui::GetWindowPos().x;
+  f32 windowStart = ImGui::GetWindowPos().x;
 
   return {windowStart + window->WindowPadding.x + padding,
           windowStart + ImGui::GetWindowWidth() - window->WindowPadding.x -
@@ -44,11 +44,11 @@ Section::Section(const char *title) {
   mPadding = ImGui::GetStyle().WindowPadding;
 
   auto *window = ImGui::GetCurrentWindow();
-  float windowWidth = ImGui::GetWindowWidth();
+  f32 windowWidth = ImGui::GetWindowWidth();
 
   auto boundsX = calculateSectionBoundsX(mPadding.x);
 
-  const float midPoint = boundsX.start + (boundsX.end - boundsX.start) / 1.2f;
+  const f32 midPoint = boundsX.start + (boundsX.end - boundsX.start) / 1.2f;
 
   ImGui::SetCursorPosY(ImGui::GetCursorPosY() + mPadding.y);
   ImGui::BeginGroup();
@@ -133,7 +133,7 @@ ContextMenu::~ContextMenu() {
   }
 }
 
-Table::Table(const char *id, uint32_t numColumns) {
+Table::Table(const char *id, u32 numColumns) {
   mExpanded = ImGui::BeginTable(id, static_cast<int>(numColumns),
                                 ImGuiTableFlags_Borders |
                                     ImGuiTableFlags_SizingStretchSame |
@@ -165,7 +165,7 @@ void Table::column(const glm::quat &value) {
   ImGui::Text("%.2f %.2f %.2f %.2f", value.x, value.y, value.z, value.w);
 }
 
-void Table::column(float value) {
+void Table::column(f32 value) {
   ImGui::TableNextColumn();
   ImGui::Text("%.2f", value);
 }
@@ -175,12 +175,12 @@ void Table::column(const String &value) {
   ImGui::Text("%s", value.c_str());
 }
 
-void Table::column(int32_t value) {
+void Table::column(i32 value) {
   ImGui::TableNextColumn();
   ImGui::Text("%d", value);
 }
 
-void Table::column(uint32_t value) {
+void Table::column(u32 value) {
   ImGui::TableNextColumn();
   ImGui::Text("%d", value);
 }
@@ -224,7 +224,7 @@ Input::Input(String label, glm::vec2 &value, bool autoChange) {
   }
 }
 
-Input::Input(String label, float &value, bool autoChange) {
+Input::Input(String label, f32 &value, bool autoChange) {
   if (autoChange) {
     auto temp = value;
 
@@ -239,9 +239,9 @@ Input::Input(String label, float &value, bool autoChange) {
   }
 }
 
-Input::Input(String label, uint32_t &value, bool autoChange) {
+Input::Input(String label, u32 &value, bool autoChange) {
   if (autoChange) {
-    uint32_t temp = value;
+    u32 temp = value;
 
     renderScalarInput(label, &temp, 1, ImGuiDataType_U32);
 
@@ -266,7 +266,7 @@ Input::Input(String label, String &value, bool autoChange) {
   }
 }
 
-void Input::renderScalarInput(String label, void *data, size_t size,
+void Input::renderScalarInput(String label, void *data, usize size,
                               ImGuiDataType dataType) {
   if (!label.empty()) {
     ImGui::Text("%s", label.c_str());

--- a/editor/src/quoll/editor/ui/Widgets.h
+++ b/editor/src/quoll/editor/ui/Widgets.h
@@ -208,7 +208,7 @@ public:
    * @param id Table ID
    * @param numColumns Number of columns
    */
-  Table(const char *id, uint32_t numColumns);
+  Table(const char *id, u32 numColumns);
 
   /**
    * @brief End table
@@ -261,7 +261,7 @@ public:
    *
    * @param value Scalar value
    */
-  void column(float value);
+  void column(f32 value);
 
   /**
    * @brief Render string column
@@ -275,14 +275,14 @@ public:
    *
    * @param value Integer value
    */
-  void column(int32_t value);
+  void column(i32 value);
 
   /**
    * @brief Render unsigned integer column
    *
    * @param value Unsigned integer value
    */
-  void column(uint32_t value);
+  void column(u32 value);
 
   /**
    * @brief Render image column
@@ -339,7 +339,7 @@ public:
    * @param value Input value
    * @param autoChange Auto change
    */
-  Input(String label, float &value, bool autoChange = true);
+  Input(String label, f32 &value, bool autoChange = true);
 
   /**
    * @brief Render uint scalar input
@@ -348,7 +348,7 @@ public:
    * @param value Input value
    * @param autoChange Auto change
    */
-  Input(String label, uint32_t &value, bool autoChange = true);
+  Input(String label, u32 &value, bool autoChange = true);
 
   /**
    * @brief Render text input
@@ -376,7 +376,7 @@ private:
    * @param size Number of data items
    * @param dataType Input data type
    */
-  void renderScalarInput(String label, void *data, size_t size,
+  void renderScalarInput(String label, void *data, usize size,
                          ImGuiDataType dataType);
 
   /**

--- a/editor/src/quoll/editor/workspace/WorkspaceIO.cpp
+++ b/editor/src/quoll/editor/workspace/WorkspaceIO.cpp
@@ -65,11 +65,11 @@ void WorkspaceIO::loadWorkspaceState(WorkspaceState &state,
     auto up = EditorCamera::DefaultUp;
 
     if (camera["near"] && camera["near"].IsScalar()) {
-      near = camera["near"].as<float>(near);
+      near = camera["near"].as<f32>(near);
     }
 
     if (camera["far"] && camera["far"].IsScalar()) {
-      far = camera["far"].as<float>(far);
+      far = camera["far"].as<f32>(far);
     }
 
     if (camera["sensorSize"] && camera["sensorSize"].IsSequence()) {
@@ -77,7 +77,7 @@ void WorkspaceIO::loadWorkspaceState(WorkspaceState &state,
     }
 
     if (camera["focalLength"] && camera["focalLength"].IsScalar()) {
-      focalLength = camera["sensorSize"].as<float>(focalLength);
+      focalLength = camera["sensorSize"].as<f32>(focalLength);
     }
 
     if (camera["eye"] && camera["eye"].IsSequence()) {
@@ -120,8 +120,8 @@ void WorkspaceIO::loadWorkspaceState(WorkspaceState &state,
       gridLinesShown = grid["gridLines"].as<bool>();
     }
 
-    state.grid.x = static_cast<uint32_t>(gridLinesShown);
-    state.grid.y = static_cast<uint32_t>(axisLinesShown);
+    state.grid.x = static_cast<u32>(gridLinesShown);
+    state.grid.y = static_cast<u32>(axisLinesShown);
   }
 }
 

--- a/editor/src/quoll/editor/workspace/WorkspaceLayoutRenderer.cpp
+++ b/editor/src/quoll/editor/workspace/WorkspaceLayoutRenderer.cpp
@@ -8,7 +8,7 @@
 namespace quoll::editor {
 
 bool WorkspaceLayoutRenderer::begin() {
-  const float WINDOW_AND_STATUS_BAR_HEIGHT = ImGui::GetFrameHeight() * 2.0f;
+  const f32 WINDOW_AND_STATUS_BAR_HEIGHT = ImGui::GetFrameHeight() * 2.0f;
 
   const auto &viewport = ImGui::GetMainViewport();
 
@@ -65,9 +65,9 @@ void WorkspaceLayoutRenderer::reset() {
   // Sidebar - Hierarchy (top) and Inspector (bottom)
   // Main - View (top) and Asset browser (bottom)
 
-  static constexpr float RatioSidebar = 1.0f / 6.0f;
-  static constexpr float RatioMainBottom = 1.0f / 4.0f;
-  static constexpr float RatioSideBottom = 2.0f / 3.0f;
+  static constexpr f32 RatioSidebar = 1.0f / 6.0f;
+  static constexpr f32 RatioMainBottom = 1.0f / 4.0f;
+  static constexpr f32 RatioSideBottom = 2.0f / 3.0f;
 
   ImGuiID mainId = -1;
   auto sidebarId = ImGui::DockBuilderSplitNode(dockspaceId, ImGuiDir_Right,

--- a/editor/tests/quoll/editor-tests/Testing.h
+++ b/editor/tests/quoll/editor-tests/Testing.h
@@ -24,7 +24,7 @@ void PrintTo(const qua<T, Q> &value, std::ostream *out) {
 namespace quoll {
 
 static void PrintTo(Entity entity, std::ostream *out) {
-  *out << static_cast<uint32_t>(entity);
+  *out << static_cast<u32>(entity);
 }
 
 } // namespace quoll

--- a/editor/tests/quoll/editor-tests/actions/ActionExecutor.test.cpp
+++ b/editor/tests/quoll/editor-tests/actions/ActionExecutor.test.cpp
@@ -166,7 +166,7 @@ TEST_F(ActionExecutorTest,
 
     EXPECT_EQ(node["entities"].size(), 1);
     auto id = state.scene.entityDatabase.get<quoll::Id>(entity).id;
-    EXPECT_EQ(node["entities"][0]["id"].as<uint64_t>(0), id);
+    EXPECT_EQ(node["entities"][0]["id"].as<u64>(0), id);
   }
 }
 
@@ -275,7 +275,7 @@ TEST_F(ActionExecutorTest,
   auto startingCamera = node["zones"][0]["startingCamera"];
   EXPECT_TRUE(startingCamera);
   EXPECT_TRUE(startingCamera.IsScalar());
-  EXPECT_EQ(startingCamera.as<uint32_t>(0), 15);
+  EXPECT_EQ(startingCamera.as<u32>(0), 15);
 }
 
 TEST_F(ActionExecutorTest,

--- a/editor/tests/quoll/editor-tests/actions/SceneWriter.test.cpp
+++ b/editor/tests/quoll/editor-tests/actions/SceneWriter.test.cpp
@@ -78,7 +78,7 @@ TEST_F(SceneWriterTest, SavingNewEntityAddsNewNodeInSceneFile) {
   writer.saveEntities({e1, e2});
 
   auto node = loadSceneFile();
-  EXPECT_EQ(node["entities"][1]["id"].as<uint64_t>(0),
+  EXPECT_EQ(node["entities"][1]["id"].as<u64>(0),
             scene.entityDatabase.get<quoll::Id>(e2).id);
   EXPECT_EQ(node["entities"][1]["name"].as<quoll::String>(""), "E2");
 }
@@ -95,10 +95,10 @@ TEST_F(SceneWriterTest, SavingExistingEntityUpdatesExistingNodeInSceneFile) {
 
     auto node = loadSceneFile();
     EXPECT_EQ(node["entities"].size(), 2);
-    EXPECT_EQ(node["entities"][0]["id"].as<uint64_t>(0), 155);
+    EXPECT_EQ(node["entities"][0]["id"].as<u64>(0), 155);
     EXPECT_EQ(node["entities"][0]["name"].as<quoll::String>(""), "E1");
 
-    EXPECT_EQ(node["entities"][1]["id"].as<uint64_t>(0),
+    EXPECT_EQ(node["entities"][1]["id"].as<u64>(0),
               scene.entityDatabase.get<quoll::Id>(e2).id);
     EXPECT_EQ(node["entities"][1]["name"].as<quoll::String>(""), "E2");
   }
@@ -110,10 +110,10 @@ TEST_F(SceneWriterTest, SavingExistingEntityUpdatesExistingNodeInSceneFile) {
 
     auto node = loadSceneFile();
     EXPECT_EQ(node["entities"].size(), 2);
-    EXPECT_EQ(node["entities"][0]["id"].as<uint32_t>(0), 155);
+    EXPECT_EQ(node["entities"][0]["id"].as<u32>(0), 155);
     EXPECT_EQ(node["entities"][0]["name"].as<quoll::String>(""), "E1 New");
 
-    EXPECT_EQ(node["entities"][1]["id"].as<uint64_t>(0),
+    EXPECT_EQ(node["entities"][1]["id"].as<u64>(0),
               scene.entityDatabase.get<quoll::Id>(e2).id);
     EXPECT_EQ(node["entities"][1]["name"].as<quoll::String>(""), "E2");
   }
@@ -139,9 +139,9 @@ TEST_F(SceneWriterTest, SavingEntitySavesParentBeforeEntityIfParentIsNotSaved) {
 
   auto node = loadSceneFile();
   EXPECT_EQ(node["entities"].size(), 3);
-  EXPECT_EQ(node["entities"][0]["id"].as<uint64_t>(0), parent2Id);
-  EXPECT_EQ(node["entities"][1]["id"].as<uint64_t>(0), parentId);
-  EXPECT_EQ(node["entities"][2]["id"].as<uint64_t>(0), entityId);
+  EXPECT_EQ(node["entities"][0]["id"].as<u64>(0), parent2Id);
+  EXPECT_EQ(node["entities"][1]["id"].as<u64>(0), parentId);
+  EXPECT_EQ(node["entities"][2]["id"].as<u64>(0), entityId);
 }
 
 TEST_F(SceneWriterTest, SavingEntityAndParentTogetherSavesTheParentOnce) {
@@ -164,9 +164,9 @@ TEST_F(SceneWriterTest, SavingEntityAndParentTogetherSavesTheParentOnce) {
 
   auto node = loadSceneFile();
   EXPECT_EQ(node["entities"].size(), 3);
-  EXPECT_EQ(node["entities"][0]["id"].as<uint64_t>(0), parent2Id);
-  EXPECT_EQ(node["entities"][1]["id"].as<uint64_t>(0), parentId);
-  EXPECT_EQ(node["entities"][2]["id"].as<uint64_t>(0), entityId);
+  EXPECT_EQ(node["entities"][0]["id"].as<u64>(0), parent2Id);
+  EXPECT_EQ(node["entities"][1]["id"].as<u64>(0), parentId);
+  EXPECT_EQ(node["entities"][2]["id"].as<u64>(0), entityId);
 }
 
 TEST_F(SceneWriterTest, DeletingEntityDeletesItFromSceneFile) {
@@ -179,13 +179,13 @@ TEST_F(SceneWriterTest, DeletingEntityDeletesItFromSceneFile) {
 
     auto node = loadSceneFile();
     EXPECT_EQ(node["entities"].size(), 3);
-    EXPECT_EQ(node["entities"][0]["id"].as<uint64_t>(1),
+    EXPECT_EQ(node["entities"][0]["id"].as<u64>(1),
               scene.entityDatabase.get<quoll::Id>(e1).id);
 
-    EXPECT_EQ(node["entities"][1]["id"].as<uint64_t>(2),
+    EXPECT_EQ(node["entities"][1]["id"].as<u64>(2),
               scene.entityDatabase.get<quoll::Id>(e2).id);
 
-    EXPECT_EQ(node["entities"][2]["id"].as<uint64_t>(3),
+    EXPECT_EQ(node["entities"][2]["id"].as<u64>(3),
               scene.entityDatabase.get<quoll::Id>(e3).id);
   }
 
@@ -194,7 +194,7 @@ TEST_F(SceneWriterTest, DeletingEntityDeletesItFromSceneFile) {
 
     auto node = loadSceneFile();
     EXPECT_EQ(node["entities"].size(), 1);
-    EXPECT_EQ(node["entities"][0]["id"].as<uint64_t>(0),
+    EXPECT_EQ(node["entities"][0]["id"].as<u64>(0),
               scene.entityDatabase.get<quoll::Id>(e2).id);
   }
 }
@@ -241,7 +241,7 @@ TEST_F(SceneWriterTest, DeletingStartingCameraSetsStartingCameraToNull) {
 
   {
     auto node = loadSceneFile();
-    EXPECT_EQ(node["zones"][0]["startingCamera"].as<uint64_t>(0),
+    EXPECT_EQ(node["zones"][0]["startingCamera"].as<u64>(0),
               scene.entityDatabase.get<quoll::Id>(e1).id);
   }
 
@@ -261,7 +261,7 @@ TEST_F(SceneWriterTest, DeletingEnvironmentSetsEnvironmentToNull) {
 
   {
     auto node = loadSceneFile();
-    EXPECT_EQ(node["zones"][0]["environment"].as<uint64_t>(0),
+    EXPECT_EQ(node["zones"][0]["environment"].as<u64>(0),
               scene.entityDatabase.get<quoll::Id>(e1).id);
   }
 
@@ -306,7 +306,7 @@ TEST_F(SceneWriterTest, SavesEntityAsStartingCameraIfItHasCameraComponent) {
   writer.saveScene();
 
   auto node = loadSceneFile();
-  EXPECT_EQ(node["zones"][0]["startingCamera"].as<uint64_t>(0), 15);
+  EXPECT_EQ(node["zones"][0]["startingCamera"].as<u64>(0), 15);
 }
 
 TEST_F(SceneWriterTest, DoesNotSaveEntityAsEnvironmentIfItDoesNotHaveId) {
@@ -326,5 +326,5 @@ TEST_F(SceneWriterTest, SetsEnvironmentToEntityIdIfEnvironmentEntityHasId) {
   auto node = loadSceneFile();
   auto envNode = node["zones"][0]["environment"];
 
-  EXPECT_EQ(envNode.as<uint64_t>(0), 10);
+  EXPECT_EQ(envNode.as<u64>(0), 10);
 }

--- a/editor/tests/quoll/editor-tests/asset/AssetManager.test.cpp
+++ b/editor/tests/quoll/editor-tests/asset/AssetManager.test.cpp
@@ -206,7 +206,7 @@ TEST_P(AssetTest, ImportModifiesTheNameAndCopiesSourceToAssetsIfDuplicate) {
               (AssetsPath / "valid-asset").replace_extension(fixtureExtension));
   }
 
-  for (uint32_t i = 1; i < 10; ++i) {
+  for (u32 i = 1; i < 10; ++i) {
     auto duplicateName = (AssetsPath / ("valid-asset-" + std::to_string(i)))
                              .replace_extension(fixtureExtension);
 
@@ -250,7 +250,7 @@ TEST_P(AssetTest, ImportCreatesMetaFileInSourceDirectory) {
   auto node = YAML::Load(stream);
   auto sourceAssetHash = node["sourceHash"].as<quoll::String>();
   auto uuid = node["uuid"]["root"].as<quoll::String>();
-  auto revision = node["revision"].as<uint32_t>();
+  auto revision = node["revision"].as<u32>();
   stream.close();
 
   EXPECT_EQ(uuid.size(), 32);

--- a/editor/tests/quoll/editor-tests/asset/gltf/GLTFImporterTestBase.h
+++ b/editor/tests/quoll/editor-tests/asset/gltf/GLTFImporterTestBase.h
@@ -29,9 +29,9 @@ template <class T> struct GLTFTestBufferData {
   int type;
   std::vector<T> data;
 
-  void fillWithZeros(size_t size) {
+  void fillWithZeros(usize size) {
     data.resize(size);
-    for (size_t i = 0; i < size; ++i) {
+    for (usize i = 0; i < size; ++i) {
       data.at(i) = T{0};
     }
   }
@@ -78,8 +78,8 @@ struct GLTFTestPrimitive {
                                            TINYGLTF_TYPE_VEC2};
   GLTFTestBufferData<glm::vec2> texCoords1{TINYGLTF_COMPONENT_TYPE_FLOAT,
                                            TINYGLTF_TYPE_VEC2};
-  GLTFTestBufferData<uint32_t> indices{TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT,
-                                       TINYGLTF_TYPE_SCALAR};
+  GLTFTestBufferData<u32> indices{TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT,
+                                  TINYGLTF_TYPE_SCALAR};
 };
 
 struct GLTFTestMesh {
@@ -109,7 +109,7 @@ struct GLTFTestScene {
 template <class T>
 int createBufferFromVector(tinygltf::Model &model,
                            GLTFTestBufferData<T> &bufferData) {
-  size_t size = sizeof(T) * bufferData.data.size();
+  usize size = sizeof(T) * bufferData.data.size();
 
   tinygltf::Buffer buffer;
   buffer.data.resize(size);
@@ -180,7 +180,7 @@ static tinygltf::Skin createSkin(tinygltf::Model &model, GLTFTestSkin &inSkin) {
 
 static tinygltf::Primitive createPrimitive(tinygltf::Model &model,
                                            GLTFTestPrimitive &inPrimitive) {
-  constexpr size_t FloatSize = sizeof(float);
+  constexpr usize FloatSize = sizeof(f32);
 
   tinygltf::Primitive primitive;
   primitive.mode = TINYGLTF_MODE_TRIANGLES;
@@ -213,23 +213,21 @@ static tinygltf::Primitive createPrimitive(tinygltf::Model &model,
   if (!inPrimitive.indices.data.empty()) {
     if (inPrimitive.indices.componentType ==
         TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT) {
-      GLTFTestBufferData<uint16_t> indices{
-          TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT, TINYGLTF_TYPE_SCALAR};
+      GLTFTestBufferData<u16> indices{TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT,
+                                      TINYGLTF_TYPE_SCALAR};
       indices.data.resize(inPrimitive.indices.data.size());
-      for (size_t i = 0; i < indices.data.size(); ++i) {
-        indices.data.at(i) =
-            static_cast<uint16_t>(inPrimitive.indices.data.at(i));
+      for (usize i = 0; i < indices.data.size(); ++i) {
+        indices.data.at(i) = static_cast<u16>(inPrimitive.indices.data.at(i));
       }
 
       primitive.indices = createBufferFromVector(model, indices);
     } else if (inPrimitive.indices.componentType ==
                TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE) {
-      GLTFTestBufferData<uint8_t> indices{TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE,
-                                          TINYGLTF_TYPE_SCALAR};
+      GLTFTestBufferData<u8> indices{TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE,
+                                     TINYGLTF_TYPE_SCALAR};
       indices.data.resize(inPrimitive.indices.data.size());
-      for (size_t i = 0; i < indices.data.size(); ++i) {
-        indices.data.at(i) =
-            static_cast<uint8_t>(inPrimitive.indices.data.at(i));
+      for (usize i = 0; i < indices.data.size(); ++i) {
+        indices.data.at(i) = static_cast<u8>(inPrimitive.indices.data.at(i));
       }
 
       primitive.indices = createBufferFromVector(model, indices);
@@ -262,7 +260,7 @@ static GLTFTestPrimitive createCubePrimitive() {
   primitive.texCoords1.data.resize(g.positions.size());
   primitive.indices.data.resize(g.indices.size());
 
-  for (size_t i = 0; i < g.positions.size(); ++i) {
+  for (usize i = 0; i < g.positions.size(); ++i) {
     primitive.positions.data.at(i) = g.positions.at(i);
     primitive.normals.data.at(i) = g.normals.at(i);
     primitive.tangents.data.at(i) = g.tangents.at(i);
@@ -270,7 +268,7 @@ static GLTFTestPrimitive createCubePrimitive() {
     primitive.texCoords1.data.at(i) = g.texCoords1.at(i);
   }
 
-  for (size_t i = 0; i < g.indices.size(); ++i) {
+  for (usize i = 0; i < g.indices.size(); ++i) {
     primitive.indices.data.at(i) = g.indices.at(i);
   }
 
@@ -278,7 +276,7 @@ static GLTFTestPrimitive createCubePrimitive() {
 }
 
 static tinygltf::Mesh createMesh(tinygltf::Model &model, GLTFTestMesh &inMesh) {
-  constexpr size_t FloatSize = sizeof(float);
+  constexpr usize FloatSize = sizeof(f32);
 
   tinygltf::Mesh mesh;
 

--- a/editor/tests/quoll/editor-tests/asset/gltf/MeshStep.test.cpp
+++ b/editor/tests/quoll/editor-tests/asset/gltf/MeshStep.test.cpp
@@ -19,7 +19,7 @@ struct AttributeTestFns {
 
   TestFn<glm::vec2> testTexCoord1 = [](auto t1, auto t2) { EXPECT_EQ(t1, t2); };
 
-  TestFn<uint32_t> testIndex = [](auto t1, auto t2) { EXPECT_EQ(t1, t2); };
+  TestFn<u32> testIndex = [](auto t1, auto t2) { EXPECT_EQ(t1, t2); };
 };
 
 class MeshAttributeTestBase : public GLTFImporterTestBase {
@@ -38,7 +38,7 @@ public:
 
     for (auto type : AllTypes) {
       bool found = false;
-      for (size_t i = 0; i < validTypes.size() && !found; ++i) {
+      for (usize i = 0; i < validTypes.size() && !found; ++i) {
         found = validTypes.at(i) == type;
       }
 
@@ -79,7 +79,7 @@ public:
 
     for (auto type : AllComponentTypes) {
       bool found = false;
-      for (size_t i = 0; i < validTypes.size() && !found; ++i) {
+      for (usize i = 0; i < validTypes.size() && !found; ++i) {
         found = validTypes.at(i) == type;
       }
 
@@ -130,7 +130,7 @@ public:
         quoll::MeshAssetHandle{1});
 
     EXPECT_EQ(meshAsset.data.geometries.size(), gltfMesh.primitives.size());
-    for (size_t gi = 0; gi < meshAsset.data.geometries.size(); ++gi) {
+    for (usize gi = 0; gi < meshAsset.data.geometries.size(); ++gi) {
       const auto &g = meshAsset.data.geometries.at(gi);
       auto &p = gltfMesh.primitives.at(gi);
 
@@ -159,7 +159,7 @@ public:
         p.indices.data.resize(g.indices.size());
       }
 
-      for (size_t i = 0; i < g.positions.size(); ++i) {
+      for (usize i = 0; i < g.positions.size(); ++i) {
         fns.testPosition(g.positions.at(i), p.positions.data.at(i));
         fns.testNormal(g.normals.at(i), p.normals.data.at(i));
         fns.testTangent(g.tangents.at(i), p.tangents.data.at(i));
@@ -168,7 +168,7 @@ public:
       }
 
       EXPECT_EQ(g.indices.size(), p.indices.data.size());
-      for (size_t i = 0; i < g.indices.size(); ++i) {
+      for (usize i = 0; i < g.indices.size(); ++i) {
         fns.testIndex(g.indices.at(i), p.indices.data.at(i));
       }
     }
@@ -258,7 +258,7 @@ TEST_F(MeshNormalAttributeTest,
 
 class MeshTexCoordAttributeTest : public MeshAttributeTestBase {
 public:
-  AttributeTestFns getInvalidTest(uint32_t index) {
+  AttributeTestFns getInvalidTest(u32 index) {
     AttributeTestFns fns{};
 
     if (index == 0) {
@@ -390,7 +390,7 @@ TEST_F(MeshTangentAttributeTest,
 class MeshIndexAttributeTest : public MeshAttributeTestBase {
 public:
   AttributeTestFns getInvalidTest() {
-    static constexpr uint32_t NumVertices = 24u;
+    static constexpr u32 NumVertices = 24u;
 
     AttributeTestFns fns{};
     fns.testIndex = [](auto n1, auto n2) { EXPECT_LT(n1, NumVertices); };

--- a/editor/tests/quoll/editor-tests/asset/gltf/SkeletonStep.test.cpp
+++ b/editor/tests/quoll/editor-tests/asset/gltf/SkeletonStep.test.cpp
@@ -8,13 +8,13 @@
 
 class GLTFImporterSkeletonTest : public GLTFImporterTestBase {
 public:
-  void createNodes(GLTFTestScene &scene, size_t nodeIndex, int currentLevel,
+  void createNodes(GLTFTestScene &scene, usize nodeIndex, int currentLevel,
                    int maxLevel) {
     if (currentLevel >= maxLevel)
       return;
 
     auto scale = glm::vec3{2.0f};
-    auto position = glm::vec3(static_cast<float>(currentLevel));
+    auto position = glm::vec3(static_cast<f32>(currentLevel));
 
     scene.nodes.push_back(GLTFTestNode{position, scale});
     scene.nodes.at(nodeIndex).children.push_back(
@@ -30,13 +30,13 @@ public:
 
   GLTFTestSkin &createSimpleSkin(GLTFTestScene &scene) {
     scene.nodes.push_back({glm::vec3{0.0f}, glm::vec3{1.0f}});
-    size_t startIndex = scene.nodes.size() - 1;
+    usize startIndex = scene.nodes.size() - 1;
 
     createNodes(scene, scene.nodes.size() - 1, 0, 2);
 
     GLTFTestSkin skin;
     skin.inverseBindMatrices.data.resize(7);
-    for (size_t i = startIndex; i < startIndex + 7; ++i) {
+    for (usize i = startIndex; i < startIndex + 7; ++i) {
       skin.joints.push_back(static_cast<int>(i));
     }
     scene.skins.push_back(skin);
@@ -178,7 +178,7 @@ TEST_F(GLTFImporterSkeletonTest, CreatesSkeletonWithJoints) {
   auto &skeleton = assetCache.getRegistry().getSkeletons().getAsset(
       quoll::SkeletonAssetHandle{1});
 
-  for (size_t i = 0; i < skeleton.data.jointLocalPositions.size(); ++i) {
+  for (usize i = 0; i < skeleton.data.jointLocalPositions.size(); ++i) {
     auto &node = scene.nodes.at(skin.joints.at(i));
 
     auto &position = skeleton.data.jointLocalPositions.at(i);

--- a/engine/rhi/core/include/quoll/rhi/AccessFlags.h
+++ b/engine/rhi/core/include/quoll/rhi/AccessFlags.h
@@ -2,7 +2,7 @@
 
 namespace quoll::rhi {
 
-enum class Access : uint64_t {
+enum class Access : u64 {
   None = 0,
   IndirectCommandRead = 0x00000001ULL,
   IndexRead = 0x00000002ULL,

--- a/engine/rhi/core/include/quoll/rhi/BlitRegion.h
+++ b/engine/rhi/core/include/quoll/rhi/BlitRegion.h
@@ -9,17 +9,17 @@ struct BlitRegion {
   /**
    * Source mip level
    */
-  uint32_t srcMipLevel = 0;
+  u32 srcMipLevel = 0;
 
   /**
    * Source array layer start
    */
-  uint32_t srcBaseArrayLayer = 0;
+  u32 srcBaseArrayLayer = 0;
 
   /**
    * Source array layer count
    */
-  uint32_t srcLayerCount = 0;
+  u32 srcLayerCount = 0;
 
   /**
    * Source offsets
@@ -29,17 +29,17 @@ struct BlitRegion {
   /**
    * Destination mip level
    */
-  uint32_t dstMipLevel = 0;
+  u32 dstMipLevel = 0;
 
   /**
    * Destination array layer start
    */
-  uint32_t dstBaseArrayLayer = 0;
+  u32 dstBaseArrayLayer = 0;
 
   /**
    * Destination array layer count
    */
-  uint32_t dstLayerCount = 0;
+  u32 dstLayerCount = 0;
 
   /**
    * Destination offsets

--- a/engine/rhi/core/include/quoll/rhi/Buffer.h
+++ b/engine/rhi/core/include/quoll/rhi/Buffer.h
@@ -44,7 +44,7 @@ public:
    * @param data New data
    * @param size Size to copy
    */
-  void update(const void *data, size_t size);
+  void update(const void *data, usize size);
 
   /**
    * @brief Resize buffer
@@ -55,7 +55,7 @@ public:
    *
    * @param size New size
    */
-  void resize(size_t size);
+  void resize(usize size);
 
   /**
    * @brief Get device address

--- a/engine/rhi/core/include/quoll/rhi/BufferDescription.h
+++ b/engine/rhi/core/include/quoll/rhi/BufferDescription.h
@@ -15,7 +15,7 @@ enum class BufferUsage {
 
 EnableBitwiseEnum(BufferUsage);
 
-enum class BufferAllocationUsage : uint8_t {
+enum class BufferAllocationUsage : u8 {
   None = 0,
   HostWrite = 1 << 0,
   HostRead = 1 << 1
@@ -35,7 +35,7 @@ struct BufferDescription {
   /**
    * Buffer size
    */
-  size_t size = 0;
+  usize size = 0;
 
   /**
    * Buffer data

--- a/engine/rhi/core/include/quoll/rhi/CopyRegion.h
+++ b/engine/rhi/core/include/quoll/rhi/CopyRegion.h
@@ -9,22 +9,22 @@ struct CopyRegion {
   /**
    * Offset of buffer during copy
    */
-  uint32_t bufferOffset = 0;
+  u32 bufferOffset = 0;
 
   /**
    * Image array layer start
    */
-  uint32_t imageBaseArrayLayer = 0;
+  u32 imageBaseArrayLayer = 0;
 
   /**
    * Image array layer count
    */
-  uint32_t imageLayerCount = 1;
+  u32 imageLayerCount = 1;
 
   /**
    * Image mip level
    */
-  uint32_t imageLevel = 0;
+  u32 imageLevel = 0;
 
   /**
    * Image offset

--- a/engine/rhi/core/include/quoll/rhi/Descriptor.h
+++ b/engine/rhi/core/include/quoll/rhi/Descriptor.h
@@ -33,8 +33,8 @@ public:
    * @param start Starting index
    * @return Current object
    */
-  Descriptor &write(uint32_t binding, std::span<TextureHandle> textures,
-                    DescriptorType type, uint32_t start = 0);
+  Descriptor &write(u32 binding, std::span<TextureHandle> textures,
+                    DescriptorType type, u32 start = 0);
 
   /**
    * @brief Bind sampler descriptors
@@ -44,8 +44,8 @@ public:
    * @param start Starting index
    * @return Current object
    */
-  Descriptor &write(uint32_t binding, std::span<SamplerHandle> samplers,
-                    uint32_t start = 0);
+  Descriptor &write(u32 binding, std::span<SamplerHandle> samplers,
+                    u32 start = 0);
 
   /**
    * @brief Bind buffer descriptors
@@ -56,8 +56,8 @@ public:
    * @param start Starting index
    * @return Current object
    */
-  Descriptor &write(uint32_t binding, std::span<BufferHandle> buffers,
-                    DescriptorType type, uint32_t start = 0);
+  Descriptor &write(u32 binding, std::span<BufferHandle> buffers,
+                    DescriptorType type, u32 start = 0);
 
   /**
    * @brief Bind buffer descriptors
@@ -68,9 +68,8 @@ public:
    * @param start Starting index
    * @return Current object
    */
-  Descriptor &write(uint32_t binding,
-                    std::span<DescriptorBufferInfo> bufferInfos,
-                    DescriptorType type, uint32_t start = 0);
+  Descriptor &write(u32 binding, std::span<DescriptorBufferInfo> bufferInfos,
+                    DescriptorType type, u32 start = 0);
 
   /**
    * @brief Get descriptor handle

--- a/engine/rhi/core/include/quoll/rhi/DescriptorLayoutDescription.h
+++ b/engine/rhi/core/include/quoll/rhi/DescriptorLayoutDescription.h
@@ -24,7 +24,7 @@ struct DescriptorLayoutBindingDescription {
   /**
    * Binding number
    */
-  uint32_t binding = 0;
+  u32 binding = 0;
 
   /**
    * Descriptor type
@@ -34,7 +34,7 @@ struct DescriptorLayoutBindingDescription {
   /**
    * Number of descriptors
    */
-  uint32_t descriptorCount = 0;
+  u32 descriptorCount = 0;
 
   /**
    * Shader stage

--- a/engine/rhi/core/include/quoll/rhi/DeviceAddress.h
+++ b/engine/rhi/core/include/quoll/rhi/DeviceAddress.h
@@ -2,6 +2,6 @@
 
 namespace quoll::rhi {
 
-enum class DeviceAddress : uint64_t { Null = 0 };
+enum class DeviceAddress : u64 { Null = 0 };
 
 }

--- a/engine/rhi/core/include/quoll/rhi/DeviceStats.h
+++ b/engine/rhi/core/include/quoll/rhi/DeviceStats.h
@@ -24,7 +24,7 @@ public:
    *
    * @param primitiveCount Number of primitives
    */
-  void addDrawCall(size_t primitiveCount);
+  void addDrawCall(usize primitiveCount);
 
   /**
    * @brief Resets calls
@@ -41,23 +41,21 @@ public:
    *
    * @return Number of draw calls
    */
-  inline uint32_t getDrawCallsCount() const { return mDrawCallsCount; }
+  inline u32 getDrawCallsCount() const { return mDrawCallsCount; }
 
   /**
    * @brief Get number of drawn primitives
    *
    * @return Number of drawn primitives
    */
-  inline size_t getDrawnPrimitivesCount() const {
-    return mDrawnPrimitivesCount;
-  }
+  inline usize getDrawnPrimitivesCount() const { return mDrawnPrimitivesCount; }
 
   /**
    * @brief Get command calls count
    *
    * @return Number of command calls
    */
-  inline uint32_t getCommandCallsCount() const { return mCommandCallsCount; }
+  inline u32 getCommandCallsCount() const { return mCommandCallsCount; }
 
   /**
    * @brief Get resource metrics
@@ -69,9 +67,9 @@ public:
   }
 
 private:
-  uint32_t mDrawCallsCount = 0;
-  size_t mDrawnPrimitivesCount = 0;
-  uint32_t mCommandCallsCount = 0;
+  u32 mDrawCallsCount = 0;
+  usize mDrawnPrimitivesCount = 0;
+  u32 mCommandCallsCount = 0;
 
   NativeResourceMetrics *mResourceMetrics;
 };

--- a/engine/rhi/core/include/quoll/rhi/FramebufferDescription.h
+++ b/engine/rhi/core/include/quoll/rhi/FramebufferDescription.h
@@ -16,17 +16,17 @@ struct FramebufferDescription {
   /**
    * Width
    */
-  uint32_t width = 0;
+  u32 width = 0;
 
   /**
    * Height
    */
-  uint32_t height = 0;
+  u32 height = 0;
 
   /**
    * Number of layers
    */
-  uint32_t layers = 0;
+  u32 layers = 0;
 
   /**
    * Texture attachments

--- a/engine/rhi/core/include/quoll/rhi/NativeBuffer.h
+++ b/engine/rhi/core/include/quoll/rhi/NativeBuffer.h
@@ -35,7 +35,7 @@ public:
    *
    * @param size New size
    */
-  virtual void resize(size_t size) = 0;
+  virtual void resize(usize size) = 0;
 
   /**
    * @brief Get buffer device address

--- a/engine/rhi/core/include/quoll/rhi/NativeDescriptor.h
+++ b/engine/rhi/core/include/quoll/rhi/NativeDescriptor.h
@@ -12,12 +12,12 @@ struct DescriptorBufferInfo {
   /**
    * Buffer offset
    */
-  uint32_t offset = 0;
+  u32 offset = 0;
 
   /**
    * Buffer range
    */
-  uint32_t range = 0;
+  u32 range = 0;
 
   /**
    * Buffer
@@ -38,8 +38,8 @@ public:
    * @param type Descriptor type
    * @param start Starting index
    */
-  virtual void write(uint32_t binding, std::span<TextureHandle> textures,
-                     DescriptorType type, uint32_t start) = 0;
+  virtual void write(u32 binding, std::span<TextureHandle> textures,
+                     DescriptorType type, u32 start) = 0;
 
   /**
    * @brief Bind sampler descriptors
@@ -48,8 +48,8 @@ public:
    * @param samplers Samplers
    * @param start Starting index
    */
-  virtual void write(uint32_t binding, std::span<SamplerHandle> samplers,
-                     uint32_t start) = 0;
+  virtual void write(u32 binding, std::span<SamplerHandle> samplers,
+                     u32 start) = 0;
 
   /**
    * @brief Bind buffer descriptors
@@ -59,8 +59,8 @@ public:
    * @param type Descriptor type
    * @param start Starting index
    */
-  virtual void write(uint32_t binding, std::span<BufferHandle> buffers,
-                     DescriptorType type, uint32_t start) = 0;
+  virtual void write(u32 binding, std::span<BufferHandle> buffers,
+                     DescriptorType type, u32 start) = 0;
 
   /**
    * @brief Bind buffer descriptors
@@ -70,9 +70,8 @@ public:
    * @param type Descriptor type
    * @param start Starting index
    */
-  virtual void write(uint32_t binding,
-                     std::span<DescriptorBufferInfo> bufferInfos,
-                     DescriptorType type, uint32_t start) = 0;
+  virtual void write(u32 binding, std::span<DescriptorBufferInfo> bufferInfos,
+                     DescriptorType type, u32 start) = 0;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/core/include/quoll/rhi/NativeRenderCommandListInterface.h
+++ b/engine/rhi/core/include/quoll/rhi/NativeRenderCommandListInterface.h
@@ -68,9 +68,9 @@ public:
    * @param descriptor Descriptor
    * @param dynamicOffsets Dynamic offsets
    */
-  virtual void bindDescriptor(PipelineHandle pipeline, uint32_t firstSet,
+  virtual void bindDescriptor(PipelineHandle pipeline, u32 firstSet,
                               const Descriptor &descriptor,
-                              std::span<uint32_t> dynamicOffsets) = 0;
+                              std::span<u32> dynamicOffsets) = 0;
 
   /**
    * @brief Bind vertex buffers
@@ -79,7 +79,7 @@ public:
    * @param offsets Vertex buffer binding offsets
    */
   virtual void bindVertexBuffers(const std::span<const BufferHandle> buffers,
-                                 const std::span<const uint64_t> offsets) = 0;
+                                 const std::span<const u64> offsets) = 0;
 
   /**
    * @brief Bind index buffer
@@ -99,7 +99,7 @@ public:
    * @param data Data
    */
   virtual void pushConstants(PipelineHandle pipeline, ShaderStage shaderStage,
-                             uint32_t offset, uint32_t size, void *data) = 0;
+                             u32 offset, u32 size, void *data) = 0;
 
   /**
    * @brief Draw
@@ -109,8 +109,8 @@ public:
    * @param instanceCount Instance count
    * @param firstInstance First instance
    */
-  virtual void draw(uint32_t vertexCount, uint32_t firstVertex,
-                    uint32_t instanceCount, uint32_t firstInstance) = 0;
+  virtual void draw(u32 vertexCount, u32 firstVertex, u32 instanceCount,
+                    u32 firstInstance) = 0;
 
   /**
    * @brief Draw indexed
@@ -121,9 +121,8 @@ public:
    * @param instanceCount Instance count
    * @param firstInstance First instance
    */
-  virtual void drawIndexed(uint32_t indexCount, uint32_t firstIndex,
-                           int32_t vertexOffset, uint32_t instanceCount,
-                           uint32_t firstInstance) = 0;
+  virtual void drawIndexed(u32 indexCount, u32 firstIndex, i32 vertexOffset,
+                           u32 instanceCount, u32 firstInstance) = 0;
 
   /**
    * @brief Dispatch compute work
@@ -132,8 +131,7 @@ public:
    * @param groupCountY Number of groups to dispatch in Y direction
    * @param groupCountZ Number of groups to dispatch in Z direction
    */
-  virtual void dispatch(uint32_t groupCountX, uint32_t groupCountY,
-                        uint32_t groupCountZ) = 0;
+  virtual void dispatch(u32 groupCountX, u32 groupCountY, u32 groupCountZ) = 0;
 
   /**
    * @brief Set viewport

--- a/engine/rhi/core/include/quoll/rhi/NativeResourceMetrics.h
+++ b/engine/rhi/core/include/quoll/rhi/NativeResourceMetrics.h
@@ -12,28 +12,28 @@ public:
    *
    * @return Total buffer size
    */
-  virtual size_t getTotalBufferSize() const = 0;
+  virtual usize getTotalBufferSize() const = 0;
 
   /**
    * @brief Get number of buffers
    *
    * @return Number of buffers
    */
-  virtual size_t getBuffersCount() const = 0;
+  virtual usize getBuffersCount() const = 0;
 
   /**
    * @brief Get number of textures
    *
    * @return Number of textures
    */
-  virtual size_t getTexturesCount() const = 0;
+  virtual usize getTexturesCount() const = 0;
 
   /**
    * @brief Get number of descriptors
    *
    * @return Number of descriptors
    */
-  virtual size_t getDescriptorsCount() const = 0;
+  virtual usize getDescriptorsCount() const = 0;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/core/include/quoll/rhi/PhysicalDeviceInformation.h
+++ b/engine/rhi/core/include/quoll/rhi/PhysicalDeviceInformation.h
@@ -30,22 +30,22 @@ struct PhysicalDeviceProperties {
   /**
    * API version
    */
-  uint32_t apiVersion;
+  u32 apiVersion;
 
   /**
    * Driver version
    */
-  uint32_t driverVersion;
+  u32 driverVersion;
 
   /**
    * Vendor ID
    */
-  uint32_t vendorId;
+  u32 vendorId;
 
   /**
    * Device ID
    */
-  uint32_t deviceId;
+  u32 deviceId;
 };
 
 /**

--- a/engine/rhi/core/include/quoll/rhi/PhysicalDeviceLimits.h
+++ b/engine/rhi/core/include/quoll/rhi/PhysicalDeviceLimits.h
@@ -9,219 +9,219 @@ struct PhysicalDeviceLimits {
   /**
    * Maximum 1D image dimensions
    */
-  uint32_t maxImageDimension1D;
+  u32 maxImageDimension1D;
 
   /**
    * Maximum 2D image dimensions
    */
-  uint32_t maxImageDimension2D;
+  u32 maxImageDimension2D;
 
   /**
    * Maximum 3D image dimensions
    */
-  uint32_t maxImageDimension3D;
+  u32 maxImageDimension3D;
 
   /**
    * Maximum cube image dimensions
    */
-  uint32_t maxImageDimensionCube;
+  u32 maxImageDimensionCube;
 
   /**
    * Maximum image array layers
    */
-  uint32_t maxImageArrayLayers;
+  u32 maxImageArrayLayers;
 
   /**
    * Maximum texel buffer elements
    */
-  uint32_t maxTexelBufferElements;
+  u32 maxTexelBufferElements;
 
   /**
    * Maximum uniform buffer range
    */
-  uint32_t maxUniformBufferRange;
+  u32 maxUniformBufferRange;
 
   /**
    * Maximum storage buffer range
    */
 
-  uint32_t maxStorageBufferRange;
+  u32 maxStorageBufferRange;
 
   /**
    * Maximum push constants size
    */
 
-  uint32_t maxPushConstantsSize;
+  u32 maxPushConstantsSize;
 
   /**
    * Maximum memory allocation count
    */
-  uint32_t maxMemoryAllocationCount;
+  u32 maxMemoryAllocationCount;
 
   /**
    * Maximum sampler allocation count
    */
-  uint32_t maxSamplerAllocationCount;
+  u32 maxSamplerAllocationCount;
 
   /**
    * Buffer image granularity
    */
-  uint64_t bufferImageGranularity;
+  u64 bufferImageGranularity;
 
   /**
    * Sparse address space size
    */
-  uint64_t sparseAddressSpaceSize;
+  u64 sparseAddressSpaceSize;
 
   /**
    * Maximum bound descriptor sets
    */
-  uint32_t maxBoundDescriptorSets;
+  u32 maxBoundDescriptorSets;
 
   /**
    * Maximum number of samplers that are
    * accessible in a single shader stage
    */
-  uint32_t maxPerStageDescriptorSamplers;
+  u32 maxPerStageDescriptorSamplers;
 
   /**
    * Maximum number of uniform buffers that are
    * accessible in a single shader stage
    */
-  uint32_t maxPerStageDescriptorUniformBuffers;
+  u32 maxPerStageDescriptorUniformBuffers;
 
   /**
    * Maximum number of storage buffers that are
    * accessible in a single shader stage
    */
-  uint32_t maxPerStageDescriptorStorageBuffers;
+  u32 maxPerStageDescriptorStorageBuffers;
 
   /**
    * Maximum number of sampler images that are
    * accessible in a single shader stage
    */
-  uint32_t maxPerStageDescriptorSampledImages;
+  u32 maxPerStageDescriptorSampledImages;
 
   /**
    * Maximum number of storage images that are
    * accessible in a single shader stage
    */
-  uint32_t maxPerStageDescriptorStorageImages;
+  u32 maxPerStageDescriptorStorageImages;
 
   /**
    * Maximum number of input attachments that are
    * accessible in a single shader stage
    */
-  uint32_t maxPerStageDescriptorInputAttachments;
+  u32 maxPerStageDescriptorInputAttachments;
 
   /**
    * Maximum number of resources that are
    * accessible in a single shader stage
    */
-  uint32_t maxPerStageResources;
+  u32 maxPerStageResources;
 
   /**
    * Maximum number of available
    * sampler descriptor sets
    */
-  uint32_t maxDescriptorSetSamplers;
+  u32 maxDescriptorSetSamplers;
 
   /**
    * Maximum number of available
    * uniform buffer descriptor sets
    */
-  uint32_t maxDescriptorSetUniformBuffers;
+  u32 maxDescriptorSetUniformBuffers;
 
   /**
    * Maximum number of available dynamic
    * uniform buffer descriptor sets
    */
-  uint32_t maxDescriptorSetUniformBuffersDynamic;
+  u32 maxDescriptorSetUniformBuffersDynamic;
 
   /**
    * Maximum number of available
    * storage buffer descriptor sets
    */
-  uint32_t maxDescriptorSetStorageBuffers;
+  u32 maxDescriptorSetStorageBuffers;
 
   /**
    * Maximum number of available dynamic
    * storage buffer descriptor sets
    */
-  uint32_t maxDescriptorSetStorageBuffersDynamic;
+  u32 maxDescriptorSetStorageBuffersDynamic;
 
   /**
    * Maximum number of available
    * sampled image descriptor sets
    */
-  uint32_t maxDescriptorSetSampledImages;
+  u32 maxDescriptorSetSampledImages;
 
   /**
    * Maximum number of available
    * storage image descriptor sets
    */
-  uint32_t maxDescriptorSetStorageImages;
+  u32 maxDescriptorSetStorageImages;
 
   /**
    * Maximum number of available
    * input attachment descriptor sets
    */
-  uint32_t maxDescriptorSetInputAttachments;
+  u32 maxDescriptorSetInputAttachments;
 
   /**
    * Maximum number of vertex
    * input attributes
    */
-  uint32_t maxVertexInputAttributes;
+  u32 maxVertexInputAttributes;
 
   /**
    * Maximum number of vertex
    * input bindings
    */
-  uint32_t maxVertexInputBindings;
+  u32 maxVertexInputBindings;
 
   /**
    * Maximum vertex input attribute offset
    */
-  uint32_t maxVertexInputAttributeOffset;
+  u32 maxVertexInputAttributeOffset;
 
   /**
    * Maximum vertex input binding stride
    */
-  uint32_t maxVertexInputBindingStride;
+  u32 maxVertexInputBindingStride;
 
   /**
    * Maximum number of vertex output components
    */
-  uint32_t maxVertexOutputComponents;
+  u32 maxVertexOutputComponents;
 
   /**
    * Maximum number of fragment input components
    */
-  uint32_t maxFragmentInputComponents;
+  u32 maxFragmentInputComponents;
 
   /**
    * Maximum number of fragment output attachments
    */
-  uint32_t maxFragmentOutputAttachments;
+  u32 maxFragmentOutputAttachments;
 
   /**
    * Maximum number of fragment dual source
    * attachments
    */
-  uint32_t maxFragmentDualSrcAttachments;
+  u32 maxFragmentDualSrcAttachments;
 
   /**
    * Maximum number of output resources
    * can be used in fragment shader stage
    */
-  uint32_t maxFragmentCombinedOutputResources;
+  u32 maxFragmentCombinedOutputResources;
 
   /**
    * Maximum shared memory size available
    * in compute shader stages
    */
-  uint32_t maxComputeSharedMemorySize;
+  u32 maxComputeSharedMemorySize;
 
   /**
    * Maximum workgroup count allowed
@@ -232,7 +232,7 @@ struct PhysicalDeviceLimits {
   /**
    * Maximum number of workgroup invocations
    */
-  uint32_t maxComputeWorkGroupInvocations;
+  u32 maxComputeWorkGroupInvocations;
 
   /**
    * Maximum workgroup size allowed
@@ -243,42 +243,42 @@ struct PhysicalDeviceLimits {
   /**
    * Subpixel precision bits
    */
-  uint32_t subPixelPrecisionBits;
+  u32 subPixelPrecisionBits;
 
   /**
    * Subtexel precision bits
    */
-  uint32_t subTexelPrecisionBits;
+  u32 subTexelPrecisionBits;
 
   /**
    * Mip map precision bits
    */
-  uint32_t mipmapPrecisionBits;
+  u32 mipmapPrecisionBits;
 
   /**
    * Maximum draw indexed index value
    */
-  uint32_t maxDrawIndexedIndexValue;
+  u32 maxDrawIndexedIndexValue;
 
   /**
    * Maximum draw indirect count
    */
-  uint32_t maxDrawIndirectCount;
+  u32 maxDrawIndirectCount;
 
   /**
    * Maximum sampler LOD bias
    */
-  float maxSamplerLodBias;
+  f32 maxSamplerLodBias;
 
   /**
    * Maximum sampler anisotropy
    */
-  float maxSamplerAnisotropy;
+  f32 maxSamplerAnisotropy;
 
   /**
    * Maximum number of viewpoer
    */
-  uint32_t maxViewports;
+  u32 maxViewports;
 
   /**
    * Maximum viewport dimension
@@ -293,127 +293,127 @@ struct PhysicalDeviceLimits {
   /**
    * Viewport subpixel bits
    */
-  uint32_t viewportSubPixelBits;
+  u32 viewportSubPixelBits;
 
   /**
    * Minimum memory map alignment
    */
-  size_t minMemoryMapAlignment;
+  usize minMemoryMapAlignment;
 
   /**
    * Minimum texel buffer offset alignment
    */
-  uint64_t minTexelBufferOffsetAlignment;
+  u64 minTexelBufferOffsetAlignment;
 
   /**
    * Minimum uniform buffer offset alignment
    */
-  uint64_t minUniformBufferOffsetAlignment;
+  u64 minUniformBufferOffsetAlignment;
 
   /**
    * Minimum storage buffer offset alignment
    */
-  uint64_t minStorageBufferOffsetAlignment;
+  u64 minStorageBufferOffsetAlignment;
 
   /**
    * Minimum texel offset
    */
-  int32_t minTexelOffset;
+  i32 minTexelOffset;
 
   /**
    * Maximum texel offset
    */
-  uint32_t maxTexelOffset;
+  u32 maxTexelOffset;
 
   /**
    * Minimum texel gather offset
    */
-  int32_t minTexelGatherOffset;
+  i32 minTexelGatherOffset;
 
   /**
    * Maximum texel gather offset
    */
-  uint32_t maxTexelGatherOffset;
+  u32 maxTexelGatherOffset;
 
   /**
    * Minimum interpolation offset
    */
-  float minInterpolationOffset;
+  f32 minInterpolationOffset;
 
   /**
    * Maximum interpolation offset
    */
-  float maxInterpolationOffset;
+  f32 maxInterpolationOffset;
 
   /**
    * Subpixel interpolation offset bits
    */
-  uint32_t subPixelInterpolationOffsetBits;
+  u32 subPixelInterpolationOffsetBits;
 
   /**
    * Maximum framebuffer width
    */
-  uint32_t maxFramebufferWidth;
+  u32 maxFramebufferWidth;
 
   /**
    * Maximum framebuffer height
    */
-  uint32_t maxFramebufferHeight;
+  u32 maxFramebufferHeight;
 
   /**
    * Maximum framebuffer layers
    */
-  uint32_t maxFramebufferLayers;
+  u32 maxFramebufferLayers;
 
   /**
    * Framebuffer color sample counts
    */
-  uint32_t framebufferColorSampleCounts;
+  u32 framebufferColorSampleCounts;
 
   /**
    * Framebuffer depth sample counts
    */
-  uint32_t framebufferDepthSampleCounts;
+  u32 framebufferDepthSampleCounts;
 
   /**
    * Framebuffer stencil sample counts
    */
-  uint32_t framebufferStencilSampleCounts;
+  u32 framebufferStencilSampleCounts;
 
   /**
    * Maximum color attachments
    */
-  uint32_t maxColorAttachments;
+  u32 maxColorAttachments;
 
   /**
    * Sampled image color sample counts
    */
-  uint32_t sampledImageColorSampleCounts;
+  u32 sampledImageColorSampleCounts;
 
   /**
    * Sampled image integer sample counts
    */
-  uint32_t sampledImageIntegerSampleCounts;
+  u32 sampledImageIntegerSampleCounts;
 
   /**
    * Sampled image depth sample counts
    */
-  uint32_t sampledImageDepthSampleCounts;
+  u32 sampledImageDepthSampleCounts;
 
   /**
    * Sampled image stencil sample counts
    */
-  uint32_t sampledImageStencilSampleCounts;
+  u32 sampledImageStencilSampleCounts;
 
   /**
    * Storage image sample counts
    */
-  uint32_t storageImageSampleCounts;
+  u32 storageImageSampleCounts;
 
   /**
    * Max sample mask words
    */
-  uint32_t maxSampleMaskWords;
+  u32 maxSampleMaskWords;
 
   /**
    * Timestamp compute and graphics
@@ -424,31 +424,31 @@ struct PhysicalDeviceLimits {
    * Number of nanoseconds required for a
    * timestamp query to be incremented
    */
-  float timestampPeriod;
+  f32 timestampPeriod;
 
   /**
    * Maximum clip distances that can be used
    * in shader stages
    */
-  uint32_t maxClipDistances;
+  u32 maxClipDistances;
 
   /**
    * Maximum cull distances that can be used
    * in shader stages
    */
-  uint32_t maxCullDistances;
+  u32 maxCullDistances;
 
   /**
    * Maximum clip and cull distances that can
    * be used in shader stages
    */
-  uint32_t maxCombinedClipAndCullDistances;
+  u32 maxCombinedClipAndCullDistances;
 
   /**
    * Discrete queue priorities that can be
    * assigned for each queue family
    */
-  uint32_t discreteQueuePriorities;
+  u32 discreteQueuePriorities;
 
   /**
    * Point size range
@@ -463,37 +463,37 @@ struct PhysicalDeviceLimits {
   /**
    * Point size granularity
    */
-  float pointSizeGranularity;
+  f32 pointSizeGranularity;
 
   /**
    * Line width granularity
    */
-  float lineWidthGranularity;
+  f32 lineWidthGranularity;
 
   /**
    * Strict lines supported
    */
-  uint32_t strictLines;
+  u32 strictLines;
 
   /**
    * Standard sample location
    */
-  uint32_t standardSampleLocations;
+  u32 standardSampleLocations;
 
   /**
    * Optimal buffer copy offset alignment
    */
-  uint64_t optimalBufferCopyOffsetAlignment;
+  u64 optimalBufferCopyOffsetAlignment;
 
   /**
    * Optimal buffer copy row pitch alignment
    */
-  uint64_t optimalBufferCopyRowPitchAlignment;
+  u64 optimalBufferCopyRowPitchAlignment;
 
   /**
    * Non coherent atom size
    */
-  uint64_t nonCoherentAtomSize;
+  u64 nonCoherentAtomSize;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/core/include/quoll/rhi/PipelineBarrier.h
+++ b/engine/rhi/core/include/quoll/rhi/PipelineBarrier.h
@@ -74,12 +74,12 @@ struct ImageBarrier {
   /**
    * Base mip level
    */
-  uint32_t baseLevel = 0;
+  u32 baseLevel = 0;
 
   /**
    * Mip level count
    */
-  uint32_t levelCount = 1;
+  u32 levelCount = 1;
 };
 
 /**
@@ -114,12 +114,12 @@ struct BufferBarrier {
   /**
    * Buffer offset
    */
-  uint32_t offset = 0;
+  u32 offset = 0;
 
   /**
    * Buffer size
    */
-  uint32_t size = 0;
+  u32 size = 0;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/core/include/quoll/rhi/PipelineDescription.h
+++ b/engine/rhi/core/include/quoll/rhi/PipelineDescription.h
@@ -57,7 +57,7 @@ struct PipelineRasterizer {
   /**
    * @brief Line width
    */
-  float lineWidth = 1.0f;
+  f32 lineWidth = 1.0f;
 };
 
 enum class BlendFactor {
@@ -111,12 +111,12 @@ struct PipelineVertexInputBinding {
   /**
    * Vertex input binding
    */
-  uint32_t binding = 0;
+  u32 binding = 0;
 
   /**
    * Vertex input stride
    */
-  uint32_t stride = 0;
+  u32 stride = 0;
 
   /**
    * Vertex input rate
@@ -131,12 +131,12 @@ struct PipelineVertexInputAttribute {
   /**
    * Attribute slot
    */
-  uint32_t slot = 0;
+  u32 slot = 0;
 
   /**
    * Attribute binding
    */
-  uint32_t binding = 0;
+  u32 binding = 0;
 
   /**
    * Attribute format
@@ -146,7 +146,7 @@ struct PipelineVertexInputAttribute {
   /**
    * Attribute offset
    */
-  uint32_t offset = 0;
+  u32 offset = 0;
 };
 
 /**
@@ -241,17 +241,17 @@ struct PipelineStencil {
   /**
    * Compare mask
    */
-  uint32_t compareMask = 0;
+  u32 compareMask = 0;
 
   /**
    * Write mask
    */
-  uint32_t writeMask = 0;
+  u32 writeMask = 0;
 
   /**
    * Reference value
    */
-  uint32_t reference = 0;
+  u32 reference = 0;
 };
 
 /**
@@ -291,7 +291,7 @@ struct PipelineMultisample {
   /**
    * Sample count
    */
-  uint32_t sampleCount = 1;
+  u32 sampleCount = 1;
 };
 
 /**

--- a/engine/rhi/core/include/quoll/rhi/RenderCommandList.h
+++ b/engine/rhi/core/include/quoll/rhi/RenderCommandList.h
@@ -101,9 +101,9 @@ public:
    * @param descriptor Descriptor
    * @param dynamicOffsets Dynamic offsets
    */
-  inline void bindDescriptor(PipelineHandle pipeline, uint32_t firstSet,
+  inline void bindDescriptor(PipelineHandle pipeline, u32 firstSet,
                              const Descriptor &descriptor,
-                             std::span<uint32_t> dynamicOffsets = {}) {
+                             std::span<u32> dynamicOffsets = {}) {
     mNativeRenderCommandList->bindDescriptor(pipeline, firstSet, descriptor,
                                              dynamicOffsets);
   }
@@ -115,7 +115,7 @@ public:
    * @param offsets Vertex buffer binding offsets
    */
   inline void bindVertexBuffers(const std::span<const BufferHandle> buffers,
-                                const std::span<const uint64_t> offsets) {
+                                const std::span<const u64> offsets) {
     mNativeRenderCommandList->bindVertexBuffers(buffers, offsets);
   }
 
@@ -139,7 +139,7 @@ public:
    * @param data Data
    */
   inline void pushConstants(PipelineHandle pipeline, ShaderStage shaderStage,
-                            uint32_t offset, uint32_t size, void *data) {
+                            u32 offset, u32 size, void *data) {
     mNativeRenderCommandList->pushConstants(pipeline, shaderStage, offset, size,
                                             data);
   }
@@ -152,8 +152,8 @@ public:
    * @param instanceCount Instance count
    * @param firstInstance First instance
    */
-  inline void draw(uint32_t vertexCount, uint32_t firstVertex,
-                   uint32_t instanceCount = 1, uint32_t firstInstance = 0) {
+  inline void draw(u32 vertexCount, u32 firstVertex, u32 instanceCount = 1,
+                   u32 firstInstance = 0) {
     mNativeRenderCommandList->draw(vertexCount, firstVertex, instanceCount,
                                    firstInstance);
   }
@@ -167,9 +167,8 @@ public:
    * @param instanceCount Instance count
    * @param firstInstance First instance
    */
-  inline void drawIndexed(uint32_t indexCount, uint32_t firstIndex,
-                          int32_t vertexOffset, uint32_t instanceCount = 1,
-                          uint32_t firstInstance = 0) {
+  inline void drawIndexed(u32 indexCount, u32 firstIndex, i32 vertexOffset,
+                          u32 instanceCount = 1, u32 firstInstance = 0) {
     mNativeRenderCommandList->drawIndexed(indexCount, firstIndex, vertexOffset,
                                           instanceCount, firstInstance);
   }
@@ -181,8 +180,7 @@ public:
    * @param groupCountY Number of groups to dispatch in Y direction
    * @param groupCountZ Number of groups to dispatch in Z direction
    */
-  inline void dispatch(uint32_t groupCountX, uint32_t groupCountY,
-                       uint32_t groupCountZ) {
+  inline void dispatch(u32 groupCountX, u32 groupCountY, u32 groupCountZ) {
     mNativeRenderCommandList->dispatch(groupCountX, groupCountY, groupCountZ);
   }
 

--- a/engine/rhi/core/include/quoll/rhi/RenderDevice.h
+++ b/engine/rhi/core/include/quoll/rhi/RenderDevice.h
@@ -27,7 +27,7 @@ public:
   /**
    * @brief Number of frames
    */
-  static constexpr size_t NumFrames = 2;
+  static constexpr usize NumFrames = 2;
 
 public:
   RenderDevice(const RenderDevice &) = delete;

--- a/engine/rhi/core/include/quoll/rhi/RenderFrame.h
+++ b/engine/rhi/core/include/quoll/rhi/RenderFrame.h
@@ -11,12 +11,12 @@ struct RenderFrame {
   /**
    * Frame index
    */
-  uint32_t frameIndex = std::numeric_limits<uint32_t>::max();
+  u32 frameIndex = std::numeric_limits<u32>::max();
 
   /**
    * Swapchain image index
    */
-  uint32_t swapchainImageIndex = std::numeric_limits<uint32_t>::max();
+  u32 swapchainImageIndex = std::numeric_limits<u32>::max();
 
   /**
    * Command list

--- a/engine/rhi/core/include/quoll/rhi/RenderHandle.h
+++ b/engine/rhi/core/include/quoll/rhi/RenderHandle.h
@@ -2,23 +2,23 @@
 
 namespace quoll::rhi {
 
-enum class ShaderHandle : uint32_t { Null = 0 };
+enum class ShaderHandle : u32 { Null = 0 };
 
-enum class BufferHandle : uint32_t { Null = 0 };
+enum class BufferHandle : u32 { Null = 0 };
 
-enum class TextureHandle : uint32_t { Null = 0 };
+enum class TextureHandle : u32 { Null = 0 };
 
-enum class SamplerHandle : uint32_t { Null = 0 };
+enum class SamplerHandle : u32 { Null = 0 };
 
-enum class RenderPassHandle : uint32_t { Null = 0 };
+enum class RenderPassHandle : u32 { Null = 0 };
 
-enum class FramebufferHandle : uint32_t { Null = 0 };
+enum class FramebufferHandle : u32 { Null = 0 };
 
-enum class PipelineHandle : uint32_t { Null = 0 };
+enum class PipelineHandle : u32 { Null = 0 };
 
-enum class DescriptorLayoutHandle : uint32_t { Null = 0 };
+enum class DescriptorLayoutHandle : u32 { Null = 0 };
 
-enum class DescriptorHandle : uint32_t { Null = 0 };
+enum class DescriptorHandle : u32 { Null = 0 };
 
 /**
  * @brief Check if type equals any of the other types
@@ -53,15 +53,14 @@ template <class THandle> constexpr inline bool isHandleValid(THandle handle) {
  * @param handle Handle
  * @return Handle value in uint
  */
-template <class THandle>
-constexpr inline uint32_t castHandleToUint(THandle handle) {
+template <class THandle> constexpr inline u32 castHandleToUint(THandle handle) {
   static_assert(
       IsAnySame<THandle, ShaderHandle, BufferHandle, TextureHandle,
                 SamplerHandle, RenderPassHandle, FramebufferHandle,
                 PipelineHandle, DescriptorLayoutHandle, DescriptorHandle>,
       "Type must be a render handle");
 
-  return static_cast<uint32_t>(handle);
+  return static_cast<u32>(handle);
 }
 
 } // namespace quoll::rhi

--- a/engine/rhi/core/include/quoll/rhi/RenderPassDescription.h
+++ b/engine/rhi/core/include/quoll/rhi/RenderPassDescription.h
@@ -17,12 +17,12 @@ struct DepthStencilClear {
   /**
    * Depth clear value
    */
-  float clearDepth = 0.0f;
+  f32 clearDepth = 0.0f;
 
   /**
    * Stencil clear value
    */
-  uint32_t clearStencil = 0;
+  u32 clearStencil = 0;
 };
 
 using AttachmentClearValue = std::variant<glm::vec4, DepthStencilClear>;

--- a/engine/rhi/core/include/quoll/rhi/SamplerDescription.h
+++ b/engine/rhi/core/include/quoll/rhi/SamplerDescription.h
@@ -37,7 +37,7 @@ struct SamplerDescription {
   /**
    * Clamp Lod to minimum value
    */
-  float minLod = 0.0f;
+  f32 minLod = 0.0f;
 
   /**
    * Maximum clamped Lod value
@@ -45,7 +45,7 @@ struct SamplerDescription {
    * If value is 0.0, maximum value
    * clamping is disabled
    */
-  float maxLod = 0.0f;
+  f32 maxLod = 0.0f;
 
   /**
    * Debug name

--- a/engine/rhi/core/include/quoll/rhi/StageFlags.h
+++ b/engine/rhi/core/include/quoll/rhi/StageFlags.h
@@ -12,7 +12,7 @@ enum class ShaderStage {
 
 EnableBitwiseEnum(ShaderStage);
 
-enum class PipelineStage : uint64_t {
+enum class PipelineStage : u64 {
   None = 0ULL,
   DrawIndirect = 0x00000002ULL,
   VertexShader = 0x00000008ULL,

--- a/engine/rhi/core/include/quoll/rhi/TextureDescription.h
+++ b/engine/rhi/core/include/quoll/rhi/TextureDescription.h
@@ -7,7 +7,7 @@ namespace quoll::rhi {
 
 enum class TextureType { Standard, Cubemap };
 
-enum class TextureUsage : uint8_t {
+enum class TextureUsage : u8 {
   None = 0,
   Color = 1 << 0,
   Depth = 1 << 1,
@@ -42,32 +42,32 @@ struct TextureDescription {
   /**
    * Texture width
    */
-  uint32_t width = 0;
+  u32 width = 0;
 
   /**
    * Texture height
    */
-  uint32_t height = 0;
+  u32 height = 0;
 
   /**
    * Texture depth
    */
-  uint32_t depth = 1;
+  u32 depth = 1;
 
   /**
    * Number of layers in texture
    */
-  uint32_t layerCount = 1;
+  u32 layerCount = 1;
 
   /**
    * Number of mip levels
    */
-  uint32_t mipLevelCount = 1;
+  u32 mipLevelCount = 1;
 
   /**
    * Number of samples
    */
-  uint32_t samples = 1;
+  u32 samples = 1;
 
   /**
    * Debug name

--- a/engine/rhi/core/include/quoll/rhi/TextureViewDescription.h
+++ b/engine/rhi/core/include/quoll/rhi/TextureViewDescription.h
@@ -16,22 +16,22 @@ struct TextureViewDescription {
   /**
    * Base mip level
    */
-  uint32_t baseMipLevel = 0;
+  u32 baseMipLevel = 0;
 
   /**
    * Number of levels
    */
-  uint32_t mipLevelCount = 1;
+  u32 mipLevelCount = 1;
 
   /**
    * Base layer
    */
-  uint32_t baseLayer = 0;
+  u32 baseLayer = 0;
 
   /**
    * Layer count
    */
-  uint32_t layerCount = 1;
+  u32 layerCount = 1;
 
   /**
    * Debug name

--- a/engine/rhi/core/src/Buffer.cpp
+++ b/engine/rhi/core/src/Buffer.cpp
@@ -12,12 +12,12 @@ void *Buffer::map() { return mNativeBuffer->map(); }
 
 void Buffer::unmap() { mNativeBuffer->unmap(); }
 
-void Buffer::update(const void *data, size_t size) {
+void Buffer::update(const void *data, usize size) {
   auto *mappedData = map();
   memcpy(mappedData, data, size);
   unmap();
 }
 
-void Buffer::resize(size_t size) { mNativeBuffer->resize(size); }
+void Buffer::resize(usize size) { mNativeBuffer->resize(size); }
 
 } // namespace quoll::rhi

--- a/engine/rhi/core/src/Descriptor.cpp
+++ b/engine/rhi/core/src/Descriptor.cpp
@@ -8,31 +8,29 @@ Descriptor::Descriptor(NativeDescriptor *nativeDescriptor,
                        DescriptorHandle handle)
     : mNativeDescriptor(nativeDescriptor), mHandle(handle) {}
 
-Descriptor &Descriptor::write(uint32_t binding,
-                              std::span<TextureHandle> textures,
-                              DescriptorType type, uint32_t start) {
+Descriptor &Descriptor::write(u32 binding, std::span<TextureHandle> textures,
+                              DescriptorType type, u32 start) {
   mNativeDescriptor->write(binding, textures, type, start);
 
   return *this;
 }
 
-Descriptor &Descriptor::write(uint32_t binding,
-                              std::span<SamplerHandle> samplers,
-                              uint32_t start) {
+Descriptor &Descriptor::write(u32 binding, std::span<SamplerHandle> samplers,
+                              u32 start) {
   mNativeDescriptor->write(binding, samplers, start);
   return *this;
 }
 
-Descriptor &Descriptor::write(uint32_t binding, std::span<BufferHandle> buffers,
-                              DescriptorType type, uint32_t start) {
+Descriptor &Descriptor::write(u32 binding, std::span<BufferHandle> buffers,
+                              DescriptorType type, u32 start) {
   mNativeDescriptor->write(binding, buffers, type, start);
 
   return *this;
 }
 
-Descriptor &Descriptor::write(uint32_t binding,
+Descriptor &Descriptor::write(u32 binding,
                               std::span<DescriptorBufferInfo> bufferInfos,
-                              DescriptorType type, uint32_t start) {
+                              DescriptorType type, u32 start) {
   mNativeDescriptor->write(binding, bufferInfos, type, start);
 
   return *this;

--- a/engine/rhi/core/src/DeviceStats.cpp
+++ b/engine/rhi/core/src/DeviceStats.cpp
@@ -6,7 +6,7 @@ namespace quoll::rhi {
 DeviceStats::DeviceStats(NativeResourceMetrics *resourceMetrics)
     : mResourceMetrics(resourceMetrics) {}
 
-void DeviceStats::addDrawCall(size_t primitiveCount) {
+void DeviceStats::addDrawCall(usize primitiveCount) {
   mDrawCallsCount++;
   mDrawnPrimitivesCount += primitiveCount;
   mCommandCallsCount++;

--- a/engine/rhi/mock/include/quoll/rhi-mock/MockBuffer.h
+++ b/engine/rhi/mock/include/quoll/rhi-mock/MockBuffer.h
@@ -34,7 +34,7 @@ public:
    *
    * @param size Resized buffer
    */
-  void resize(size_t size) override;
+  void resize(usize size) override;
 
   /**
    * @brief Get buffer device address
@@ -53,7 +53,7 @@ public:
   }
 
 private:
-  std::vector<uint8_t> mData;
+  std::vector<u8> mData;
   BufferDescription mDescription;
 };
 

--- a/engine/rhi/mock/include/quoll/rhi-mock/MockCommand.h
+++ b/engine/rhi/mock/include/quoll/rhi-mock/MockCommand.h
@@ -96,7 +96,7 @@ struct MockCommandBindDescriptor
   /**
    * First descriptor set
    */
-  uint32_t firstSet;
+  u32 firstSet;
 
   /**
    * Descriptor
@@ -106,7 +106,7 @@ struct MockCommandBindDescriptor
   /**
    * Dynamic offsets
    */
-  std::vector<uint32_t> dynamicOffsets;
+  std::vector<u32> dynamicOffsets;
 };
 
 /**
@@ -122,7 +122,7 @@ struct MockCommandBindVertexBuffer
   /**
    * Vertex buffer binding offsets
    */
-  std::vector<uint64_t> offsets;
+  std::vector<u64> offsets;
 };
 
 /**
@@ -159,12 +159,12 @@ struct MockCommandPushConstants
   /**
    * Offset
    */
-  uint32_t offset;
+  u32 offset;
 
   /**
    * Size
    */
-  uint32_t size;
+  u32 size;
 
   /**
    * Data
@@ -179,22 +179,22 @@ struct MockCommandDraw : public MockCommandTyped<MockCommandType::Draw> {
   /**
    * Vertex count
    */
-  uint32_t vertexCount;
+  u32 vertexCount;
 
   /**
    * First vertex
    */
-  uint32_t firstVertex;
+  u32 firstVertex;
 
   /**
    * Instance count
    */
-  uint32_t instanceCount;
+  u32 instanceCount;
 
   /**
    * First instance
    */
-  uint32_t firstInstance;
+  u32 firstInstance;
 };
 
 /**
@@ -205,27 +205,27 @@ struct MockCommandDrawIndexed
   /**
    * Index count
    */
-  uint32_t indexCount;
+  u32 indexCount;
 
   /**
    * First index
    */
-  uint32_t firstIndex;
+  u32 firstIndex;
 
   /**
    * Vertex offset
    */
-  int32_t vertexOffset;
+  i32 vertexOffset;
 
   /**
    * Instance count
    */
-  uint32_t instanceCount;
+  u32 instanceCount;
 
   /**
    * First instance
    */
-  uint32_t firstInstance;
+  u32 firstInstance;
 };
 
 /**
@@ -236,17 +236,17 @@ struct MockCommandDispatch
   /**
    * Group count X
    */
-  uint32_t groupCountX;
+  u32 groupCountX;
 
   /**
    * Group count Y
    */
-  uint32_t groupCountY;
+  u32 groupCountY;
 
   /**
    * Group count Z
    */
-  uint32_t groupCountZ;
+  u32 groupCountZ;
 };
 
 /**

--- a/engine/rhi/mock/include/quoll/rhi-mock/MockCommandData.h
+++ b/engine/rhi/mock/include/quoll/rhi-mock/MockCommandData.h
@@ -14,7 +14,7 @@ struct MockBindings {
   /**
    * Descriptors
    */
-  std::unordered_map<uint32_t, Descriptor> descriptors{};
+  std::unordered_map<u32, Descriptor> descriptors{};
 
   /**
    * Render pass
@@ -79,17 +79,17 @@ struct MockDispatchCall {
   /**
    * Group count x
    */
-  uint32_t groupCountX = 0;
+  u32 groupCountX = 0;
 
   /**
    * Group count y
    */
-  uint32_t groupCountY = 0;
+  u32 groupCountY = 0;
 
   /**
    * Group count z
    */
-  uint32_t groupCountZ = 0;
+  u32 groupCountZ = 0;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/mock/include/quoll/rhi-mock/MockCommandList.h
+++ b/engine/rhi/mock/include/quoll/rhi-mock/MockCommandList.h
@@ -58,9 +58,9 @@ public:
    * @param descriptor Descriptor
    * @param dynamicOffsets Dynamic offsets
    */
-  void bindDescriptor(PipelineHandle pipeline, uint32_t firstSet,
+  void bindDescriptor(PipelineHandle pipeline, u32 firstSet,
                       const Descriptor &descriptor,
-                      std::span<uint32_t> dynamicOffsets) override;
+                      std::span<u32> dynamicOffsets) override;
 
   /**
    * @brief Bind vertex buffers
@@ -69,7 +69,7 @@ public:
    * @param offsets Vertex buffer binding offsets
    */
   void bindVertexBuffers(const std::span<const BufferHandle> buffers,
-                         const std::span<const uint64_t> offsets) override;
+                         const std::span<const u64> offsets) override;
 
   /**
    * @brief Bind index buffer
@@ -89,7 +89,7 @@ public:
    * @param data Data
    */
   void pushConstants(PipelineHandle pipeline, ShaderStage shaderStage,
-                     uint32_t offset, uint32_t size, void *data) override;
+                     u32 offset, u32 size, void *data) override;
 
   /**
    * @brief Draw
@@ -99,8 +99,8 @@ public:
    * @param instanceCount Instance count
    * @param firstInstance First instance
    */
-  void draw(uint32_t vertexCount, uint32_t firstVertex, uint32_t instanceCount,
-            uint32_t firstInstance) override;
+  void draw(u32 vertexCount, u32 firstVertex, u32 instanceCount,
+            u32 firstInstance) override;
 
   /**
    * @brief Draw indexed
@@ -111,9 +111,8 @@ public:
    * @param instanceCount Instance count
    * @param firstInstance First instance
    */
-  void drawIndexed(uint32_t indexCount, uint32_t firstIndex,
-                   int32_t vertexOffset, uint32_t instanceCount,
-                   uint32_t firstInstance) override;
+  void drawIndexed(u32 indexCount, u32 firstIndex, i32 vertexOffset,
+                   u32 instanceCount, u32 firstInstance) override;
 
   /**
    * @brief Dispatch compute work
@@ -122,8 +121,7 @@ public:
    * @param groupCountY Number of groups to dispatch in Y direction
    * @param groupCountZ Number of groups to dispatch in Z direction
    */
-  void dispatch(uint32_t groupCountX, uint32_t groupCountY,
-                uint32_t groupCountZ) override;
+  void dispatch(u32 groupCountX, u32 groupCountY, u32 groupCountZ) override;
 
   /**
    * @brief Set viewport

--- a/engine/rhi/mock/include/quoll/rhi-mock/MockDescriptor.h
+++ b/engine/rhi/mock/include/quoll/rhi-mock/MockDescriptor.h
@@ -16,7 +16,7 @@ public:
     /**
      * Binding
      */
-    uint32_t binding;
+    u32 binding;
 
     /**
      * Descriptor type
@@ -26,7 +26,7 @@ public:
     /**
      * Start index
      */
-    uint32_t start;
+    u32 start;
 
     /**
      * Binding data
@@ -52,8 +52,8 @@ public:
    * @param type Descriptor type
    * @param start Starting index
    */
-  void write(uint32_t binding, std::span<TextureHandle> textures,
-             DescriptorType type, uint32_t start) override;
+  void write(u32 binding, std::span<TextureHandle> textures,
+             DescriptorType type, u32 start) override;
 
   /**
    * @brief Bind sampler descriptors
@@ -62,8 +62,8 @@ public:
    * @param samplers Samplers
    * @param start Starting index
    */
-  void write(uint32_t binding, std::span<SamplerHandle> samplers,
-             uint32_t start) override;
+  void write(u32 binding, std::span<SamplerHandle> samplers,
+             u32 start) override;
 
   /**
    * @brief Bind buffer descriptors
@@ -73,8 +73,8 @@ public:
    * @param type Descriptor type
    * @param start Starting index
    */
-  void write(uint32_t binding, std::span<BufferHandle> buffers,
-             DescriptorType type, uint32_t start) override;
+  void write(u32 binding, std::span<BufferHandle> buffers, DescriptorType type,
+             u32 start) override;
 
   /**
    * @brief Bind buffer descriptors
@@ -84,8 +84,8 @@ public:
    * @param type Descriptor type
    * @param start Starting index
    */
-  void write(uint32_t binding, std::span<DescriptorBufferInfo> bufferInfos,
-             DescriptorType type, uint32_t start) override;
+  void write(u32 binding, std::span<DescriptorBufferInfo> bufferInfos,
+             DescriptorType type, u32 start) override;
 
 private:
   std::vector<Binding> mBindings;

--- a/engine/rhi/mock/include/quoll/rhi-mock/MockRenderDevice.h
+++ b/engine/rhi/mock/include/quoll/rhi-mock/MockRenderDevice.h
@@ -187,7 +187,7 @@ public:
    * @param handle Texture handle
    * @return Texture updates
    */
-  uint32_t getTextureUpdates(TextureHandle handle);
+  u32 getTextureUpdates(TextureHandle handle);
 
   /**
    * @brief Create texture view
@@ -346,7 +346,7 @@ private:
 
   std::array<RenderCommandList, NumFrames> mCommandLists;
   std::vector<MockCommandList> mSubmittedCommandLists;
-  uint32_t mFrameIndex = 0;
+  u32 mFrameIndex = 0;
 
   DeviceStats mDeviceStats;
 };

--- a/engine/rhi/mock/include/quoll/rhi-mock/MockResourceMap.h
+++ b/engine/rhi/mock/include/quoll/rhi-mock/MockResourceMap.h
@@ -113,9 +113,7 @@ public:
    * @param handle Resource handle
    * @return Number of times the handle is emplaced
    */
-  uint32_t getEmplaced(THandle handle) const {
-    return mEmplacements.at(handle);
-  }
+  u32 getEmplaced(THandle handle) const { return mEmplacements.at(handle); }
 
 private:
   void incrementEmplacement(THandle handle) {
@@ -128,9 +126,9 @@ private:
   }
 
 private:
-  uint32_t mIncrement = 1;
+  u32 mIncrement = 1;
   std::unordered_map<THandle, TResource> mResources;
-  std::unordered_map<THandle, uint32_t> mEmplacements;
+  std::unordered_map<THandle, u32> mEmplacements;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/mock/include/quoll/rhi-mock/MockResourceMetrics.h
+++ b/engine/rhi/mock/include/quoll/rhi-mock/MockResourceMetrics.h
@@ -14,28 +14,28 @@ public:
    *
    * @return Total buffer size
    */
-  size_t getTotalBufferSize() const override;
+  usize getTotalBufferSize() const override;
 
   /**
    * @brief Get number of buffers
    *
    * @return Number of buffers
    */
-  size_t getBuffersCount() const override;
+  usize getBuffersCount() const override;
 
   /**
    * @brief Get number of textures
    *
    * @return Number of textures
    */
-  size_t getTexturesCount() const override;
+  usize getTexturesCount() const override;
 
   /**
    * @brief Get number of descriptors
    *
    * @return Number of descriptors
    */
-  size_t getDescriptorsCount() const override;
+  usize getDescriptorsCount() const override;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/mock/include/quoll/rhi-mock/MockTexture.h
+++ b/engine/rhi/mock/include/quoll/rhi-mock/MockTexture.h
@@ -43,7 +43,7 @@ public:
   }
 
 private:
-  std::vector<uint8_t> mData;
+  std::vector<u8> mData;
   TextureDescription mDescription;
   TextureViewDescription mViewDescription;
 };

--- a/engine/rhi/mock/src/MockBuffer.cpp
+++ b/engine/rhi/mock/src/MockBuffer.cpp
@@ -6,7 +6,7 @@ namespace quoll::rhi {
 MockBuffer::MockBuffer(const BufferDescription &description)
     : mDescription(description) {
   mData.resize(description.size);
-  const auto *data = static_cast<const uint8_t *>(description.data);
+  const auto *data = static_cast<const u8 *>(description.data);
   memcpy(mData.data(), data, description.size);
 }
 
@@ -16,10 +16,10 @@ void MockBuffer::unmap() {
   // Do nothing as the data is always mapped
 }
 
-void MockBuffer::resize(size_t size) { mData.resize(size); }
+void MockBuffer::resize(usize size) { mData.resize(size); }
 
 rhi::DeviceAddress MockBuffer::getAddress() {
-  return rhi::DeviceAddress{reinterpret_cast<uint64_t>(this)};
+  return rhi::DeviceAddress{reinterpret_cast<u64>(this)};
 }
 
 } // namespace quoll::rhi

--- a/engine/rhi/mock/src/MockCommandList.cpp
+++ b/engine/rhi/mock/src/MockCommandList.cpp
@@ -43,9 +43,9 @@ void MockCommandList::bindPipeline(PipelineHandle pipeline) {
   mBindings.pipeline = pipeline;
 }
 
-void MockCommandList::bindDescriptor(PipelineHandle pipeline, uint32_t firstSet,
+void MockCommandList::bindDescriptor(PipelineHandle pipeline, u32 firstSet,
                                      const Descriptor &descriptor,
-                                     std::span<uint32_t> dynamicOffsets) {
+                                     std::span<u32> dynamicOffsets) {
   auto *command = new MockCommandBindDescriptor;
   command->pipeline = pipeline;
   command->firstSet = firstSet;
@@ -59,7 +59,7 @@ void MockCommandList::bindDescriptor(PipelineHandle pipeline, uint32_t firstSet,
 
 void MockCommandList::bindVertexBuffers(
     const std::span<const BufferHandle> buffers,
-    const std::span<const uint64_t> offsets) {
+    const std::span<const u64> offsets) {
   auto *command = new MockCommandBindVertexBuffer;
   command->buffers = std::vector(buffers.begin(), buffers.end());
   command->offsets = std::vector(offsets.begin(), offsets.end());
@@ -80,8 +80,8 @@ void MockCommandList::bindIndexBuffer(BufferHandle buffer,
 }
 
 void MockCommandList::pushConstants(PipelineHandle pipeline,
-                                    ShaderStage shaderStage, uint32_t offset,
-                                    uint32_t size, void *data) {
+                                    ShaderStage shaderStage, u32 offset,
+                                    u32 size, void *data) {
   auto *command = new MockCommandPushConstants;
   command->pipeline = pipeline;
   command->shaderStage = shaderStage;
@@ -91,8 +91,8 @@ void MockCommandList::pushConstants(PipelineHandle pipeline,
   mCommands.push_back(std::unique_ptr<MockCommand>(command));
 }
 
-void MockCommandList::draw(uint32_t vertexCount, uint32_t firstVertex,
-                           uint32_t instanceCount, uint32_t firstInstance) {
+void MockCommandList::draw(u32 vertexCount, u32 firstVertex, u32 instanceCount,
+                           u32 firstInstance) {
   auto *command = new MockCommandDraw;
   command->vertexCount = vertexCount;
   command->firstVertex = firstVertex;
@@ -107,9 +107,9 @@ void MockCommandList::draw(uint32_t vertexCount, uint32_t firstVertex,
   mDrawCalls.push_back(call);
 }
 
-void MockCommandList::drawIndexed(uint32_t indexCount, uint32_t firstIndex,
-                                  int32_t vertexOffset, uint32_t instanceCount,
-                                  uint32_t firstInstance) {
+void MockCommandList::drawIndexed(u32 indexCount, u32 firstIndex,
+                                  i32 vertexOffset, u32 instanceCount,
+                                  u32 firstInstance) {
   auto *command = new MockCommandDrawIndexed;
   command->indexCount = indexCount;
   command->firstIndex = firstIndex;
@@ -125,8 +125,8 @@ void MockCommandList::drawIndexed(uint32_t indexCount, uint32_t firstIndex,
   mDrawCalls.push_back(call);
 }
 
-void MockCommandList::dispatch(uint32_t groupCountX, uint32_t groupCountY,
-                               uint32_t groupCountZ) {
+void MockCommandList::dispatch(u32 groupCountX, u32 groupCountY,
+                               u32 groupCountZ) {
   auto *command = new MockCommandDispatch;
   command->groupCountX = groupCountX;
   command->groupCountY = groupCountY;

--- a/engine/rhi/mock/src/MockDescriptor.cpp
+++ b/engine/rhi/mock/src/MockDescriptor.cpp
@@ -11,25 +11,25 @@ static constexpr std::vector<T> vectorFrom(std::span<T> data) {
 MockDescriptor::MockDescriptor(DescriptorLayoutHandle layout)
     : mLayout(layout) {}
 
-void MockDescriptor::write(uint32_t binding, std::span<TextureHandle> textures,
-                           DescriptorType type, uint32_t start) {
+void MockDescriptor::write(u32 binding, std::span<TextureHandle> textures,
+                           DescriptorType type, u32 start) {
   mBindings.push_back({binding, type, start, vectorFrom(textures)});
 }
 
-void MockDescriptor::write(uint32_t binding, std::span<SamplerHandle> samplers,
-                           uint32_t start) {
+void MockDescriptor::write(u32 binding, std::span<SamplerHandle> samplers,
+                           u32 start) {
   mBindings.push_back(
       {binding, DescriptorType::Sampler, start, vectorFrom(samplers)});
 }
 
-void MockDescriptor::write(uint32_t binding, std::span<BufferHandle> buffers,
-                           DescriptorType type, uint32_t start) {
+void MockDescriptor::write(u32 binding, std::span<BufferHandle> buffers,
+                           DescriptorType type, u32 start) {
   mBindings.push_back({binding, type, start, vectorFrom(buffers)});
 }
 
-void MockDescriptor::write(uint32_t binding,
+void MockDescriptor::write(u32 binding,
                            std::span<DescriptorBufferInfo> bufferInfos,
-                           DescriptorType type, uint32_t start) {
+                           DescriptorType type, u32 start) {
   mBindings.push_back({binding, type, start, vectorFrom(bufferInfos)});
 }
 

--- a/engine/rhi/mock/src/MockRenderDevice.cpp
+++ b/engine/rhi/mock/src/MockRenderDevice.cpp
@@ -121,7 +121,7 @@ void MockRenderDevice::destroyTexture(TextureHandle handle) {
   mTextures.erase(handle);
 }
 
-uint32_t MockRenderDevice::getTextureUpdates(TextureHandle handle) {
+u32 MockRenderDevice::getTextureUpdates(TextureHandle handle) {
   return mTextures.getEmplaced(handle);
 }
 

--- a/engine/rhi/mock/src/MockResourceMetrics.cpp
+++ b/engine/rhi/mock/src/MockResourceMetrics.cpp
@@ -3,12 +3,12 @@
 
 namespace quoll::rhi {
 
-size_t MockResourceMetrics::getTotalBufferSize() const { return 0; }
+usize MockResourceMetrics::getTotalBufferSize() const { return 0; }
 
-size_t MockResourceMetrics::getBuffersCount() const { return 0; }
+usize MockResourceMetrics::getBuffersCount() const { return 0; }
 
-size_t MockResourceMetrics::getTexturesCount() const { return 0; }
+usize MockResourceMetrics::getTexturesCount() const { return 0; }
 
-size_t MockResourceMetrics::getDescriptorsCount() const { return 0; }
+usize MockResourceMetrics::getDescriptorsCount() const { return 0; }
 
 } // namespace quoll::rhi

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanBuffer.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanBuffer.h
@@ -54,7 +54,7 @@ public:
    *
    * @param size New size
    */
-  void resize(size_t size) override;
+  void resize(usize size) override;
 
   /**
    * @brief Get device address
@@ -89,7 +89,7 @@ public:
    *
    * @return Buffer size
    */
-  inline size_t getSize() const { return mSize; }
+  inline usize getSize() const { return mSize; }
 
 private:
   /**
@@ -108,7 +108,7 @@ private:
   rhi::BufferUsage mUsage;
   rhi::BufferAllocationUsage mAllocationUsage;
   bool mMapped = false;
-  size_t mSize = 0;
+  usize mSize = 0;
   void *mMappedData = nullptr;
 
   String mDebugName;

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanCommandBuffer.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanCommandBuffer.h
@@ -78,9 +78,9 @@ public:
    * @param descriptor Descriptor
    * @param dynamicOffsets Dynamic offsets
    */
-  void bindDescriptor(PipelineHandle pipeline, uint32_t firstSet,
+  void bindDescriptor(PipelineHandle pipeline, u32 firstSet,
                       const Descriptor &descriptor,
-                      std::span<uint32_t> dynamicOffsets) override;
+                      std::span<u32> dynamicOffsets) override;
 
   /**
    * @brief Bind vertex buffers
@@ -89,7 +89,7 @@ public:
    * @param offsets Vertex buffer binding offsets
    */
   void bindVertexBuffers(const std::span<const BufferHandle> buffers,
-                         const std::span<const uint64_t> offsets) override;
+                         const std::span<const u64> offsets) override;
 
   /**
    * @brief Bind index buffer
@@ -109,7 +109,7 @@ public:
    * @param data Data
    */
   void pushConstants(PipelineHandle pipeline, ShaderStage shaderStage,
-                     uint32_t offset, uint32_t size, void *data) override;
+                     u32 offset, u32 size, void *data) override;
 
   /**
    * @brief Draw
@@ -119,8 +119,8 @@ public:
    * @param instanceCount Instance count
    * @param firstInstance First instance
    */
-  void draw(uint32_t vertexCount, uint32_t firstVertex, uint32_t instanceCount,
-            uint32_t firstInstance) override;
+  void draw(u32 vertexCount, u32 firstVertex, u32 instanceCount,
+            u32 firstInstance) override;
 
   /**
    * @brief Draw indexed
@@ -131,9 +131,8 @@ public:
    * @param instanceCount Instance count
    * @param firstInstance First instance
    */
-  void drawIndexed(uint32_t indexCount, uint32_t firstIndex,
-                   int32_t vertexOffset, uint32_t instanceCount,
-                   uint32_t firstInstance) override;
+  void drawIndexed(u32 indexCount, u32 firstIndex, i32 vertexOffset,
+                   u32 instanceCount, u32 firstInstance) override;
 
   /**
    * @brief Dispatch compute work
@@ -142,8 +141,7 @@ public:
    * @param groupCountY Number of groups to dispatch in Y direction
    * @param groupCountZ Number of groups to dispatch in Z direction
    */
-  void dispatch(uint32_t groupCountX, uint32_t groupCountY,
-                uint32_t groupCountZ) override;
+  void dispatch(u32 groupCountX, u32 groupCountY, u32 groupCountZ) override;
 
   /**
    * @brief Set viewport

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanCommandPool.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanCommandPool.h
@@ -22,7 +22,7 @@ public:
    * @param descriptorPool Descriptor pool
    * @param stats Device stats
    */
-  VulkanCommandPool(VulkanDeviceObject &device, uint32_t queueFamilyIndex,
+  VulkanCommandPool(VulkanDeviceObject &device, u32 queueFamilyIndex,
                     const VulkanResourceRegistry &registry,
                     const VulkanDescriptorPool &descriptorPool,
                     DeviceStats &stats);
@@ -43,7 +43,7 @@ public:
    * @param count Number of buffers
    * @return List of render command lists
    */
-  std::vector<RenderCommandList> createCommandLists(uint32_t count);
+  std::vector<RenderCommandList> createCommandLists(u32 count);
 
   /**
    * @brief Free command list
@@ -58,7 +58,7 @@ private:
   DeviceStats &mStats;
   const VulkanResourceRegistry &mRegistry;
   const VulkanDescriptorPool &mDescriptorPool;
-  uint32_t mQueueFamilyIndex = 0;
+  u32 mQueueFamilyIndex = 0;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanDescriptorPool.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanDescriptorPool.h
@@ -49,7 +49,7 @@ public:
    * @return Vulkan descriptor set
    */
   inline VkDescriptorSet getDescriptorSet(DescriptorHandle handle) const {
-    return mDescriptorSets.at(static_cast<size_t>(handle) - 1);
+    return mDescriptorSets.at(static_cast<usize>(handle) - 1);
   }
 
   /**
@@ -57,7 +57,7 @@ public:
    *
    * @return Number of descriptors
    */
-  inline size_t getDescriptorsCount() const { return mDescriptorSets.size(); }
+  inline usize getDescriptorsCount() const { return mDescriptorSets.size(); }
 
   /**
    * @brief Get layout from descriptor

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanDescriptorSet.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanDescriptorSet.h
@@ -31,8 +31,8 @@ public:
    * @param type Descriptor type
    * @param start Starting index
    */
-  void write(uint32_t binding, std::span<TextureHandle> textures,
-             DescriptorType type, uint32_t start) override;
+  void write(u32 binding, std::span<TextureHandle> textures,
+             DescriptorType type, u32 start) override;
 
   /**
    * @brief Bind sampler descriptors
@@ -41,8 +41,8 @@ public:
    * @param samplers Samplers
    * @param start Starting index
    */
-  void write(uint32_t binding, std::span<SamplerHandle> samplers,
-             uint32_t start) override;
+  void write(u32 binding, std::span<SamplerHandle> samplers,
+             u32 start) override;
 
   /**
    * @brief Write buffers
@@ -52,8 +52,8 @@ public:
    * @param type Descriptor type
    * @param start Starting index
    */
-  void write(uint32_t binding, std::span<BufferHandle> buffers,
-             DescriptorType type, uint32_t start) override;
+  void write(u32 binding, std::span<BufferHandle> buffers, DescriptorType type,
+             u32 start) override;
 
   /**
    * @brief Bind buffer descriptors
@@ -63,8 +63,8 @@ public:
    * @param type Descriptor type
    * @param start Starting index
    */
-  void write(uint32_t binding, std::span<DescriptorBufferInfo> bufferInfos,
-             DescriptorType type, uint32_t start) override;
+  void write(u32 binding, std::span<DescriptorBufferInfo> bufferInfos,
+             DescriptorType type, u32 start) override;
 
 private:
   /**
@@ -77,7 +77,7 @@ private:
    * @param imageInfos Image infos
    * @param bufferInfos Buffer infos
    */
-  void write(uint32_t binding, uint32_t start, size_t descriptorCount,
+  void write(u32 binding, u32 start, usize descriptorCount,
              VkDescriptorType type, const VkDescriptorImageInfo *imageInfos,
              VkDescriptorBufferInfo *bufferInfos);
 

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanFrameManager.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanFrameManager.h
@@ -61,7 +61,7 @@ public:
    *
    * @return Current frame index
    */
-  inline uint32_t getCurrentFrameIndex() const { return mFrameIndex; }
+  inline u32 getCurrentFrameIndex() const { return mFrameIndex; }
 
   /**
    * @brief Go to next frame
@@ -91,7 +91,7 @@ private:
   std::array<VkSemaphore, RenderDevice::NumFrames> mImageAvailableSemaphores{};
   std::array<VkSemaphore, RenderDevice::NumFrames> mRenderFinishedSemaphores{};
 
-  uint32_t mFrameIndex = 0;
+  u32 mFrameIndex = 0;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanPipeline.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanPipeline.h
@@ -73,7 +73,7 @@ public:
    * @param index Descriptor layout index
    * @return Descriptor layout
    */
-  inline const VkDescriptorSetLayout getDescriptorLayout(uint32_t index) const {
+  inline const VkDescriptorSetLayout getDescriptorLayout(u32 index) const {
     return mDescriptorLayouts.at(index);
   }
 
@@ -109,7 +109,7 @@ private:
   VkPipelineLayout mPipelineLayout = VK_NULL_HANDLE;
   VkPipelineBindPoint mBindPoint = VK_PIPELINE_BIND_POINT_MAX_ENUM;
 
-  std::unordered_map<uint32_t, VkDescriptorSetLayout> mDescriptorLayouts;
+  std::unordered_map<u32, VkDescriptorSetLayout> mDescriptorLayouts;
 
   String mDebugName;
 };

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanPipelineLayoutCache.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanPipelineLayoutCache.h
@@ -59,7 +59,7 @@ public:
    */
   inline VkDescriptorSetLayout
   getVulkanDescriptorSetLayout(DescriptorLayoutHandle handle) {
-    return mDescriptorSetLayouts.at(static_cast<size_t>(handle) - 1);
+    return mDescriptorSetLayouts.at(static_cast<usize>(handle) - 1);
   }
 
   /**
@@ -70,7 +70,7 @@ public:
    */
   inline const DescriptorLayoutDescription &
   getDescriptorLayoutDescription(DescriptorLayoutHandle handle) {
-    return mDescriptorLayoutDescriptions.at(static_cast<size_t>(handle) - 1);
+    return mDescriptorLayoutDescriptions.at(static_cast<usize>(handle) - 1);
   }
 
 private:

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanQueue.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanQueue.h
@@ -15,14 +15,14 @@ public:
    * @param device Vulkan device object
    * @param queueIndex Queue index
    */
-  VulkanQueue(VulkanDeviceObject &device, uint32_t queueIndex);
+  VulkanQueue(VulkanDeviceObject &device, u32 queueIndex);
 
   /**
    * @brief Get queue index
    *
    * @return Queue index
    */
-  inline uint32_t getQueueIndex() const { return mQueueIndex; }
+  inline u32 getQueueIndex() const { return mQueueIndex; }
 
   /**
    * @brief Get Vulkan queue handle
@@ -58,7 +58,7 @@ public:
 
 private:
   VkQueue mQueue = VK_NULL_HANDLE;
-  uint32_t mQueueIndex = 0;
+  u32 mQueueIndex = 0;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanQueueFamily.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanQueueFamily.h
@@ -44,7 +44,7 @@ public:
    *
    * @return Array of all queue families
    */
-  inline const std::array<uint32_t, 3> toArray() const {
+  inline const std::array<u32, 3> toArray() const {
     return {getGraphicsFamily(), getTransferFamily(), getPresentFamily()};
   }
 
@@ -53,26 +53,26 @@ public:
    *
    * @return Graphics queue index
    */
-  inline uint32_t getGraphicsFamily() const { return mGraphicsFamily.value(); }
+  inline u32 getGraphicsFamily() const { return mGraphicsFamily.value(); }
 
   /**
    * @brief Get present queue index
    *
    * @return Present queue index
    */
-  inline uint32_t getPresentFamily() const { return mPresentFamily.value(); }
+  inline u32 getPresentFamily() const { return mPresentFamily.value(); }
 
   /**
    * @brief Get transfer queue index
    *
    * @return Transfer queue index
    */
-  inline uint32_t getTransferFamily() const { return mTransferFamily.value(); }
+  inline u32 getTransferFamily() const { return mTransferFamily.value(); }
 
 private:
-  std::optional<uint32_t> mGraphicsFamily;
-  std::optional<uint32_t> mPresentFamily;
-  std::optional<uint32_t> mTransferFamily;
+  std::optional<u32> mGraphicsFamily;
+  std::optional<u32> mPresentFamily;
+  std::optional<u32> mTransferFamily;
 };
 
 } // namespace quoll::rhi

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanRenderContext.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanRenderContext.h
@@ -41,7 +41,7 @@ public:
    * @return Present queue submit result
    */
   VkResult present(VulkanFrameManager &frameManager,
-                   const VulkanSwapchain &swapchain, uint32_t imageIdx);
+                   const VulkanSwapchain &swapchain, u32 imageIdx);
 
   /**
    * @brief Begin Rendering

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanResourceMetrics.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanResourceMetrics.h
@@ -25,28 +25,28 @@ public:
    *
    * @return Total buffer size
    */
-  size_t getTotalBufferSize() const override;
+  usize getTotalBufferSize() const override;
 
   /**
    * @brief Get number of buffers
    *
    * @return Number of buffers
    */
-  size_t getBuffersCount() const override;
+  usize getBuffersCount() const override;
 
   /**
    * @brief Get number of textures
    *
    * @return Number of textures
    */
-  size_t getTexturesCount() const override;
+  usize getTexturesCount() const override;
 
   /**
    * @brief Get number of descriptors
    *
    * @return Descriptors
    */
-  size_t getDescriptorsCount() const override;
+  usize getDescriptorsCount() const override;
 
 private:
   VulkanResourceRegistry &mRegistry;

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanResourceRegistry.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanResourceRegistry.h
@@ -43,7 +43,7 @@ class VulkanResourceRegistry {
      *
      * Used for auto generation
      */
-    uint32_t lastHandle = 1;
+    u32 lastHandle = 1;
   };
 
   using ShaderMap = ResourceMap<ShaderHandle, VulkanShader>;

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanShader.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanShader.h
@@ -24,7 +24,7 @@ public:
     /**
      * @brief Descriptor layouts
      */
-    std::map<uint32_t, DescriptorLayoutDescription> descriptorLayouts;
+    std::map<u32, DescriptorLayoutDescription> descriptorLayouts;
   };
 
 public:

--- a/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanSwapchain.h
+++ b/engine/rhi/vulkan/include/quoll/rhi-vulkan/VulkanSwapchain.h
@@ -56,7 +56,7 @@ public:
    * @param imageAvailableSemaphore Semaphore to signal
    * @return Next acquired image index
    */
-  uint32_t acquireNextImage(VkSemaphore imageAvailableSemaphore);
+  u32 acquireNextImage(VkSemaphore imageAvailableSemaphore);
 
   /**
    * @brief Gets surface format

--- a/engine/rhi/vulkan/src/VulkanBuffer.cpp
+++ b/engine/rhi/vulkan/src/VulkanBuffer.cpp
@@ -36,7 +36,7 @@ void VulkanBuffer::unmap() {
   vmaUnmapMemory(mAllocator, mAllocation);
 }
 
-void VulkanBuffer::resize(size_t size) {
+void VulkanBuffer::resize(usize size) {
   mSize = size;
   createBuffer({mUsage, mSize, nullptr, mAllocationUsage, mMapped, mDebugName});
 }

--- a/engine/rhi/vulkan/src/VulkanCommandPool.cpp
+++ b/engine/rhi/vulkan/src/VulkanCommandPool.cpp
@@ -10,7 +10,7 @@
 namespace quoll::rhi {
 
 VulkanCommandPool::VulkanCommandPool(VulkanDeviceObject &device,
-                                     uint32_t queueFamilyIndex,
+                                     u32 queueFamilyIndex,
                                      const VulkanResourceRegistry &registry,
                                      const VulkanDescriptorPool &descriptorPool,
                                      DeviceStats &stats)
@@ -37,7 +37,7 @@ VulkanCommandPool::~VulkanCommandPool() {
 }
 
 std::vector<RenderCommandList>
-VulkanCommandPool::createCommandLists(uint32_t count) {
+VulkanCommandPool::createCommandLists(u32 count) {
   std::vector<VkCommandBuffer> commandBuffers(count);
   std::vector<RenderCommandList> renderCommandLists(count);
 
@@ -51,7 +51,7 @@ VulkanCommandPool::createCommandLists(uint32_t count) {
       vkAllocateCommandBuffers(mDevice, &allocInfo, commandBuffers.data()),
       "Failed to allocate command buffers");
 
-  for (size_t i = 0; i < count; ++i) {
+  for (usize i = 0; i < count; ++i) {
     renderCommandLists.at(i) =
         std::move(RenderCommandList(new VulkanCommandBuffer(
             commandBuffers.at(i), mRegistry, mDescriptorPool, mStats)));

--- a/engine/rhi/vulkan/src/VulkanDescriptorPool.cpp
+++ b/engine/rhi/vulkan/src/VulkanDescriptorPool.cpp
@@ -25,15 +25,14 @@ VulkanDescriptorPool::~VulkanDescriptorPool() {
 }
 
 void VulkanDescriptorPool::createDescriptorPool() {
-  static constexpr uint32_t NumUniformBuffers = 15000;
-  static constexpr uint32_t NumUniformBuffersDynamic = 20;
-  static constexpr uint32_t NumStorageBuffers = 10;
-  static constexpr uint32_t NumSamplers = 1000;
-  static constexpr uint32_t NumDescriptors = 30000;
-  static constexpr uint32_t MaxTextureDescriptors = 8;
+  static constexpr u32 NumUniformBuffers = 15000;
+  static constexpr u32 NumUniformBuffersDynamic = 20;
+  static constexpr u32 NumStorageBuffers = 10;
+  static constexpr u32 NumSamplers = 1000;
+  static constexpr u32 NumDescriptors = 30000;
+  static constexpr u32 MaxTextureDescriptors = 8;
 
-  static constexpr uint32_t MaxImageSamplers =
-      MaxTextureDescriptors * NumSamplers;
+  static constexpr u32 MaxImageSamplers = MaxTextureDescriptors * NumSamplers;
 
   std::array<VkDescriptorPoolSize, 4> poolSizes{
       VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
@@ -50,7 +49,7 @@ void VulkanDescriptorPool::createDescriptorPool() {
   descriptorPoolInfo.pNext = nullptr;
   descriptorPoolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT;
   descriptorPoolInfo.maxSets = NumDescriptors;
-  descriptorPoolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
+  descriptorPoolInfo.poolSizeCount = static_cast<u32>(poolSizes.size());
   descriptorPoolInfo.pPoolSizes = poolSizes.data();
 
   checkForVulkanError(vkCreateDescriptorPool(mDevice, &descriptorPoolInfo,

--- a/engine/rhi/vulkan/src/VulkanDescriptorSet.cpp
+++ b/engine/rhi/vulkan/src/VulkanDescriptorSet.cpp
@@ -13,13 +13,12 @@ VulkanDescriptorSet::VulkanDescriptorSet(VulkanDeviceObject &device,
                                          VkDescriptorSet descriptorSet)
     : mDevice(device), mRegistry(registry), mDescriptorSet(descriptorSet) {}
 
-void VulkanDescriptorSet::write(uint32_t binding,
-                                std::span<TextureHandle> textures,
-                                DescriptorType type, uint32_t start) {
+void VulkanDescriptorSet::write(u32 binding, std::span<TextureHandle> textures,
+                                DescriptorType type, u32 start) {
   std::vector<VkDescriptorImageInfo> imageInfos(textures.size(),
                                                 VkDescriptorImageInfo{});
 
-  for (size_t i = 0; i < textures.size(); ++i) {
+  for (usize i = 0; i < textures.size(); ++i) {
     const auto &vkTexture = mRegistry.getTextures().at(textures[i]);
     imageInfos.at(i).imageLayout =
         type == DescriptorType::StorageImage
@@ -33,13 +32,12 @@ void VulkanDescriptorSet::write(uint32_t binding,
         VulkanMapping::getDescriptorType(type), imageInfos.data(), nullptr);
 }
 
-void VulkanDescriptorSet::write(uint32_t binding,
-                                std::span<SamplerHandle> samplers,
-                                uint32_t start) {
+void VulkanDescriptorSet::write(u32 binding, std::span<SamplerHandle> samplers,
+                                u32 start) {
   std::vector<VkDescriptorImageInfo> samplerInfos{samplers.size(),
                                                   VkDescriptorImageInfo{}};
 
-  for (size_t i = 0; i < samplers.size(); ++i) {
+  for (usize i = 0; i < samplers.size(); ++i) {
     const auto &vkSampler = mRegistry.getSamplers().at(samplers[i]);
     samplerInfos.at(i).sampler = vkSampler->getSampler();
     samplerInfos.at(i).imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -50,13 +48,12 @@ void VulkanDescriptorSet::write(uint32_t binding,
         samplerInfos.data(), nullptr);
 }
 
-void VulkanDescriptorSet::write(uint32_t binding,
-                                std::span<BufferHandle> buffers,
-                                DescriptorType type, uint32_t start) {
+void VulkanDescriptorSet::write(u32 binding, std::span<BufferHandle> buffers,
+                                DescriptorType type, u32 start) {
   std::vector<VkDescriptorBufferInfo> bufferInfos(buffers.size(),
                                                   VkDescriptorBufferInfo{});
 
-  for (size_t i = 0; i < buffers.size(); ++i) {
+  for (usize i = 0; i < buffers.size(); ++i) {
     const auto &vkBuffer = mRegistry.getBuffers().at(buffers[i]);
     bufferInfos.at(i).buffer = vkBuffer->getBuffer();
     bufferInfos.at(i).offset = 0;
@@ -67,13 +64,13 @@ void VulkanDescriptorSet::write(uint32_t binding,
         VulkanMapping::getDescriptorType(type), nullptr, bufferInfos.data());
 }
 
-void VulkanDescriptorSet::write(uint32_t binding,
+void VulkanDescriptorSet::write(u32 binding,
                                 std::span<DescriptorBufferInfo> bufferInfos,
-                                DescriptorType type, uint32_t start) {
+                                DescriptorType type, u32 start) {
   std::vector<VkDescriptorBufferInfo> vkBufferInfos(bufferInfos.size(),
                                                     VkDescriptorBufferInfo{});
 
-  for (size_t i = 0; i < bufferInfos.size(); ++i) {
+  for (usize i = 0; i < bufferInfos.size(); ++i) {
     const auto &vkBuffer = mRegistry.getBuffers().at(bufferInfos[i].buffer);
     vkBufferInfos.at(i).buffer = vkBuffer->getBuffer();
     vkBufferInfos.at(i).offset = bufferInfos[i].offset;
@@ -84,8 +81,8 @@ void VulkanDescriptorSet::write(uint32_t binding,
         VulkanMapping::getDescriptorType(type), nullptr, vkBufferInfos.data());
 }
 
-void VulkanDescriptorSet::write(uint32_t binding, uint32_t start,
-                                size_t descriptorCount, VkDescriptorType type,
+void VulkanDescriptorSet::write(u32 binding, u32 start, usize descriptorCount,
+                                VkDescriptorType type,
                                 const VkDescriptorImageInfo *imageInfos,
                                 VkDescriptorBufferInfo *bufferInfos) {
   VkWriteDescriptorSet write{};
@@ -93,7 +90,7 @@ void VulkanDescriptorSet::write(uint32_t binding, uint32_t start,
   write.pNext = nullptr;
   write.dstBinding = binding;
   write.dstSet = mDescriptorSet;
-  write.descriptorCount = static_cast<uint32_t>(descriptorCount);
+  write.descriptorCount = static_cast<u32>(descriptorCount);
   write.dstArrayElement = start;
   write.pBufferInfo = bufferInfos;
   write.pImageInfo = imageInfos;

--- a/engine/rhi/vulkan/src/VulkanDeviceObject.cpp
+++ b/engine/rhi/vulkan/src/VulkanDeviceObject.cpp
@@ -28,7 +28,7 @@ static void assertFeature(VkBool32 featureFlag, String name) {
 VulkanDeviceObject::VulkanDeviceObject(
     const VulkanPhysicalDevice &physicalDevice)
     : mPhysicalDevice(physicalDevice) {
-  float queuePriority = 1.0f;
+  f32 queuePriority = 1.0f;
   VkDeviceQueueCreateInfo createGraphicsQueueInfo{};
   createGraphicsQueueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
   createGraphicsQueueInfo.flags = 0;
@@ -133,13 +133,11 @@ VulkanDeviceObject::VulkanDeviceObject(
   createDeviceInfo.pNext = &deviceFeatures;
   createDeviceInfo.flags = 0;
   createDeviceInfo.pQueueCreateInfos = queueInfos.data();
-  createDeviceInfo.queueCreateInfoCount =
-      static_cast<uint32_t>(queueInfos.size());
+  createDeviceInfo.queueCreateInfoCount = static_cast<u32>(queueInfos.size());
   createDeviceInfo.pEnabledFeatures = nullptr;
   createDeviceInfo.enabledLayerCount = 0;
   createDeviceInfo.ppEnabledLayerNames = nullptr;
-  createDeviceInfo.enabledExtensionCount =
-      static_cast<uint32_t>(extensions.size());
+  createDeviceInfo.enabledExtensionCount = static_cast<u32>(extensions.size());
   createDeviceInfo.ppEnabledExtensionNames = extensions.data();
 
   checkForVulkanError(
@@ -204,7 +202,7 @@ void VulkanDeviceObject::setObjectName(const String &name, VkObjectType type,
   nameInfo.pNext = nullptr;
   nameInfo.pObjectName = objectName.c_str();
   nameInfo.objectType = type;
-  nameInfo.objectHandle = reinterpret_cast<uint64_t &>(handle);
+  nameInfo.objectHandle = reinterpret_cast<u64 &>(handle);
 
   vkSetDebugUtilsObjectNameEXT(mDevice, &nameInfo);
 }

--- a/engine/rhi/vulkan/src/VulkanFrameManager.cpp
+++ b/engine/rhi/vulkan/src/VulkanFrameManager.cpp
@@ -14,7 +14,7 @@ VulkanFrameManager::VulkanFrameManager(VulkanDeviceObject &device)
 }
 
 VulkanFrameManager::~VulkanFrameManager() {
-  for (uint32_t i = 0; i < RenderDevice::NumFrames; ++i) {
+  for (u32 i = 0; i < RenderDevice::NumFrames; ++i) {
     if (mFrameFences.at(i)) {
       vkDestroyFence(mDevice, mFrameFences.at(i), nullptr);
       mFrameFences.at(i) = VK_NULL_HANDLE;
@@ -22,7 +22,7 @@ VulkanFrameManager::~VulkanFrameManager() {
   }
   LOG_DEBUG_VK_NO_HANDLE("Frame fences destroyed: " << mFrameFences.size());
 
-  for (uint32_t i = 0; i < RenderDevice::NumFrames; ++i) {
+  for (u32 i = 0; i < RenderDevice::NumFrames; ++i) {
     if (mImageAvailableSemaphores.at(i)) {
       vkDestroySemaphore(mDevice, mImageAvailableSemaphores.at(i), nullptr);
       mImageAvailableSemaphores.at(i) = VK_NULL_HANDLE;
@@ -45,7 +45,7 @@ void VulkanFrameManager::nextFrame() {
 
 void VulkanFrameManager::waitForFrame() {
   vkWaitForFences(mDevice, 1, &mFrameFences.at(mFrameIndex), true,
-                  std::numeric_limits<uint32_t>::max());
+                  std::numeric_limits<u32>::max());
   vkResetFences(mDevice, 1, &mFrameFences.at(mFrameIndex));
 }
 
@@ -55,7 +55,7 @@ void VulkanFrameManager::createSemaphores() {
   semaphoreInfo.pNext = nullptr;
   semaphoreInfo.flags = 0;
 
-  for (uint32_t i = 0; i < RenderDevice::NumFrames; ++i) {
+  for (u32 i = 0; i < RenderDevice::NumFrames; ++i) {
     checkForVulkanError(vkCreateSemaphore(mDevice, &semaphoreInfo, nullptr,
                                           &mImageAvailableSemaphores.at(i)),
                         "Failed to create image available semaphore");
@@ -77,7 +77,7 @@ void VulkanFrameManager::createFences() {
   fenceInfo.pNext = nullptr;
   fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
-  for (uint32_t i = 0; i < RenderDevice::NumFrames; ++i) {
+  for (u32 i = 0; i < RenderDevice::NumFrames; ++i) {
     checkForVulkanError(
         vkCreateFence(mDevice, &fenceInfo, nullptr, &mFrameFences.at(i)),
         "Failed to create render fence");

--- a/engine/rhi/vulkan/src/VulkanFramebuffer.cpp
+++ b/engine/rhi/vulkan/src/VulkanFramebuffer.cpp
@@ -14,7 +14,7 @@ VulkanFramebuffer::VulkanFramebuffer(const FramebufferDescription &description,
   std::vector<VkImageView> attachments(description.attachments.size(),
                                        VK_NULL_HANDLE);
 
-  for (size_t i = 0; i < attachments.size(); ++i) {
+  for (usize i = 0; i < attachments.size(); ++i) {
     attachments.at(i) = registry.getTextures()
                             .at(description.attachments.at(i))
                             ->getImageView();
@@ -25,7 +25,7 @@ VulkanFramebuffer::VulkanFramebuffer(const FramebufferDescription &description,
   createInfo.flags = 0;
   createInfo.pNext = nullptr;
   createInfo.pAttachments = attachments.data();
-  createInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
+  createInfo.attachmentCount = static_cast<u32>(attachments.size());
   createInfo.renderPass =
       registry.getRenderPasses().at(description.renderPass)->getRenderPass();
   createInfo.width = description.width;

--- a/engine/rhi/vulkan/src/VulkanPhysicalDevice.cpp
+++ b/engine/rhi/vulkan/src/VulkanPhysicalDevice.cpp
@@ -6,7 +6,7 @@ namespace quoll::rhi {
 std::vector<VulkanPhysicalDevice>
 VulkanPhysicalDevice::getPhysicalDevices(VkInstance instance,
                                          VkSurfaceKHR surface) {
-  uint32_t deviceCount = 0;
+  u32 deviceCount = 0;
   vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
   std::vector<VkPhysicalDevice> rawDevices(deviceCount);
   vkEnumeratePhysicalDevices(instance, &deviceCount, rawDevices.data());
@@ -52,7 +52,7 @@ bool VulkanPhysicalDevice::supportsSwapchain() const {
 
 const std::vector<VkExtensionProperties>
 VulkanPhysicalDevice::getSupportedExtensions() const {
-  uint32_t extensionCount = 0;
+  u32 extensionCount = 0;
   vkEnumerateDeviceExtensionProperties(mDevice, nullptr, &extensionCount,
                                        nullptr);
 
@@ -73,7 +73,7 @@ const VkSurfaceCapabilitiesKHR VulkanPhysicalDevice::getSurfaceCapabilities(
 
 const std::vector<VkSurfaceFormatKHR>
 VulkanPhysicalDevice::getSurfaceFormats(const VkSurfaceKHR &surface) const {
-  uint32_t surfaceFormatsCount = 0;
+  u32 surfaceFormatsCount = 0;
   vkGetPhysicalDeviceSurfaceFormatsKHR(mDevice, surface, &surfaceFormatsCount,
                                        nullptr);
   std::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatsCount);
@@ -85,7 +85,7 @@ VulkanPhysicalDevice::getSurfaceFormats(const VkSurfaceKHR &surface) const {
 
 const std::vector<VkPresentModeKHR>
 VulkanPhysicalDevice::getPresentModes(const VkSurfaceKHR &surface) const {
-  uint32_t presentModesCount = 0;
+  u32 presentModesCount = 0;
   vkGetPhysicalDeviceSurfacePresentModesKHR(mDevice, surface,
                                             &presentModesCount, nullptr);
   std::vector<VkPresentModeKHR> presentModes(presentModesCount);

--- a/engine/rhi/vulkan/src/VulkanPipeline.cpp
+++ b/engine/rhi/vulkan/src/VulkanPipeline.cpp
@@ -23,7 +23,7 @@ VulkanPipeline::VulkanPipeline(const GraphicsPipelineDescription &description,
   };
 
   std::array<VkPipelineShaderStageCreateInfo, 2> stages{};
-  for (size_t i = 0; i < 2; ++i) {
+  for (usize i = 0; i < 2; ++i) {
     stages.at(i).sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stages.at(i).pName = "main";
     stages.at(i).module = shaders.at(i)->getShaderModule();
@@ -40,7 +40,7 @@ VulkanPipeline::VulkanPipeline(const GraphicsPipelineDescription &description,
   dynamicState.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
   dynamicState.flags = 0;
   dynamicState.pNext = nullptr;
-  dynamicState.dynamicStateCount = static_cast<uint32_t>(dynamicStates.size());
+  dynamicState.dynamicStateCount = static_cast<u32>(dynamicStates.size());
   dynamicState.pDynamicStates = dynamicStates.data();
 
   // Viewport
@@ -134,7 +134,7 @@ VulkanPipeline::VulkanPipeline(const GraphicsPipelineDescription &description,
       description.colorBlend.attachments.size(),
       VkPipelineColorBlendAttachmentState{});
 
-  for (size_t i = 0; i < description.colorBlend.attachments.size(); ++i) {
+  for (usize i = 0; i < description.colorBlend.attachments.size(); ++i) {
     const auto &src = description.colorBlend.attachments.at(i);
     auto &dst = colorBlendAttachments.at(i);
 
@@ -155,7 +155,7 @@ VulkanPipeline::VulkanPipeline(const GraphicsPipelineDescription &description,
   colorBlending.pNext = nullptr;
   colorBlending.flags = 0;
   colorBlending.attachmentCount =
-      static_cast<uint32_t>(colorBlendAttachments.size());
+      static_cast<u32>(colorBlendAttachments.size());
   colorBlending.pAttachments = colorBlendAttachments.data();
   colorBlending.logicOpEnable = false;
   colorBlending.logicOp = VK_LOGIC_OP_COPY;
@@ -172,10 +172,10 @@ VulkanPipeline::VulkanPipeline(const GraphicsPipelineDescription &description,
 
   // Vertex Input Bindings
   vertexInput.vertexBindingDescriptionCount =
-      static_cast<uint32_t>(description.inputLayout.bindings.size());
+      static_cast<u32>(description.inputLayout.bindings.size());
   std::vector<VkVertexInputBindingDescription> vertexInputBindings(
       description.inputLayout.bindings.size());
-  for (size_t i = 0; i < description.inputLayout.bindings.size(); ++i) {
+  for (usize i = 0; i < description.inputLayout.bindings.size(); ++i) {
     vertexInputBindings.at(i) = VkVertexInputBindingDescription{
         description.inputLayout.bindings.at(i).binding,
         description.inputLayout.bindings.at(i).stride,
@@ -185,11 +185,11 @@ VulkanPipeline::VulkanPipeline(const GraphicsPipelineDescription &description,
   vertexInput.pVertexBindingDescriptions = vertexInputBindings.data();
 
   vertexInput.vertexAttributeDescriptionCount =
-      static_cast<uint32_t>(description.inputLayout.attributes.size());
+      static_cast<u32>(description.inputLayout.attributes.size());
   std::vector<VkVertexInputAttributeDescription> vertexInputDescriptions(
       description.inputLayout.attributes.size());
 
-  for (size_t i = 0; i < description.inputLayout.attributes.size(); ++i) {
+  for (usize i = 0; i < description.inputLayout.attributes.size(); ++i) {
     vertexInputDescriptions.at(i) = VkVertexInputAttributeDescription{
         description.inputLayout.attributes.at(i).slot,
         description.inputLayout.attributes.at(i).binding,
@@ -212,7 +212,7 @@ VulkanPipeline::VulkanPipeline(const GraphicsPipelineDescription &description,
   pipelineInfo.renderPass = pass->getRenderPass();
   pipelineInfo.subpass = 0;
   pipelineInfo.layout = mPipelineLayout;
-  pipelineInfo.stageCount = static_cast<uint32_t>(stages.size());
+  pipelineInfo.stageCount = static_cast<u32>(stages.size());
   pipelineInfo.pStages = stages.data();
   pipelineInfo.pVertexInputState = &vertexInput;
   pipelineInfo.pInputAssemblyState = &inputAssembly;
@@ -291,7 +291,7 @@ void VulkanPipeline::createLayout(
     VulkanPipelineLayoutCache &pipelineLayoutCache) {
 
   // Pipeline Layout
-  std::map<uint32_t, VkDescriptorSetLayout> descriptorLayoutsMap;
+  std::map<u32, VkDescriptorSetLayout> descriptorLayoutsMap;
   std::vector<VkDescriptorSetLayout> descriptorLayoutsRaw;
   std::vector<VkPushConstantRange> pushConstantRanges;
 
@@ -322,10 +322,10 @@ void VulkanPipeline::createLayout(
   pipelineLayoutCreateInfo.flags = 0;
   pipelineLayoutCreateInfo.pNext = nullptr;
   pipelineLayoutCreateInfo.setLayoutCount =
-      static_cast<uint32_t>(mDescriptorLayouts.size());
+      static_cast<u32>(mDescriptorLayouts.size());
   pipelineLayoutCreateInfo.pSetLayouts = descriptorLayoutsRaw.data();
   pipelineLayoutCreateInfo.pushConstantRangeCount =
-      static_cast<uint32_t>(pushConstantRanges.size());
+      static_cast<u32>(pushConstantRanges.size());
   pipelineLayoutCreateInfo.pPushConstantRanges = pushConstantRanges.data();
 
   checkForVulkanError(vkCreatePipelineLayout(mDevice, &pipelineLayoutCreateInfo,

--- a/engine/rhi/vulkan/src/VulkanPipelineLayoutCache.cpp
+++ b/engine/rhi/vulkan/src/VulkanPipelineLayoutCache.cpp
@@ -43,14 +43,14 @@ VulkanPipelineLayoutCache::~VulkanPipelineLayoutCache() {
 
 DescriptorLayoutHandle VulkanPipelineLayoutCache::getOrCreateDescriptorLayout(
     const DescriptorLayoutDescription &description) {
-  for (size_t i = 0; i < mDescriptorLayoutDescriptions.size(); ++i) {
+  for (usize i = 0; i < mDescriptorLayoutDescriptions.size(); ++i) {
     const auto &existing = mDescriptorLayoutDescriptions.at(i);
     if (existing.bindings.size() != description.bindings.size()) {
       continue;
     }
 
     bool matches = true;
-    for (size_t li = 0; li < description.bindings.size() && matches; ++li) {
+    for (usize li = 0; li < description.bindings.size() && matches; ++li) {
       matches =
           bindingsMatch(description.bindings.at(li), existing.bindings.at(li));
     }
@@ -82,7 +82,7 @@ VkDescriptorSetLayout VulkanPipelineLayoutCache::createDescriptorLayout(
   std::vector<VkDescriptorSetLayoutBinding> vkBindings(
       description.bindings.size(), VkDescriptorSetLayoutBinding{});
 
-  for (size_t i = 0; i < description.bindings.size(); ++i) {
+  for (usize i = 0; i < description.bindings.size(); ++i) {
     auto &binding = description.bindings.at(i);
 
     if (binding.type == DescriptorLayoutBindingType::Dynamic) {
@@ -104,15 +104,14 @@ VkDescriptorSetLayout VulkanPipelineLayoutCache::createDescriptorLayout(
       VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT;
   bindingFlagsCreateInfo.pNext = nullptr;
   bindingFlagsCreateInfo.pBindingFlags = vkBindingFlags.data();
-  bindingFlagsCreateInfo.bindingCount =
-      static_cast<uint32_t>(vkBindingFlags.size());
+  bindingFlagsCreateInfo.bindingCount = static_cast<u32>(vkBindingFlags.size());
 
   VkDescriptorSetLayout layout = VK_NULL_HANDLE;
   VkDescriptorSetLayoutCreateInfo createInfo{};
   createInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
   createInfo.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
   createInfo.pNext = &bindingFlagsCreateInfo;
-  createInfo.bindingCount = static_cast<uint32_t>(vkBindings.size());
+  createInfo.bindingCount = static_cast<u32>(vkBindings.size());
   createInfo.pBindings = vkBindings.data();
 
   checkForVulkanError(

--- a/engine/rhi/vulkan/src/VulkanQueue.cpp
+++ b/engine/rhi/vulkan/src/VulkanQueue.cpp
@@ -5,7 +5,7 @@
 
 namespace quoll::rhi {
 
-VulkanQueue::VulkanQueue(VulkanDeviceObject &device, uint32_t queueIndex)
+VulkanQueue::VulkanQueue(VulkanDeviceObject &device, u32 queueIndex)
     : mQueueIndex(queueIndex) {
   vkGetDeviceQueue(device, mQueueIndex, 0, &mQueue);
 }
@@ -20,13 +20,13 @@ void VulkanQueue::submit(
   submitInfo.pNext = nullptr;
   submitInfo.flags = 0;
   submitInfo.commandBufferInfoCount =
-      static_cast<uint32_t>(commandBufferInfos.size());
+      static_cast<u32>(commandBufferInfos.size());
   submitInfo.pCommandBufferInfos = commandBufferInfos.data();
   submitInfo.waitSemaphoreInfoCount =
-      static_cast<uint32_t>(waitSemaphoreInfos.size());
+      static_cast<u32>(waitSemaphoreInfos.size());
   submitInfo.pWaitSemaphoreInfos = waitSemaphoreInfos.data();
   submitInfo.signalSemaphoreInfoCount =
-      static_cast<uint32_t>(signalSemaphoreInfos.size());
+      static_cast<u32>(signalSemaphoreInfos.size());
   submitInfo.pSignalSemaphoreInfos = signalSemaphoreInfos.data();
 
   checkForVulkanError(vkQueueSubmit2KHR(mQueue, 1, &submitInfo, fence),

--- a/engine/rhi/vulkan/src/VulkanQueueFamily.cpp
+++ b/engine/rhi/vulkan/src/VulkanQueueFamily.cpp
@@ -6,14 +6,14 @@ namespace quoll::rhi {
 
 VulkanQueueFamily::VulkanQueueFamily(VkPhysicalDevice device,
                                      VkSurfaceKHR surface) {
-  uint32_t queueFamilyCount = 0;
+  u32 queueFamilyCount = 0;
   vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
 
   std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
   vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount,
                                            queueFamilies.data());
 
-  for (uint32_t i = 0; i < queueFamilies.size(); ++i) {
+  for (u32 i = 0; i < queueFamilies.size(); ++i) {
     if (queueFamilies.at(i).queueFlags & VK_QUEUE_GRAPHICS_BIT) {
       mGraphicsFamily = i;
     }

--- a/engine/rhi/vulkan/src/VulkanRenderBackend.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderBackend.cpp
@@ -87,7 +87,7 @@ void VulkanRenderBackend::createInstance(StringView applicationName,
   }
 
   createInstanceInfo.enabledExtensionCount =
-      static_cast<uint32_t>(extensions.size());
+      static_cast<u32>(extensions.size());
   createInstanceInfo.ppEnabledExtensionNames = extensions.data();
 
   checkForVulkanError(

--- a/engine/rhi/vulkan/src/VulkanRenderContext.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderContext.cpp
@@ -20,7 +20,7 @@ VulkanRenderContext::VulkanRenderContext(VulkanDeviceObject &device,
 
 VkResult VulkanRenderContext::present(VulkanFrameManager &frameManager,
                                       const VulkanSwapchain &swapchain,
-                                      uint32_t imageIdx) {
+                                      u32 imageIdx) {
   QUOLL_PROFILE_EVENT("VulkanRenderContext::present");
   std::array<VkSemaphore, 1> waitSemaphores{
       frameManager.getRenderFinishedSemaphore()};
@@ -28,9 +28,9 @@ VkResult VulkanRenderContext::present(VulkanFrameManager &frameManager,
   VkPresentInfoKHR presentInfo{};
 
   presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-  presentInfo.waitSemaphoreCount = static_cast<uint32_t>(waitSemaphores.size());
+  presentInfo.waitSemaphoreCount = static_cast<u32>(waitSemaphores.size());
   presentInfo.pWaitSemaphores = waitSemaphores.data();
-  presentInfo.swapchainCount = static_cast<uint32_t>(swapchains.size());
+  presentInfo.swapchainCount = static_cast<u32>(swapchains.size());
   presentInfo.pSwapchains = swapchains.data();
   presentInfo.pImageIndices = &imageIdx;
   presentInfo.pResults = nullptr;

--- a/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderDevice.cpp
@@ -40,7 +40,7 @@ VulkanRenderDevice::VulkanRenderDevice(
   VkDevice device = mDevice.getVulkanHandle();
   VkPhysicalDevice physicalDeviceHandle = mPhysicalDevice.getVulkanHandle();
   VkQueue graphicsQueue = mGraphicsQueue.getVulkanHandle();
-  uint32_t queueIndex = mGraphicsQueue.getQueueIndex();
+  u32 queueIndex = mGraphicsQueue.getQueueIndex();
 
   QUOLL_PROFILE_GPU_INIT_VULKAN(&device, &physicalDeviceHandle, &graphicsQueue,
                                 &queueIndex, 1, nullptr);
@@ -85,7 +85,7 @@ void VulkanRenderDevice::submitImmediate(RenderCommandList &commandList) {
 }
 
 RenderFrame VulkanRenderDevice::beginFrame() {
-  static constexpr auto SkipFrame = std::numeric_limits<uint32_t>::max();
+  static constexpr auto SkipFrame = std::numeric_limits<u32>::max();
   static RenderCommandList emptyCommandList;
 
   QUOLL_PROFILE_EVENT("VulkanRenderDevice::beginFrame");
@@ -93,10 +93,10 @@ RenderFrame VulkanRenderDevice::beginFrame() {
   mStats.resetCalls();
   mFrameManager.waitForFrame();
 
-  uint32_t imageIndex =
+  u32 imageIndex =
       mSwapchain.acquireNextImage(mFrameManager.getImageAvailableSemaphore());
 
-  if (imageIndex == std::numeric_limits<uint32_t>::max()) {
+  if (imageIndex == std::numeric_limits<u32>::max()) {
     recreateSwapchain();
     return {SkipFrame, SkipFrame, emptyCommandList};
   }

--- a/engine/rhi/vulkan/src/VulkanRenderPass.cpp
+++ b/engine/rhi/vulkan/src/VulkanRenderPass.cpp
@@ -14,12 +14,12 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
                                    const VulkanResourceRegistry &registry)
     : mDevice(device) {
 
-  size_t numDepthAttachments = description.depthAttachment.has_value() ? 1 : 0;
-  size_t numResolveAttachments =
+  usize numDepthAttachments = description.depthAttachment.has_value() ? 1 : 0;
+  usize numResolveAttachments =
       description.resolveAttachment.has_value() ? 1 : 0;
 
-  size_t numAttachments = description.colorAttachments.size() +
-                          numDepthAttachments + numResolveAttachments;
+  usize numAttachments = description.colorAttachments.size() +
+                         numDepthAttachments + numResolveAttachments;
 
   std::vector<VkAttachmentDescription> attachments;
   attachments.reserve(numAttachments);
@@ -29,7 +29,7 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
   std::optional<VkAttachmentReference> depthReference;
   std::optional<VkAttachmentReference> resolveReference;
 
-  for (size_t i = 0; i < description.colorAttachments.size(); ++i) {
+  for (usize i = 0; i < description.colorAttachments.size(); ++i) {
     auto &desc = description.colorAttachments.at(i);
     const auto &texture = registry.getTextures().at(desc.texture);
 
@@ -45,7 +45,7 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
     attachments.push_back(attachment);
 
     VkAttachmentReference ref;
-    ref.attachment = static_cast<uint32_t>(attachments.size() - 1);
+    ref.attachment = static_cast<u32>(attachments.size() - 1);
     ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     colorReferences.push_back(ref);
 
@@ -73,7 +73,7 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
     attachments.push_back(attachment);
 
     VkAttachmentReference ref;
-    ref.attachment = static_cast<uint32_t>(attachments.size() - 1);
+    ref.attachment = static_cast<u32>(attachments.size() - 1);
     ref.layout = attachment.finalLayout;
     depthReference.emplace(ref);
 
@@ -98,7 +98,7 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
     attachments.push_back(attachment);
 
     VkAttachmentReference ref;
-    ref.attachment = static_cast<uint32_t>(attachments.size() - 1);
+    ref.attachment = static_cast<u32>(attachments.size() - 1);
     ref.layout = attachment.finalLayout;
     resolveReference.emplace(ref);
 
@@ -112,7 +112,7 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
 
   VkSubpassDescription subpass{};
   subpass.flags = 0;
-  subpass.colorAttachmentCount = static_cast<uint32_t>(colorReferences.size());
+  subpass.colorAttachmentCount = static_cast<u32>(colorReferences.size());
   subpass.pColorAttachments = colorReferences.data();
   subpass.pDepthStencilAttachment =
       depthReference.has_value() ? &depthReference.value() : nullptr;
@@ -129,7 +129,7 @@ VulkanRenderPass::VulkanRenderPass(const RenderPassDescription &description,
   createInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
   createInfo.flags = 0;
   createInfo.pNext = nullptr;
-  createInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
+  createInfo.attachmentCount = static_cast<u32>(attachments.size());
   createInfo.pAttachments = attachments.data();
   createInfo.subpassCount = 1;
   createInfo.pSubpasses = &subpass;

--- a/engine/rhi/vulkan/src/VulkanResourceMetrics.cpp
+++ b/engine/rhi/vulkan/src/VulkanResourceMetrics.cpp
@@ -9,8 +9,8 @@ VulkanResourceMetrics::VulkanResourceMetrics(
     VulkanResourceRegistry &registry, VulkanDescriptorPool &descriptorPool)
     : mRegistry(registry), mDescriptorPool(descriptorPool) {}
 
-size_t VulkanResourceMetrics::getTotalBufferSize() const {
-  size_t size = 0;
+usize VulkanResourceMetrics::getTotalBufferSize() const {
+  usize size = 0;
 
   for (auto &[_, buffer] : mRegistry.getBuffers()) {
     size += buffer->getSize();
@@ -19,15 +19,15 @@ size_t VulkanResourceMetrics::getTotalBufferSize() const {
   return size;
 }
 
-size_t VulkanResourceMetrics::getBuffersCount() const {
+usize VulkanResourceMetrics::getBuffersCount() const {
   return mRegistry.getBuffers().size();
 }
 
-size_t VulkanResourceMetrics::getTexturesCount() const {
+usize VulkanResourceMetrics::getTexturesCount() const {
   return mRegistry.getTextures().size();
 }
 
-size_t VulkanResourceMetrics::getDescriptorsCount() const {
+usize VulkanResourceMetrics::getDescriptorsCount() const {
   return mDescriptorPool.getDescriptorsCount();
 }
 

--- a/engine/rhi/vulkan/src/VulkanShader.cpp
+++ b/engine/rhi/vulkan/src/VulkanShader.cpp
@@ -21,7 +21,7 @@ VulkanShader::VulkanShader(const ShaderDescription &description,
   createInfo.pNext = nullptr;
 
   createInfo.codeSize = shaderBytes.size();
-  createInfo.pCode = reinterpret_cast<const uint32_t *>(shaderBytes.data());
+  createInfo.pCode = reinterpret_cast<const u32 *>(shaderBytes.data());
 
   checkForVulkanError(
       vkCreateShaderModule(device, &createInfo, nullptr, &mShaderModule),
@@ -81,7 +81,7 @@ void VulkanShader::createReflectionInfo(const std::vector<char> &bytes) {
 
   // Push constants
   {
-    uint32_t count = 0;
+    u32 count = 0;
     spvReflectEnumeratePushConstantBlocks(&shaderReflectModule, &count,
                                           nullptr);
 
@@ -106,7 +106,7 @@ void VulkanShader::createReflectionInfo(const std::vector<char> &bytes) {
 
   // Descriptor layouts
   {
-    uint32_t count = 0;
+    u32 count = 0;
     spvReflectEnumerateDescriptorSets(&shaderReflectModule, &count, nullptr);
 
     if (count > 0) {
@@ -119,9 +119,9 @@ void VulkanShader::createReflectionInfo(const std::vector<char> &bytes) {
 
         DescriptorLayoutDescription description{};
 
-        std::map<uint32_t, DescriptorLayoutBindingDescription> bindingsMap;
+        std::map<u32, DescriptorLayoutBindingDescription> bindingsMap;
 
-        for (uint32_t i = 0; i < reflectDescriptorSet.binding_count; ++i) {
+        for (u32 i = 0; i < reflectDescriptorSet.binding_count; ++i) {
           // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
 
           auto *reflectBinding = reflectDescriptorSet.bindings[i];
@@ -140,7 +140,7 @@ void VulkanShader::createReflectionInfo(const std::vector<char> &bytes) {
               static_cast<VkDescriptorType>(reflectBinding->descriptor_type));
           layoutBinding.descriptorCount = 1;
 
-          for (uint32_t j = 0; j < reflectBinding->array.dims_count; ++j) {
+          for (u32 j = 0; j < reflectBinding->array.dims_count; ++j) {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
             layoutBinding.descriptorCount *= reflectBinding->array.dims[j];
           }

--- a/engine/rhi/vulkan/src/VulkanSwapchain.cpp
+++ b/engine/rhi/vulkan/src/VulkanSwapchain.cpp
@@ -50,8 +50,8 @@ void VulkanSwapchain::create(VulkanRenderBackend &backend,
       physicalDevice.getPresentModes(backend.getSurface()));
   calculateExtent(surfaceCapabilities, backend.getFramebufferSize());
 
-  uint32_t imageCount = std::min(surfaceCapabilities.minImageCount + 1,
-                                 surfaceCapabilities.maxImageCount);
+  u32 imageCount = std::min(surfaceCapabilities.minImageCount + 1,
+                            surfaceCapabilities.maxImageCount);
 
   bool sameQueueFamily =
       physicalDevice.getQueueFamilyIndices().getGraphicsFamily() ==
@@ -72,7 +72,7 @@ void VulkanSwapchain::create(VulkanRenderBackend &backend,
   if (sameQueueFamily) {
     auto &array = physicalDevice.getQueueFamilyIndices().toArray();
     createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    createInfo.queueFamilyIndexCount = static_cast<uint32_t>(array.size());
+    createInfo.queueFamilyIndexCount = static_cast<u32>(array.size());
     createInfo.pQueueFamilyIndices = array.data();
   } else {
     // TODO: Handle the case where graphics
@@ -96,16 +96,16 @@ void VulkanSwapchain::create(VulkanRenderBackend &backend,
   std::vector<VkImage> images(imageCount, VK_NULL_HANDLE);
   vkGetSwapchainImagesKHR(mDevice, mSwapchain, &imageCount, images.data());
 
-  size_t oldSize = mTextures.size();
+  usize oldSize = mTextures.size();
 
   // Delete old textures
-  for (size_t i = oldSize + 1; i < images.size(); ++i) {
+  for (usize i = oldSize + 1; i < images.size(); ++i) {
     mRegistry.deleteTexture(static_cast<TextureHandle>(i));
   }
 
   mTextures.resize(images.size());
 
-  for (size_t i = 0; i < mTextures.size(); ++i) {
+  for (usize i = 0; i < mTextures.size(); ++i) {
     VkImage image = images.at(i);
     VkImageView imageView = VK_NULL_HANDLE;
 
@@ -175,12 +175,10 @@ void VulkanSwapchain::pickMostSuitablePresentMode(
 void VulkanSwapchain::calculateExtent(
     const VkSurfaceCapabilitiesKHR &capabilities, const glm::uvec2 &size) {
 
-  uint32_t width =
-      std::max(capabilities.minImageExtent.width,
-               std::min(capabilities.maxImageExtent.width, size.x));
-  uint32_t height =
-      std::max(capabilities.minImageExtent.height,
-               std::min(capabilities.maxImageExtent.height, size.y));
+  u32 width = std::max(capabilities.minImageExtent.width,
+                       std::min(capabilities.maxImageExtent.width, size.x));
+  u32 height = std::max(capabilities.minImageExtent.height,
+                        std::min(capabilities.maxImageExtent.height, size.y));
 
   mExtent = glm::uvec2{width, height};
 }
@@ -205,16 +203,15 @@ VkCompositeAlphaFlagBitsKHR VulkanSwapchain::getSuitableCompositeAlpha(
   return VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
 }
 
-uint32_t
-VulkanSwapchain::acquireNextImage(VkSemaphore imageAvailableSemaphore) {
+u32 VulkanSwapchain::acquireNextImage(VkSemaphore imageAvailableSemaphore) {
   QUOLL_PROFILE_EVENT("VulkanSwapchain::acquireNextImage");
-  uint32_t imageIndex = 0;
+  u32 imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(
-      mDevice, mSwapchain, std::numeric_limits<uint64_t>::max(),
+      mDevice, mSwapchain, std::numeric_limits<u64>::max(),
       imageAvailableSemaphore, VK_NULL_HANDLE, &imageIndex);
 
   if (result == VK_ERROR_OUT_OF_DATE_KHR) {
-    return std::numeric_limits<uint32_t>::max();
+    return std::numeric_limits<u32>::max();
   }
 
   return imageIndex;

--- a/engine/rhi/vulkan/src/VulkanTexture.cpp
+++ b/engine/rhi/vulkan/src/VulkanTexture.cpp
@@ -35,9 +35,9 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
                   : true,
               "Cubemap must have 6 layers");
 
-  uint32_t imageFlags = description.type == TextureType::Cubemap
-                            ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT
-                            : 0;
+  u32 imageFlags = description.type == TextureType::Cubemap
+                       ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT
+                       : 0;
 
   VkImageViewType imageViewType = VK_IMAGE_VIEW_TYPE_MAX_ENUM;
 
@@ -49,7 +49,7 @@ VulkanTexture::VulkanTexture(const TextureDescription &description,
     imageViewType = VK_IMAGE_VIEW_TYPE_2D;
   }
 
-  static constexpr uint32_t HundredPercent = 100;
+  static constexpr u32 HundredPercent = 100;
 
   VkExtent3D extent{};
   extent.width = description.width;

--- a/engine/rhi/vulkan/src/VulkanUploadContext.cpp
+++ b/engine/rhi/vulkan/src/VulkanUploadContext.cpp
@@ -27,7 +27,7 @@ VulkanUploadContext::~VulkanUploadContext() {
 
 void VulkanUploadContext::submit(const SubmitFn &submitFn) const {
   vkWaitForFences(mDevice, 1, &mUploadFence, true,
-                  std::numeric_limits<uint32_t>::max());
+                  std::numeric_limits<u32>::max());
 
   vkResetFences(mDevice, 1, &mUploadFence);
 
@@ -55,7 +55,7 @@ void VulkanUploadContext::submit(const SubmitFn &submitFn) const {
   vkQueueSubmit(mQueue, 1, &submitInfo, mUploadFence);
 
   vkWaitForFences(mDevice, 1, &mUploadFence, true,
-                  std::numeric_limits<uint32_t>::max());
+                  std::numeric_limits<u32>::max());
 
   vkResetCommandBuffer(commandBuffer, 0);
 }

--- a/engine/rhi/vulkan/src/VulkanValidator.cpp
+++ b/engine/rhi/vulkan/src/VulkanValidator.cpp
@@ -34,8 +34,7 @@ void VulkanValidator::attachToInstanceCreateConfig(
   createInfo.pNext =
       (VkDebugUtilsMessengerCreateInfoEXT *)&mMessengerCreateInfo;
   createInfo.ppEnabledLayerNames = mValidationLayers.data();
-  createInfo.enabledLayerCount =
-      static_cast<uint32_t>(mValidationLayers.size());
+  createInfo.enabledLayerCount = static_cast<u32>(mValidationLayers.size());
 }
 
 void VulkanValidator::attachToInstance(VkInstance instance) {
@@ -84,7 +83,7 @@ static String getValidationMessage(
   ss << newStr;
   ss << "\n\t"
      << "Message ID: " << pCallbackData->pMessageIdName;
-  for (uint32_t i = 0; i < pCallbackData->objectCount; ++i) {
+  for (u32 i = 0; i < pCallbackData->objectCount; ++i) {
     const char *name = pCallbackData->pObjects[i].pObjectName;
     ss << "\n\t"
        << "Object: " << (name ? name : "[no name]");
@@ -111,7 +110,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanValidator::debugCallback(
 }
 
 bool VulkanValidator::checkValidationSupport() {
-  uint32_t layerCount = 0;
+  u32 layerCount = 0;
   vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
 
   std::vector<VkLayerProperties> availableLayers(layerCount);

--- a/engine/src/quoll/animation/AnimationSystem.cpp
+++ b/engine/src/quoll/animation/AnimationSystem.cpp
@@ -6,7 +6,7 @@ namespace quoll {
 AnimationSystem::AnimationSystem(AssetRegistry &assetRegistry)
     : mAssetRegistry(assetRegistry) {}
 
-void AnimationSystem::update(float dt, EntityDatabase &entityDatabase) {
+void AnimationSystem::update(f32 dt, EntityDatabase &entityDatabase) {
   QUOLL_PROFILE_EVENT("AnimationSystem::update");
   const auto &animMap = mAssetRegistry.getAnimations();
 

--- a/engine/src/quoll/animation/AnimationSystem.h
+++ b/engine/src/quoll/animation/AnimationSystem.h
@@ -24,7 +24,7 @@ public:
    * @param dt Time delta
    * @param entityDatabase Entity database
    */
-  void update(float dt, EntityDatabase &entityDatabase);
+  void update(f32 dt, EntityDatabase &entityDatabase);
 
 private:
   AssetRegistry &mAssetRegistry;

--- a/engine/src/quoll/animation/Animator.h
+++ b/engine/src/quoll/animation/Animator.h
@@ -16,14 +16,14 @@ struct Animator {
   /**
    * Current animator state
    */
-  size_t currentState = std::numeric_limits<size_t>::max();
+  usize currentState = std::numeric_limits<usize>::max();
 
   /**
    * Normalized time
    *
    * Range: [0.0, 1.0];
    */
-  float normalizedTime = 0.0f;
+  f32 normalizedTime = 0.0f;
 
   /**
    * Animation is playing

--- a/engine/src/quoll/animation/KeyframeInterpolator.cpp
+++ b/engine/src/quoll/animation/KeyframeInterpolator.cpp
@@ -31,7 +31,7 @@ template <> glm::quat convertVec4(const glm::vec4 &value) {
  * @param k Interpolation constant
  * @return Interpolated value
  */
-template <class T> T interpolateLinear(const T &a, const T &b, float k) {
+template <class T> T interpolateLinear(const T &a, const T &b, f32 k) {
   return a + k * (b - a);
 }
 
@@ -46,7 +46,7 @@ template <class T> T interpolateLinear(const T &a, const T &b, float k) {
  * @return Interpolated value
  */
 template <>
-glm::quat interpolateLinear(const glm::quat &a, const glm::quat &b, float k) {
+glm::quat interpolateLinear(const glm::quat &a, const glm::quat &b, f32 k) {
   return glm::normalize(glm::slerp(a, b, k));
 }
 
@@ -59,10 +59,10 @@ glm::quat interpolateLinear(const glm::quat &a, const glm::quat &b, float k) {
  * @return Step interpolated value
  */
 template <class T>
-T getStepValue(const KeyframeSequenceAsset &sequence, float time) {
-  size_t found = 0;
+T getStepValue(const KeyframeSequenceAsset &sequence, f32 time) {
+  usize found = 0;
 
-  for (size_t i = 0; i < sequence.keyframeTimes.size(); ++i) {
+  for (usize i = 0; i < sequence.keyframeTimes.size(); ++i) {
     if (time < sequence.keyframeTimes.at(i)) {
       break;
     }
@@ -82,10 +82,10 @@ T getStepValue(const KeyframeSequenceAsset &sequence, float time) {
  * @return Linear interpolated value
  */
 template <class T>
-const T getLinearValue(const KeyframeSequenceAsset &sequence, float time) {
-  size_t found = 0;
+const T getLinearValue(const KeyframeSequenceAsset &sequence, f32 time) {
+  usize found = 0;
 
-  for (size_t i = 0; i < sequence.keyframeTimes.size(); ++i) {
+  for (usize i = 0; i < sequence.keyframeTimes.size(); ++i) {
     if (time < sequence.keyframeTimes.at(i)) {
       break;
     }
@@ -103,7 +103,7 @@ const T getLinearValue(const KeyframeSequenceAsset &sequence, float time) {
   const auto &currentTime = sequence.keyframeTimes.at(found);
   const auto &nextTime = sequence.keyframeTimes.at(found + 1);
 
-  float k = (time - currentTime) / (nextTime - currentTime);
+  f32 k = (time - currentTime) / (nextTime - currentTime);
 
   return interpolateLinear(currentVal, nextVal, k);
 }
@@ -117,7 +117,7 @@ const T getLinearValue(const KeyframeSequenceAsset &sequence, float time) {
  * @return Interpolated value
  */
 template <class T>
-T interpolate(const KeyframeSequenceAsset &sequence, float time) {
+T interpolate(const KeyframeSequenceAsset &sequence, f32 time) {
   if (sequence.interpolation == KeyframeSequenceAssetInterpolation::Step) {
     return getStepValue<T>(sequence, time);
   }
@@ -127,13 +127,13 @@ T interpolate(const KeyframeSequenceAsset &sequence, float time) {
 
 glm::vec3
 KeyframeInterpolator::interpolateVec3(const KeyframeSequenceAsset &sequence,
-                                      float time) {
+                                      f32 time) {
   return interpolate<glm::vec3>(sequence, time);
 }
 
 glm::quat
 KeyframeInterpolator::interpolateQuat(const KeyframeSequenceAsset &sequence,
-                                      float time) {
+                                      f32 time) {
   return interpolate<glm::quat>(sequence, time);
 }
 

--- a/engine/src/quoll/animation/KeyframeInterpolator.h
+++ b/engine/src/quoll/animation/KeyframeInterpolator.h
@@ -17,7 +17,7 @@ public:
    * @return Vec3 value
    */
   static glm::vec3 interpolateVec3(const KeyframeSequenceAsset &sequence,
-                                   float time);
+                                   f32 time);
 
   /**
    * @brief Get quat interpolated value based on keyframe sequence
@@ -27,7 +27,7 @@ public:
    * @return Quat value
    */
   static glm::quat interpolateQuat(const KeyframeSequenceAsset &sequence,
-                                   float time);
+                                   f32 time);
 };
 
 } // namespace quoll

--- a/engine/src/quoll/asset/AnimationAsset.h
+++ b/engine/src/quoll/asset/AnimationAsset.h
@@ -4,9 +4,9 @@
 
 namespace quoll {
 
-enum class KeyframeSequenceAssetTarget : uint8_t { Position, Rotation, Scale };
+enum class KeyframeSequenceAssetTarget : u8 { Position, Rotation, Scale };
 
-enum class KeyframeSequenceAssetInterpolation : uint8_t { Step, Linear };
+enum class KeyframeSequenceAssetInterpolation : u8 { Step, Linear };
 
 /**
  * @brief Keyframe sequence asset
@@ -15,7 +15,7 @@ struct KeyframeSequenceAsset {
   /**
    * List of keyframe times
    */
-  std::vector<float> keyframeTimes;
+  std::vector<f32> keyframeTimes;
 
   /**
    * List of keyframe values
@@ -51,7 +51,7 @@ struct AnimationAsset {
   /**
    * Animation time
    */
-  float time = 0.0f;
+  f32 time = 0.0f;
 
   /**
    * Keyframes

--- a/engine/src/quoll/asset/AnimatorAsset.h
+++ b/engine/src/quoll/asset/AnimatorAsset.h
@@ -14,7 +14,7 @@ struct AnimationStateTransition {
   /**
    * Index to animation state
    */
-  size_t target;
+  usize target;
 };
 
 /**
@@ -53,7 +53,7 @@ struct AnimatorAsset {
   /**
    * Initial state
    */
-  size_t initialState = 0;
+  usize initialState = 0;
 
   /**
    * Animation states

--- a/engine/src/quoll/asset/Asset.h
+++ b/engine/src/quoll/asset/Asset.h
@@ -2,33 +2,33 @@
 
 namespace quoll {
 
-enum class MaterialAssetHandle : uint32_t { Null = 0 };
+enum class MaterialAssetHandle : u32 { Null = 0 };
 
-enum class TextureAssetHandle : uint32_t { Null = 0 };
+enum class TextureAssetHandle : u32 { Null = 0 };
 
-enum class FontAssetHandle : uint32_t { Null = 0 };
+enum class FontAssetHandle : u32 { Null = 0 };
 
-enum class MeshAssetHandle : uint32_t { Null = 0 };
+enum class MeshAssetHandle : u32 { Null = 0 };
 
-enum class SkeletonAssetHandle : uint32_t { Null = 0 };
+enum class SkeletonAssetHandle : u32 { Null = 0 };
 
-enum class AnimationAssetHandle : uint32_t { Null = 0 };
+enum class AnimationAssetHandle : u32 { Null = 0 };
 
-enum class AnimatorAssetHandle : uint32_t { Null = 0 };
+enum class AnimatorAssetHandle : u32 { Null = 0 };
 
-enum class AudioAssetHandle : uint32_t { Null = 0 };
+enum class AudioAssetHandle : u32 { Null = 0 };
 
-enum class PrefabAssetHandle : uint32_t { Null = 0 };
+enum class PrefabAssetHandle : u32 { Null = 0 };
 
-enum class LuaScriptAssetHandle : uint32_t { Null = 0 };
+enum class LuaScriptAssetHandle : u32 { Null = 0 };
 
-enum class EnvironmentAssetHandle : uint32_t { Null = 0 };
+enum class EnvironmentAssetHandle : u32 { Null = 0 };
 
-enum class SceneAssetHandle : uint32_t { Null = 0 };
+enum class SceneAssetHandle : u32 { Null = 0 };
 
-enum class InputMapAssetHandle : uint32_t { Null = 0 };
+enum class InputMapAssetHandle : u32 { Null = 0 };
 
-enum class AssetType : uint8_t {
+enum class AssetType : u8 {
   None,
   Material,
   Texture,

--- a/engine/src/quoll/asset/AssetCacheAnimation.cpp
+++ b/engine/src/quoll/asset/AssetCacheAnimation.cpp
@@ -32,7 +32,7 @@ AssetCache::createAnimationFromAsset(const AssetData<AnimationAsset> &asset) {
   file.write(header);
 
   file.write(asset.data.time);
-  uint32_t numKeyframes = static_cast<uint32_t>(asset.data.keyframes.size());
+  u32 numKeyframes = static_cast<u32>(asset.data.keyframes.size());
   file.write(numKeyframes);
 
   for (auto &keyframe : asset.data.keyframes) {
@@ -41,7 +41,7 @@ AssetCache::createAnimationFromAsset(const AssetData<AnimationAsset> &asset) {
     file.write(keyframe.jointTarget);
     file.write(keyframe.joint);
 
-    uint32_t numValues = static_cast<uint32_t>(keyframe.keyframeTimes.size());
+    u32 numValues = static_cast<u32>(keyframe.keyframeTimes.size());
     file.write(numValues);
     file.write(keyframe.keyframeTimes);
     file.write(keyframe.keyframeValues);
@@ -62,7 +62,7 @@ AssetCache::loadAnimationDataFromInputStream(InputBinaryStream &stream,
   animation.name = header.name;
 
   stream.read(animation.data.time);
-  uint32_t numKeyframes = 0;
+  u32 numKeyframes = 0;
   stream.read(numKeyframes);
   animation.data.keyframes.resize(numKeyframes);
 
@@ -72,7 +72,7 @@ AssetCache::loadAnimationDataFromInputStream(InputBinaryStream &stream,
     stream.read(keyframe.jointTarget);
     stream.read(keyframe.joint);
 
-    uint32_t numValues = 0;
+    u32 numValues = 0;
     stream.read(numValues);
     keyframe.keyframeTimes.resize(numValues);
     keyframe.keyframeValues.resize(numValues);

--- a/engine/src/quoll/asset/AssetCacheAnimator.cpp
+++ b/engine/src/quoll/asset/AssetCacheAnimator.cpp
@@ -151,14 +151,14 @@ Result<AnimatorAssetHandle> AssetCache::loadAnimator(const Uuid &uuid) {
     asset.data.states.push_back(state);
   }
 
-  for (size_t i = 0; i < transitionNodes.size(); ++i) {
+  for (usize i = 0; i < transitionNodes.size(); ++i) {
     auto &state = asset.data.states.at(i);
     auto &stateOn = transitionNodes.at(i);
     if (!stateOn || !stateOn.IsSequence()) {
       continue;
     }
 
-    for (size_t j = 0; j < stateOn.size(); ++j) {
+    for (usize j = 0; j < stateOn.size(); ++j) {
       auto transitionIndex =
           "Transition at index " + std::to_string(j) + " of " + state.name;
 
@@ -201,7 +201,7 @@ Result<AnimatorAssetHandle> AssetCache::loadAnimator(const Uuid &uuid) {
       }
 
       auto target = transitionNode["target"].as<String>("");
-      size_t i = 0;
+      usize i = 0;
       for (; i < asset.data.states.size() &&
              asset.data.states.at(i).name != target;
            ++i) {
@@ -229,7 +229,7 @@ Result<AnimatorAssetHandle> AssetCache::loadAnimator(const Uuid &uuid) {
 
   if (root["initial"]) {
     auto initial = root["initial"].as<String>("");
-    size_t i = 0;
+    usize i = 0;
     for (; i < asset.data.states.size() &&
            asset.data.states.at(i).name != initial;
          ++i) {

--- a/engine/src/quoll/asset/AssetCacheInputMap.cpp
+++ b/engine/src/quoll/asset/AssetCacheInputMap.cpp
@@ -180,24 +180,24 @@ Result<InputMapAssetHandle> AssetCache::loadInputMap(const Uuid &uuid) {
       return Result<InputMapAssetHandle>::Error("Binding item must be a map");
     }
 
-    auto scheme = binding["scheme"].as<int32_t>(-1);
+    auto scheme = binding["scheme"].as<i32>(-1);
     if (scheme == -1) {
       return Result<InputMapAssetHandle>::Error(
           "Binding item scheme is invalid");
     }
 
-    auto command = binding["command"].as<int32_t>(-1);
+    auto command = binding["command"].as<i32>(-1);
     if (command == -1) {
       return Result<InputMapAssetHandle>::Error(
           "Binding item command is invalid");
     }
 
-    if (scheme >= static_cast<int32_t>(root["schemes"].size())) {
+    if (scheme >= static_cast<i32>(root["schemes"].size())) {
       return Result<InputMapAssetHandle>::Error(
           "Binding item scheme does not point to scheme item");
     }
 
-    if (command >= static_cast<int32_t>(root["commands"].size())) {
+    if (command >= static_cast<i32>(root["commands"].size())) {
       return Result<InputMapAssetHandle>::Error(
           "Binding item command does not point to command item");
     }
@@ -205,8 +205,7 @@ Result<InputMapAssetHandle> AssetCache::loadInputMap(const Uuid &uuid) {
     auto value = binding["binding"];
 
     auto commandType =
-        root["commands"][binding["command"].as<size_t>()]["type"].as<String>(
-            "");
+        root["commands"][binding["command"].as<usize>()]["type"].as<String>("");
 
     if (commandType == "boolean") {
       auto p = value.as<String>("");
@@ -265,8 +264,8 @@ Result<InputMapAssetHandle> AssetCache::loadInputMap(const Uuid &uuid) {
 
   for (auto node : root["bindings"]) {
     InputMapBinding binding{};
-    binding.command = node["command"].as<size_t>(0);
-    binding.scheme = node["scheme"].as<size_t>(0);
+    binding.command = node["command"].as<usize>(0);
+    binding.scheme = node["scheme"].as<usize>(0);
 
     auto &command = asset.data.commands.at(binding.command);
 

--- a/engine/src/quoll/asset/AssetCacheLuaScript.cpp
+++ b/engine/src/quoll/asset/AssetCacheLuaScript.cpp
@@ -12,11 +12,11 @@ namespace quoll {
  * @param stream Input stream
  * @return Vector of characters
  */
-static std::vector<uint8_t> readFileIntoBuffer(std::ifstream &stream) {
+static std::vector<u8> readFileIntoBuffer(std::ifstream &stream) {
   std::ostringstream ss;
   ss << stream.rdbuf();
   const std::string &s = ss.str();
-  std::vector<uint8_t> bytes(s.begin(), s.end());
+  std::vector<u8> bytes(s.begin(), s.end());
 
   return bytes;
 }
@@ -30,8 +30,8 @@ static std::vector<uint8_t> readFileIntoBuffer(std::ifstream &stream) {
 static void injectInputVarsInterface(sol::state &state, LuaScriptAsset &data) {
   auto inputVars = state.create_named_table("input_vars");
   auto *luaState = state.lua_state();
-  inputVars["register"] = [&data, luaState](String name, uint32_t type) {
-    if (type >= static_cast<uint32_t>(LuaScriptVariableType::Invalid)) {
+  inputVars["register"] = [&data, luaState](String name, u32 type) {
+    if (type >= static_cast<u32>(LuaScriptVariableType::Invalid)) {
       luaL_error(luaState, "Variable \"%s\" has invalid type", name.c_str());
       return sol::nil;
     }

--- a/engine/src/quoll/asset/AssetCacheMesh.cpp
+++ b/engine/src/quoll/asset/AssetCacheMesh.cpp
@@ -31,11 +31,11 @@ AssetCache::createMeshFromAsset(const AssetData<MeshAsset> &asset) {
   header.name = asset.name;
   file.write(header);
 
-  auto numGeometries = static_cast<uint32_t>(asset.data.geometries.size());
+  auto numGeometries = static_cast<u32>(asset.data.geometries.size());
   file.write(numGeometries);
 
   for (auto &geometry : asset.data.geometries) {
-    auto numVertices = static_cast<uint32_t>(geometry.positions.size());
+    auto numVertices = static_cast<u32>(geometry.positions.size());
     file.write(numVertices);
     file.write(geometry.positions);
     file.write(geometry.normals);
@@ -48,7 +48,7 @@ AssetCache::createMeshFromAsset(const AssetData<MeshAsset> &asset) {
       file.write(geometry.weights);
     }
 
-    auto numIndices = static_cast<uint32_t>(geometry.indices.size());
+    auto numIndices = static_cast<u32>(geometry.indices.size());
     file.write(numIndices);
     file.write(geometry.indices);
   }
@@ -68,13 +68,13 @@ AssetCache::loadMeshDataFromInputStream(InputBinaryStream &stream,
   mesh.type = header.type;
   mesh.uuid = Uuid(filePath.stem().string());
 
-  uint32_t numGeometries = 0;
+  u32 numGeometries = 0;
   stream.read(numGeometries);
 
   mesh.data.geometries.resize(numGeometries);
 
-  for (uint32_t i = 0; i < numGeometries; ++i) {
-    uint32_t numVertices = 0;
+  for (u32 i = 0; i < numGeometries; ++i) {
+    u32 numVertices = 0;
     stream.read(numVertices);
 
     if (numVertices == 0) {
@@ -102,7 +102,7 @@ AssetCache::loadMeshDataFromInputStream(InputBinaryStream &stream,
       stream.read(g.weights);
     }
 
-    uint32_t numIndices = 0;
+    u32 numIndices = 0;
     stream.read(numIndices);
 
     if (numIndices == 0) {

--- a/engine/src/quoll/asset/AssetCachePrefab.cpp
+++ b/engine/src/quoll/asset/AssetCachePrefab.cpp
@@ -31,7 +31,7 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   header.name = asset.name;
   file.write(header);
 
-  std::map<MaterialAssetHandle, uint32_t> localMaterialMap;
+  std::map<MaterialAssetHandle, u32> localMaterialMap;
   {
     std::vector<Uuid> assetPaths;
     assetPaths.reserve(asset.data.meshes.size());
@@ -41,7 +41,7 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
         if (localMaterialMap.find(material) == localMaterialMap.end()) {
           auto uuid = mRegistry.getMaterials().getAsset(material).uuid;
           localMaterialMap.insert_or_assign(
-              material, static_cast<uint32_t>(assetPaths.size()));
+              material, static_cast<u32>(assetPaths.size()));
           assetPaths.push_back(uuid);
         }
       }
@@ -52,17 +52,17 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
         if (localMaterialMap.find(material) == localMaterialMap.end()) {
           auto uuid = mRegistry.getMaterials().getAsset(material).uuid;
           localMaterialMap.insert_or_assign(
-              material, static_cast<uint32_t>(assetPaths.size()));
+              material, static_cast<u32>(assetPaths.size()));
           assetPaths.push_back(uuid);
         }
       }
     }
 
-    file.write(static_cast<uint32_t>(assetPaths.size()));
+    file.write(static_cast<u32>(assetPaths.size()));
     file.write(assetPaths);
   }
 
-  std::map<MeshAssetHandle, uint32_t> localMeshMap;
+  std::map<MeshAssetHandle, u32> localMeshMap;
   {
     std::vector<Uuid> assetPaths;
     assetPaths.reserve(asset.data.meshes.size());
@@ -71,16 +71,16 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
       if (localMeshMap.find(component.value) == localMeshMap.end()) {
         auto uuid = mRegistry.getMeshes().getAsset(component.value).uuid;
         localMeshMap.insert_or_assign(component.value,
-                                      static_cast<uint32_t>(assetPaths.size()));
+                                      static_cast<u32>(assetPaths.size()));
         assetPaths.push_back(uuid);
       }
     }
 
-    file.write(static_cast<uint32_t>(assetPaths.size()));
+    file.write(static_cast<u32>(assetPaths.size()));
     file.write(assetPaths);
   }
 
-  std::map<SkeletonAssetHandle, uint32_t> localSkeletonMap;
+  std::map<SkeletonAssetHandle, u32> localSkeletonMap;
   {
     std::vector<Uuid> assetPaths;
     assetPaths.reserve(asset.data.skeletons.size());
@@ -89,17 +89,17 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
       auto uuid = mRegistry.getSkeletons().getAsset(component.value).uuid;
 
       if (localSkeletonMap.find(component.value) == localSkeletonMap.end()) {
-        localSkeletonMap.insert_or_assign(
-            component.value, static_cast<uint32_t>(assetPaths.size()));
+        localSkeletonMap.insert_or_assign(component.value,
+                                          static_cast<u32>(assetPaths.size()));
         assetPaths.push_back(uuid);
       }
     }
 
-    file.write(static_cast<uint32_t>(assetPaths.size()));
+    file.write(static_cast<u32>(assetPaths.size()));
     file.write(assetPaths);
   }
 
-  std::map<AnimationAssetHandle, uint32_t> localAnimationMap;
+  std::map<AnimationAssetHandle, u32> localAnimationMap;
   {
     std::vector<Uuid> assetPaths;
     assetPaths.reserve(asset.data.animations.size());
@@ -108,17 +108,17 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
       auto uuid = mRegistry.getAnimations().getAsset(handle).uuid;
 
       if (localAnimationMap.find(handle) == localAnimationMap.end()) {
-        localAnimationMap.insert_or_assign(
-            handle, static_cast<uint32_t>(assetPaths.size()));
+        localAnimationMap.insert_or_assign(handle,
+                                           static_cast<u32>(assetPaths.size()));
         assetPaths.push_back(uuid);
       }
     }
 
-    file.write(static_cast<uint32_t>(assetPaths.size()));
+    file.write(static_cast<u32>(assetPaths.size()));
     file.write(assetPaths);
   }
 
-  std::map<AnimatorAssetHandle, uint32_t> localAnimatorMap;
+  std::map<AnimatorAssetHandle, u32> localAnimatorMap;
   {
     std::vector<Uuid> assetPaths;
     assetPaths.reserve(asset.data.animators.size());
@@ -127,22 +127,22 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
       auto uuid = mRegistry.getAnimators().getAsset(component.value).uuid;
 
       if (localAnimatorMap.find(component.value) == localAnimatorMap.end()) {
-        localAnimatorMap.insert_or_assign(
-            component.value, static_cast<uint32_t>(assetPaths.size()));
+        localAnimatorMap.insert_or_assign(component.value,
+                                          static_cast<u32>(assetPaths.size()));
         assetPaths.push_back(uuid);
       }
     }
 
-    file.write(static_cast<uint32_t>(assetPaths.size()));
+    file.write(static_cast<u32>(assetPaths.size()));
     file.write(assetPaths);
   }
 
   // Load component data
   {
-    auto numComponents = static_cast<uint32_t>(asset.data.transforms.size());
+    auto numComponents = static_cast<u32>(asset.data.transforms.size());
 
     file.write(numComponents);
-    for (uint32_t i = 0; i < numComponents; ++i) {
+    for (u32 i = 0; i < numComponents; ++i) {
       const auto &transform = asset.data.transforms.at(i).value;
       file.write(asset.data.transforms.at(i).entity);
 
@@ -154,7 +154,7 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   }
 
   {
-    auto numComponents = static_cast<uint32_t>(asset.data.names.size());
+    auto numComponents = static_cast<u32>(asset.data.names.size());
     file.write(numComponents);
 
     for (auto &name : asset.data.names) {
@@ -164,7 +164,7 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   }
 
   {
-    auto numComponents = static_cast<uint32_t>(asset.data.meshes.size());
+    auto numComponents = static_cast<u32>(asset.data.meshes.size());
     file.write(numComponents);
     for (auto &component : asset.data.meshes) {
       file.write(component.entity);
@@ -173,12 +173,12 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   }
 
   {
-    auto numComponents = static_cast<uint32_t>(asset.data.meshRenderers.size());
+    auto numComponents = static_cast<u32>(asset.data.meshRenderers.size());
     file.write(numComponents);
     for (auto &component : asset.data.meshRenderers) {
       file.write(component.entity);
 
-      file.write(static_cast<uint32_t>(component.value.materials.size()));
+      file.write(static_cast<u32>(component.value.materials.size()));
       for (auto handle : component.value.materials) {
         file.write(localMaterialMap.at(handle));
       }
@@ -187,12 +187,12 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
 
   {
     auto numComponents =
-        static_cast<uint32_t>(asset.data.skinnedMeshRenderers.size());
+        static_cast<u32>(asset.data.skinnedMeshRenderers.size());
     file.write(numComponents);
     for (auto &component : asset.data.skinnedMeshRenderers) {
       file.write(component.entity);
 
-      file.write(static_cast<uint32_t>(component.value.materials.size()));
+      file.write(static_cast<u32>(component.value.materials.size()));
       for (auto handle : component.value.materials) {
         file.write(localMaterialMap.at(handle));
       }
@@ -200,7 +200,7 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   }
 
   {
-    auto numComponents = static_cast<uint32_t>(asset.data.skeletons.size());
+    auto numComponents = static_cast<u32>(asset.data.skeletons.size());
     file.write(numComponents);
     for (auto &component : asset.data.skeletons) {
       file.write(component.entity);
@@ -209,7 +209,7 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   }
 
   {
-    auto numComponents = static_cast<uint32_t>(asset.data.animations.size());
+    auto numComponents = static_cast<u32>(asset.data.animations.size());
     file.write(numComponents);
 
     for (auto &component : asset.data.animations) {
@@ -218,7 +218,7 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   }
 
   {
-    auto numComponents = static_cast<uint32_t>(asset.data.animators.size());
+    auto numComponents = static_cast<u32>(asset.data.animators.size());
     file.write(numComponents);
 
     for (auto &component : asset.data.animators) {
@@ -228,8 +228,7 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   }
 
   {
-    auto numComponents =
-        static_cast<uint32_t>(asset.data.directionalLights.size());
+    auto numComponents = static_cast<u32>(asset.data.directionalLights.size());
     file.write(numComponents);
 
     for (auto &light : asset.data.directionalLights) {
@@ -240,7 +239,7 @@ AssetCache::createPrefabFromAsset(const AssetData<PrefabAsset> &asset) {
   }
 
   {
-    auto numComponents = static_cast<uint32_t>(asset.data.pointLights.size());
+    auto numComponents = static_cast<u32>(asset.data.pointLights.size());
     file.write(numComponents);
 
     for (auto &light : asset.data.pointLights) {
@@ -269,13 +268,13 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
 
   std::vector<MaterialAssetHandle> localMaterialMap;
   {
-    uint32_t numAssets = 0;
+    u32 numAssets = 0;
     stream.read(numAssets);
     std::vector<quoll::Uuid> actual(numAssets);
     stream.read(actual);
     localMaterialMap.resize(numAssets, MaterialAssetHandle::Null);
 
-    for (uint32_t i = 0; i < numAssets; ++i) {
+    for (u32 i = 0; i < numAssets; ++i) {
       auto assetUuid = actual.at(i);
       const auto &res = getOrLoadMaterial(assetUuid);
       if (res.hasData()) {
@@ -290,13 +289,13 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
 
   std::vector<MeshAssetHandle> localMeshMap;
   {
-    uint32_t numAssets = 0;
+    u32 numAssets = 0;
     stream.read(numAssets);
     std::vector<quoll::Uuid> actual(numAssets);
     stream.read(actual);
     localMeshMap.resize(numAssets, MeshAssetHandle::Null);
 
-    for (uint32_t i = 0; i < numAssets; ++i) {
+    for (u32 i = 0; i < numAssets; ++i) {
       auto assetUuid = actual.at(i);
       const auto &res = getOrLoadMesh(assetUuid);
       if (res.hasData()) {
@@ -311,13 +310,13 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
 
   std::vector<SkeletonAssetHandle> localSkeletonMap;
   {
-    uint32_t numAssets = 0;
+    u32 numAssets = 0;
     stream.read(numAssets);
     std::vector<quoll::Uuid> actual(numAssets);
     stream.read(actual);
     localSkeletonMap.resize(numAssets, SkeletonAssetHandle::Null);
 
-    for (uint32_t i = 0; i < numAssets; ++i) {
+    for (u32 i = 0; i < numAssets; ++i) {
       auto assetUuid = actual.at(i);
       const auto &res = getOrLoadSkeleton(assetUuid);
       if (res.hasData()) {
@@ -334,13 +333,13 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   {
     auto &map = mRegistry.getAnimations();
 
-    uint32_t numAssets = 0;
+    u32 numAssets = 0;
     stream.read(numAssets);
     std::vector<quoll::Uuid> actual(numAssets);
     stream.read(actual);
     localAnimationMap.resize(numAssets, AnimationAssetHandle::Null);
 
-    for (uint32_t i = 0; i < numAssets; ++i) {
+    for (u32 i = 0; i < numAssets; ++i) {
       auto assetUuid = actual.at(i);
       const auto &res = getOrLoadAnimation(assetUuid);
       if (res.hasData()) {
@@ -358,13 +357,13 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   {
     auto &map = mRegistry.getAnimators();
 
-    uint32_t numAssets = 0;
+    u32 numAssets = 0;
     stream.read(numAssets);
     std::vector<quoll::Uuid> actual(numAssets);
     stream.read(actual);
     localAnimatorMap.resize(numAssets, AnimatorAssetHandle::Null);
 
-    for (uint32_t i = 0; i < numAssets; ++i) {
+    for (u32 i = 0; i < numAssets; ++i) {
       auto assetUuid = actual.at(i);
       const auto &res = getOrLoadAnimator(assetUuid);
       if (res.hasData()) {
@@ -379,17 +378,17 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     stream.read(numComponents);
     prefab.data.transforms.resize(numComponents);
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 0;
       stream.read(entity);
 
       glm::vec3 position;
       glm::quat rotation;
       glm::vec3 scale;
-      int32_t parent = -1;
+      i32 parent = -1;
       stream.read(position);
       stream.read(rotation);
       stream.read(scale);
@@ -401,11 +400,11 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     stream.read(numComponents);
     prefab.data.names.resize(numComponents);
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 0;
       stream.read(entity);
 
       String name;
@@ -417,16 +416,16 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     stream.read(numComponents);
 
     prefab.data.meshes.resize(numComponents);
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 0;
       stream.read(entity);
 
-      uint32_t meshIndex = 0;
+      u32 meshIndex = 0;
       stream.read(meshIndex);
 
       prefab.data.meshes.at(i).entity = entity;
@@ -435,19 +434,19 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     stream.read(numComponents);
 
     prefab.data.meshRenderers.resize(numComponents);
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 0;
       stream.read(entity);
 
-      uint32_t numMaterials = 0;
+      u32 numMaterials = 0;
       stream.read(numMaterials);
 
-      std::vector<uint32_t> materialIndices(numMaterials);
+      std::vector<u32> materialIndices(numMaterials);
       stream.read(materialIndices);
 
       prefab.data.meshRenderers.at(i).entity = entity;
@@ -460,19 +459,19 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     stream.read(numComponents);
 
     prefab.data.skinnedMeshRenderers.resize(numComponents);
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 0;
       stream.read(entity);
 
-      uint32_t numMaterials = 0;
+      u32 numMaterials = 0;
       stream.read(numMaterials);
 
-      std::vector<uint32_t> materialIndices(numMaterials);
+      std::vector<u32> materialIndices(numMaterials);
       stream.read(materialIndices);
 
       prefab.data.skinnedMeshRenderers.at(i).entity = entity;
@@ -485,16 +484,16 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     stream.read(numComponents);
 
     prefab.data.skeletons.resize(numComponents);
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 0;
       stream.read(entity);
 
-      uint32_t meshIndex = 0;
+      u32 meshIndex = 0;
       stream.read(meshIndex);
 
       prefab.data.skeletons.at(i).entity = entity;
@@ -503,13 +502,13 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     stream.read(numComponents);
 
     prefab.data.animations.resize(numComponents);
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t animationIndex = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 animationIndex = 0;
       stream.read(animationIndex);
 
       prefab.data.animations.at(i) = localAnimationMap.at(animationIndex);
@@ -517,16 +516,16 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     stream.read(numComponents);
 
     prefab.data.animators.resize(numComponents);
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 0;
       stream.read(entity);
 
-      uint32_t animatorIndex = 0;
+      u32 animatorIndex = 0;
       stream.read(animatorIndex);
 
       prefab.data.animators.at(i).entity = entity;
@@ -535,15 +534,15 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     stream.read(numComponents);
     prefab.data.directionalLights.resize(numComponents);
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 0;
       stream.read(entity);
 
       glm::vec4 color;
-      float intensity = 0.0f;
+      f32 intensity = 0.0f;
       stream.read(color);
       stream.read(intensity);
 
@@ -553,16 +552,16 @@ AssetCache::loadPrefabDataFromInputStream(InputBinaryStream &stream,
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     stream.read(numComponents);
     prefab.data.pointLights.resize(numComponents);
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 0;
       stream.read(entity);
 
       glm::vec4 color;
-      float intensity = 0.0f;
-      float range = 0.0f;
+      f32 intensity = 0.0f;
+      f32 range = 0.0f;
       stream.read(color);
       stream.read(intensity);
       stream.read(range);

--- a/engine/src/quoll/asset/AssetCacheSkeleton.cpp
+++ b/engine/src/quoll/asset/AssetCacheSkeleton.cpp
@@ -31,7 +31,7 @@ AssetCache::createSkeletonFromAsset(const AssetData<SkeletonAsset> &asset) {
   header.name = asset.name;
   file.write(header);
 
-  auto numJoints = static_cast<uint32_t>(asset.data.jointLocalPositions.size());
+  auto numJoints = static_cast<u32>(asset.data.jointLocalPositions.size());
   file.write(numJoints);
 
   file.write(asset.data.jointLocalPositions);
@@ -54,7 +54,7 @@ AssetCache::loadSkeletonDataFromInputStream(InputBinaryStream &stream,
   skeleton.uuid = Uuid(filePath.stem().string());
   skeleton.name = header.name;
 
-  uint32_t numJoints = 0;
+  u32 numJoints = 0;
   stream.read(numJoints);
 
   skeleton.data.jointLocalPositions.resize(numJoints);

--- a/engine/src/quoll/asset/AssetCacheTexture.cpp
+++ b/engine/src/quoll/asset/AssetCacheTexture.cpp
@@ -14,7 +14,7 @@
 
 namespace quoll {
 
-static constexpr uint32_t CubemapSides = 6;
+static constexpr u32 CubemapSides = 6;
 
 /**
  * @brief Get Vulkan format from RHI format
@@ -130,7 +130,7 @@ AssetCache::createTextureFromAsset(const AssetData<TextureAsset> &asset) {
   createInfo.numFaces =
       asset.data.type == quoll::TextureAssetType::Cubemap ? CubemapSides : 1;
   createInfo.numLayers = asset.data.layers;
-  createInfo.numLevels = static_cast<uint32_t>(asset.data.levels.size());
+  createInfo.numLevels = static_cast<u32>(asset.data.levels.size());
   createInfo.isArray = KTX_FALSE;
   createInfo.generateMipmaps = KTX_FALSE;
   createInfo.vkFormat = getVulkanFormatFromFormat(asset.data.format);
@@ -152,12 +152,12 @@ AssetCache::createTextureFromAsset(const AssetData<TextureAsset> &asset) {
 
   const auto *baseData =
       static_cast<const ktx_uint8_t *>(asset.data.data.data());
-  for (size_t i = 0; i < asset.data.levels.size(); ++i) {
+  for (usize i = 0; i < asset.data.levels.size(); ++i) {
     const auto &level = asset.data.levels.at(i);
 
-    size_t faceOffset = 0;
-    size_t faceSize = level.size / createInfo.numFaces;
-    for (uint32_t face = 0; face < createInfo.numFaces; ++face) {
+    usize faceOffset = 0;
+    usize faceSize = level.size / createInfo.numFaces;
+    for (u32 face = 0; face < createInfo.numFaces; ++face) {
       ktxTexture_SetImageFromMemory(
           baseTexture, static_cast<ktx_uint32_t>(i), 0, face,
           baseData + level.offset + faceOffset, faceSize);
@@ -198,7 +198,7 @@ Result<TextureAssetHandle> AssetCache::loadTexture(const Uuid &uuid) {
   auto size = stream.tellg();
   stream.seekg(0, std::ios::beg);
 
-  std::vector<uint8_t> bytes(size);
+  std::vector<u8> bytes(size);
   stream.read(reinterpret_cast<char *>(bytes.data()), size);
   stream.close();
 
@@ -243,22 +243,22 @@ Result<TextureAssetHandle> AssetCache::loadTexture(const Uuid &uuid) {
 
   auto *srcData = ktxTexture_GetData(ktxTextureData);
 
-  size_t numFaces = ktxTextureData->isCubemap ? CubemapSides : 1;
+  usize numFaces = ktxTextureData->isCubemap ? CubemapSides : 1;
 
-  size_t levelOffset = 0;
-  uint32_t mipWidth = texture.data.width;
-  uint32_t mipHeight = texture.data.height;
+  usize levelOffset = 0;
+  u32 mipWidth = texture.data.width;
+  u32 mipHeight = texture.data.height;
 
-  for (size_t level = 0; level < texture.data.levels.size(); ++level) {
+  for (usize level = 0; level < texture.data.levels.size(); ++level) {
     // ktsTexture_GetImageSize returns size of a
     // single face or layer within a level
-    size_t blockSize =
-        ktxTexture_GetImageSize(ktxTextureData, static_cast<int32_t>(level));
+    usize blockSize =
+        ktxTexture_GetImageSize(ktxTextureData, static_cast<i32>(level));
 
-    size_t levelSize = blockSize * numFaces;
+    usize levelSize = blockSize * numFaces;
 
-    texture.data.levels.at(level).offset = static_cast<uint32_t>(levelOffset);
-    texture.data.levels.at(level).size = static_cast<uint32_t>(levelSize);
+    texture.data.levels.at(level).offset = static_cast<u32>(levelOffset);
+    texture.data.levels.at(level).size = static_cast<u32>(levelSize);
     texture.data.levels.at(level).width = mipWidth;
     texture.data.levels.at(level).height = mipHeight;
 
@@ -270,12 +270,12 @@ Result<TextureAssetHandle> AssetCache::loadTexture(const Uuid &uuid) {
       mipHeight /= 2;
     }
 
-    for (size_t face = 0; face < numFaces; ++face) {
-      size_t offset = 0;
-      ktxTexture_GetImageOffset(ktxTextureData, static_cast<int32_t>(level), 0,
-                                static_cast<uint32_t>(face), &offset);
+    for (usize face = 0; face < numFaces; ++face) {
+      usize offset = 0;
+      ktxTexture_GetImageOffset(ktxTextureData, static_cast<i32>(level), 0,
+                                static_cast<u32>(face), &offset);
 
-      memcpy(static_cast<uint8_t *>(texture.data.data.data()) + levelOffset +
+      memcpy(static_cast<u8 *>(texture.data.data.data()) + levelOffset +
                  (blockSize * face),
              srcData + offset, blockSize);
     }

--- a/engine/src/quoll/asset/AssetData.h
+++ b/engine/src/quoll/asset/AssetData.h
@@ -19,7 +19,7 @@ template <class TData> struct AssetData {
   /**
    * Asset size
    */
-  size_t size = 0;
+  usize size = 0;
 
   /**
    * Asset data

--- a/engine/src/quoll/asset/AssetFileHeader.h
+++ b/engine/src/quoll/asset/AssetFileHeader.h
@@ -4,7 +4,7 @@
 
 namespace quoll {
 
-static constexpr size_t AssetFileMagicLength = 11;
+static constexpr usize AssetFileMagicLength = 11;
 
 /**
  * @brief Asset file header

--- a/engine/src/quoll/asset/AssetMap.h
+++ b/engine/src/quoll/asset/AssetMap.h
@@ -118,7 +118,7 @@ public:
 private:
   THandle getNewHandle() {
     THandle handle = mLastHandle;
-    mLastHandle = THandle{static_cast<uint32_t>(mLastHandle) + 1};
+    mLastHandle = THandle{static_cast<u32>(mLastHandle) + 1};
     return handle;
   }
 

--- a/engine/src/quoll/asset/AssetRegistry.cpp
+++ b/engine/src/quoll/asset/AssetRegistry.cpp
@@ -24,8 +24,7 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
     if (texture.data.deviceHandle == rhi::TextureHandle::Null) {
       rhi::TextureDescription description{};
       description.width = texture.data.width;
-      description.mipLevelCount =
-          static_cast<uint32_t>(texture.data.levels.size());
+      description.mipLevelCount = static_cast<u32>(texture.data.levels.size());
       description.layerCount = texture.data.layers;
       description.height = texture.data.height;
       description.usage = rhi::TextureUsage::Color |
@@ -118,17 +117,17 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
       continue;
     }
 
-    size_t ibSize = 0;
+    usize ibSize = 0;
     for (auto &g : mesh.data.geometries) {
-      ibSize += g.indices.size() * sizeof(uint32_t);
+      ibSize += g.indices.size() * sizeof(u32);
     }
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CreateBuffer(FieldName, Type)                                          \
   {                                                                            \
-    size_t vbSize = 0;                                                         \
+    usize vbSize = 0;                                                          \
     for (auto &g : mesh.data.geometries) {                                     \
-      size_t vertexSize = g.FieldName.size();                                  \
+      usize vertexSize = g.FieldName.size();                                   \
       vbSize += vertexSize * sizeof(Type);                                     \
     }                                                                          \
     rhi::BufferDescription description;                                        \
@@ -140,7 +139,7 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
                                                                                \
     auto *data = static_cast<Type *>(buffer.map());                            \
     mesh.data.vertexBufferOffsets.push_back(0);                                \
-    size_t offset = 0;                                                         \
+    usize offset = 0;                                                          \
     for (auto &g : mesh.data.geometries) {                                     \
       memcpy(data + offset, g.FieldName.data(),                                \
              g.FieldName.size() * sizeof(Type));                               \
@@ -170,11 +169,10 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
 
       auto buffer = renderStorage.createBuffer(description);
 
-      auto *data = static_cast<uint32_t *>(buffer.map());
-      size_t offset = 0;
+      auto *data = static_cast<u32 *>(buffer.map());
+      usize offset = 0;
       for (auto &g : mesh.data.geometries) {
-        memcpy(data + offset, g.indices.data(),
-               g.indices.size() * sizeof(uint32_t));
+        memcpy(data + offset, g.indices.data(), g.indices.size() * sizeof(u32));
         offset += g.indices.size();
       }
 
@@ -185,83 +183,83 @@ void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {
   }
 }
 
-std::pair<AssetType, uint32_t> AssetRegistry::getAssetByUuid(const Uuid &uuid) {
+std::pair<AssetType, u32> AssetRegistry::getAssetByUuid(const Uuid &uuid) {
   QUOLL_PROFILE_EVENT("AssetRegistry::getAssetByUUID");
   for (auto &[handle, asset] : mTextures.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Texture, static_cast<uint32_t>(handle)};
+      return {AssetType::Texture, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mFonts.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Font, static_cast<uint32_t>(handle)};
+      return {AssetType::Font, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mMaterials.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Material, static_cast<uint32_t>(handle)};
+      return {AssetType::Material, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mMeshes.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Mesh, static_cast<uint32_t>(handle)};
+      return {AssetType::Mesh, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mSkeletons.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Skeleton, static_cast<uint32_t>(handle)};
+      return {AssetType::Skeleton, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mAnimations.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Animation, static_cast<uint32_t>(handle)};
+      return {AssetType::Animation, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mAnimators.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Animator, static_cast<uint32_t>(handle)};
+      return {AssetType::Animator, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mAudios.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Audio, static_cast<uint32_t>(handle)};
+      return {AssetType::Audio, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mPrefabs.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Prefab, static_cast<uint32_t>(handle)};
+      return {AssetType::Prefab, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mLuaScripts.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::LuaScript, static_cast<uint32_t>(handle)};
+      return {AssetType::LuaScript, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mEnvironments.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Environment, static_cast<uint32_t>(handle)};
+      return {AssetType::Environment, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mScenes.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::Scene, static_cast<uint32_t>(handle)};
+      return {AssetType::Scene, static_cast<u32>(handle)};
     }
   }
 
   for (auto &[handle, asset] : mInputMaps.getAssets()) {
     if (asset.uuid == uuid) {
-      return {AssetType::InputMap, static_cast<uint32_t>(handle)};
+      return {AssetType::InputMap, static_cast<u32>(handle)};
     }
   }
 

--- a/engine/src/quoll/asset/AssetRegistry.h
+++ b/engine/src/quoll/asset/AssetRegistry.h
@@ -188,7 +188,7 @@ public:
    * @retval {AssetType::None, 0} Asset does not exist
    * @return Asset type and ID
    */
-  std::pair<AssetType, uint32_t> getAssetByUuid(const Uuid &uuid);
+  std::pair<AssetType, u32> getAssetByUuid(const Uuid &uuid);
 
 private:
   TextureMap mTextures;

--- a/engine/src/quoll/asset/AssetRevision.h
+++ b/engine/src/quoll/asset/AssetRevision.h
@@ -4,7 +4,7 @@
 
 namespace quoll {
 
-enum class AssetRevision : uint32_t {
+enum class AssetRevision : u32 {
   Material = 230901,
   Texture = 230901,
   Mesh = 230901,

--- a/engine/src/quoll/asset/DefaultObjects.cpp
+++ b/engine/src/quoll/asset/DefaultObjects.cpp
@@ -19,9 +19,9 @@ AssetData<MeshAsset> createCube() {
   std::vector<glm::vec4> tangents;
   std::vector<glm::vec2> texCoords;
 
-  std::vector<uint32_t> indices{0,  1,  2,  3,  2,  1,  4,  5,  6,  7,  6,  5,
-                                8,  9,  10, 11, 10, 9,  12, 13, 14, 15, 14, 13,
-                                16, 17, 18, 19, 18, 17, 20, 21, 22, 23, 22, 21};
+  std::vector<u32> indices{0,  1,  2,  3,  2,  1,  4,  5,  6,  7,  6,  5,
+                           8,  9,  10, 11, 10, 9,  12, 13, 14, 15, 14, 13,
+                           16, 17, 18, 19, 18, 17, 20, 21, 22, 23, 22, 21};
 
   // Front face
   positions.push_back({-1.0f, -1.0f, -1.0f});

--- a/engine/src/quoll/asset/FontAsset.h
+++ b/engine/src/quoll/asset/FontAsset.h
@@ -20,7 +20,7 @@ struct FontGlyph {
   /**
    * Glyph advance
    */
-  float advanceX = 0.0;
+  f32 advanceX = 0.0;
 };
 
 /**
@@ -40,12 +40,12 @@ struct FontAsset {
   /**
    * Glyph data
    */
-  std::unordered_map<uint32_t, FontGlyph> glyphs;
+  std::unordered_map<u32, FontGlyph> glyphs;
 
   /**
    * Font scale
    */
-  float fontScale = 1.0f;
+  f32 fontScale = 1.0f;
 
   /**
    * Device handle

--- a/engine/src/quoll/asset/InputBinaryStream.h
+++ b/engine/src/quoll/asset/InputBinaryStream.h
@@ -43,7 +43,7 @@ public:
    * @param value Address to value
    * @param size Size to read
    */
-  template <class TPrimitive> void read(TPrimitive *value, size_t size) {
+  template <class TPrimitive> void read(TPrimitive *value, usize size) {
     mStream.read(reinterpret_cast<char *>(value),
                  static_cast<std::streamsize>(size));
   }
@@ -78,8 +78,8 @@ private:
  * @param value String value
  */
 template <> inline void InputBinaryStream::read(String &value) {
-  uint32_t length = 0;
-  read(&length, sizeof(uint32_t));
+  u32 length = 0;
+  read(&length, sizeof(u32));
 
   value.resize(length);
   read(value.data(), length);
@@ -138,7 +138,7 @@ template <> inline void InputBinaryStream::read(glm::quat &value) {
  * @param value String vector
  */
 template <> inline void InputBinaryStream::read(std::vector<String> &value) {
-  for (size_t i = 0; i < value.size(); ++i) {
+  for (usize i = 0; i < value.size(); ++i) {
     read<String>(value.at(i));
   }
 }
@@ -149,7 +149,7 @@ template <> inline void InputBinaryStream::read(std::vector<String> &value) {
  * @param value String vector
  */
 template <> inline void InputBinaryStream::read(std::vector<Uuid> &value) {
-  for (size_t i = 0; i < value.size(); ++i) {
+  for (usize i = 0; i < value.size(); ++i) {
     read<Uuid>(value.at(i));
   }
 }

--- a/engine/src/quoll/asset/InputMapAsset.h
+++ b/engine/src/quoll/asset/InputMapAsset.h
@@ -57,12 +57,12 @@ struct InputMapBinding {
   /**
    * Scheme index
    */
-  size_t scheme = 0;
+  usize scheme = 0;
 
   /**
    * Command index
    */
-  size_t command = 0;
+  usize command = 0;
 
   /**
    * Binding value

--- a/engine/src/quoll/asset/LuaScriptAsset.h
+++ b/engine/src/quoll/asset/LuaScriptAsset.h
@@ -26,7 +26,7 @@ struct LuaScriptAsset {
   /**
    * Bytes that represent the script
    */
-  std::vector<uint8_t> bytes;
+  std::vector<u8> bytes;
 
   /**
    * Variables

--- a/engine/src/quoll/asset/MaterialAsset.h
+++ b/engine/src/quoll/asset/MaterialAsset.h
@@ -16,7 +16,7 @@ struct MaterialAsset {
   /**
    * Base color texture coordinate index
    */
-  int8_t baseColorTextureCoord = -1;
+  i8 baseColorTextureCoord = -1;
 
   /**
    * Base color factor
@@ -31,17 +31,17 @@ struct MaterialAsset {
   /**
    * Metallic roughness texture coordinate index
    */
-  int8_t metallicRoughnessTextureCoord = -1;
+  i8 metallicRoughnessTextureCoord = -1;
 
   /**
    * Metallic factor
    */
-  float metallicFactor = 0.0f;
+  f32 metallicFactor = 0.0f;
 
   /**
    * Roughness factor
    */
-  float roughnessFactor = 0.0f;
+  f32 roughnessFactor = 0.0f;
 
   /**
    * Normal texture
@@ -51,12 +51,12 @@ struct MaterialAsset {
   /**
    * Normal texture coordinate index
    */
-  int8_t normalTextureCoord = -1;
+  i8 normalTextureCoord = -1;
 
   /**
    * Normal scale
    */
-  float normalScale = 0.0f;
+  f32 normalScale = 0.0f;
 
   /**
    * Occlusion texture
@@ -66,12 +66,12 @@ struct MaterialAsset {
   /**
    * Occlusion texture coordinate index
    */
-  int8_t occlusionTextureCoord = -1;
+  i8 occlusionTextureCoord = -1;
 
   /**
    * Occlusion strength
    */
-  float occlusionStrength = 0.0f;
+  f32 occlusionStrength = 0.0f;
 
   /**
    * Emissive texture
@@ -81,7 +81,7 @@ struct MaterialAsset {
   /**
    * Emissive texture coordinate index
    */
-  int8_t emissiveTextureCoord = -1;
+  i8 emissiveTextureCoord = -1;
 
   /**
    * Emissive factor

--- a/engine/src/quoll/asset/MeshAsset.h
+++ b/engine/src/quoll/asset/MeshAsset.h
@@ -49,7 +49,7 @@ struct BaseGeometryAsset {
   /**
    * List of indices
    */
-  std::vector<uint32_t> indices;
+  std::vector<u32> indices;
 };
 
 /**
@@ -69,7 +69,7 @@ struct MeshAsset {
   /**
    * Vertex buffer binding offsets
    */
-  std::vector<uint64_t> vertexBufferOffsets;
+  std::vector<u64> vertexBufferOffsets;
 
   /**
    * @brief Index buffer for all geometries

--- a/engine/src/quoll/asset/OutputBinaryStream.h
+++ b/engine/src/quoll/asset/OutputBinaryStream.h
@@ -43,7 +43,7 @@ public:
    * @param size Size of write
    */
   template <class TPrimitive>
-  inline void write(const TPrimitive *value, std::size_t size) {
+  inline void write(const TPrimitive *value, usize size) {
     mStream.write(reinterpret_cast<const char *>(value),
                   static_cast<std::streamsize>(size));
   }
@@ -79,8 +79,8 @@ private:
  * @param value String value
  */
 template <> inline void OutputBinaryStream::write(const String &value) {
-  uint32_t length = static_cast<uint32_t>(value.length());
-  write(&length, sizeof(uint32_t));
+  u32 length = static_cast<u32>(value.length());
+  write(&length, sizeof(u32));
   write(value.c_str(), length);
 }
 

--- a/engine/src/quoll/asset/PrefabAsset.h
+++ b/engine/src/quoll/asset/PrefabAsset.h
@@ -19,7 +19,7 @@ template <class T> struct PrefabComponent {
    *
    * This value is local to prefab asset file
    */
-  uint32_t entity = 0;
+  u32 entity = 0;
 
   /**
    * Value
@@ -51,7 +51,7 @@ struct PrefabTransformData {
    *
    * This value is local to prefab asset file
    */
-  int32_t parent = -1;
+  i32 parent = -1;
 };
 
 /**

--- a/engine/src/quoll/asset/TextureAsset.h
+++ b/engine/src/quoll/asset/TextureAsset.h
@@ -14,22 +14,22 @@ struct TextureAssetLevel {
   /**
    * Offset of mip level
    */
-  size_t offset = 0;
+  usize offset = 0;
 
   /**
    * Size of mip level
    */
-  size_t size = 0;
+  usize size = 0;
 
   /**
    * Mip level width
    */
-  uint32_t width = 0;
+  u32 width = 0;
 
   /**
    * Mip level height
    */
-  uint32_t height = 0;
+  u32 height = 0;
 };
 
 /**
@@ -39,17 +39,17 @@ struct TextureAsset {
   /**
    * Width
    */
-  uint32_t width = 0;
+  u32 width = 0;
 
   /**
    * Height
    */
-  uint32_t height = 0;
+  u32 height = 0;
 
   /**
    * Layers
    */
-  uint32_t layers = 0;
+  u32 layers = 0;
 
   /**
    * Texture type
@@ -64,7 +64,7 @@ struct TextureAsset {
   /**
    * Raw texture data
    */
-  std::vector<uint8_t> data;
+  std::vector<u8> data;
 
   /**
    * Mip levels

--- a/engine/src/quoll/core/Base.h
+++ b/engine/src/quoll/core/Base.h
@@ -68,5 +68,6 @@ template <class T> using SharedPtr = std::shared_ptr<T>;
 #include "Errorable.h"
 #include "BitwiseEnum.h"
 #include "Uuid.h"
+#include "DataTypes.h"
 
 #endif

--- a/engine/src/quoll/core/DataTypes.h
+++ b/engine/src/quoll/core/DataTypes.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// Signed integers
+using i8 = int8_t;
+using i16 = int16_t;
+using i32 = int32_t;
+using i64 = int64_t;
+using iptr = intptr_t;
+
+// Unsigned integers
+using u8 = uint8_t;
+using u16 = uint16_t;
+using u32 = uint32_t;
+using u64 = uint64_t;
+using usize = size_t;
+using uptr = uintptr_t;
+
+// Floating points
+using f32 = float;
+using f64 = double;

--- a/engine/src/quoll/core/Id.h
+++ b/engine/src/quoll/core/Id.h
@@ -9,7 +9,7 @@ struct Id {
   /**
    * ID
    */
-  uint64_t id = 0;
+  u64 id = 0;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/core/Property.cpp
+++ b/engine/src/quoll/core/Property.cpp
@@ -3,25 +3,25 @@
 
 namespace quoll {
 
-Property::Property(int32_t value) : mType(INT32), mValue(value) {}
-Property::Property(uint32_t value) : mType(UINT32), mValue(value) {}
-Property::Property(uint64_t value) : mType(UINT64), mValue(value) {}
-Property::Property(float value) : mType(REAL), mValue(value) {}
+Property::Property(i32 value) : mType(INT32), mValue(value) {}
+Property::Property(u32 value) : mType(UINT32), mValue(value) {}
+Property::Property(u64 value) : mType(UINT64), mValue(value) {}
+Property::Property(f32 value) : mType(REAL), mValue(value) {}
 Property::Property(const glm::vec2 &value) : mType(VECTOR2), mValue(value) {}
 Property::Property(const glm::vec3 &value) : mType(VECTOR3), mValue(value) {}
 Property::Property(const glm::vec4 &value) : mType(VECTOR4), mValue(value) {}
 Property::Property(const glm::mat4 &value) : mType(MATRIX4), mValue(value) {}
 
-size_t Property::getSize() const {
+usize Property::getSize() const {
   switch (mType) {
   case INT32:
-    return sizeof(int32_t);
+    return sizeof(i32);
   case UINT32:
-    return sizeof(uint32_t);
+    return sizeof(u32);
   case UINT64:
-    return sizeof(uint64_t);
+    return sizeof(u64);
   case REAL:
-    return sizeof(float);
+    return sizeof(f32);
   case VECTOR2:
     return sizeof(glm::vec2);
   case VECTOR3:
@@ -38,16 +38,16 @@ size_t Property::getSize() const {
 const String Property::toString() const {
   switch (mType) {
   case INT32:
-    return std::to_string(getValue<int32_t>());
+    return std::to_string(getValue<i32>());
   case UINT32:
-    return std::to_string(getValue<uint32_t>());
+    return std::to_string(getValue<u32>());
   case UINT64:
-    return std::to_string(getValue<uint64_t>());
+    return std::to_string(getValue<u64>());
   case REAL: {
     std::stringstream ss;
     ss.setf(std::ios::fixed);
     ss.precision(2);
-    ss << getValue<float>();
+    ss << getValue<f32>();
     return ss.str();
   }
   case VECTOR2: {

--- a/engine/src/quoll/core/Property.h
+++ b/engine/src/quoll/core/Property.h
@@ -27,28 +27,28 @@ public:
    *
    * @param value 32bit integer value
    */
-  Property(int32_t value);
+  Property(i32 value);
 
   /**
    * @brief Create 32bit unsigned  integer property
    *
    * @param value 32bit unsigned integer value
    */
-  Property(uint32_t value);
+  Property(u32 value);
 
   /**
    * @brief Create 64bit unsigned integer property
    *
    * @param value 64bit unsigned integer value
    */
-  Property(uint64_t value);
+  Property(u64 value);
 
   /**
    * @brief Create real property
    *
    * @param value Real value
    */
-  Property(float value);
+  Property(f32 value);
 
   /**
    * @brief Create vector2 property
@@ -90,7 +90,7 @@ public:
    *
    * @return Property size
    */
-  size_t getSize() const;
+  usize getSize() const;
 
   /**
    * @brief Get value in string
@@ -122,10 +122,10 @@ private:
  *
  * @return int32 value
  */
-template <> inline const int32_t Property::getValue() const {
+template <> inline const i32 Property::getValue() const {
   QuollAssert(mType == INT32, "Property type is not int32");
 
-  return std::any_cast<int32_t>(mValue);
+  return std::any_cast<i32>(mValue);
 }
 
 /**
@@ -133,10 +133,10 @@ template <> inline const int32_t Property::getValue() const {
  *
  * @return uint32 value
  */
-template <> inline const uint32_t Property::getValue() const {
+template <> inline const u32 Property::getValue() const {
   QuollAssert(mType == UINT32, "Property type is not uint32");
 
-  return std::any_cast<uint32_t>(mValue);
+  return std::any_cast<u32>(mValue);
 }
 
 /**
@@ -144,10 +144,10 @@ template <> inline const uint32_t Property::getValue() const {
  *
  * @return uint64 value
  */
-template <> inline const uint64_t Property::getValue() const {
+template <> inline const u64 Property::getValue() const {
   QuollAssert(mType == UINT64, "Property type is not uint64");
 
-  return std::any_cast<uint64_t>(mValue);
+  return std::any_cast<u64>(mValue);
 }
 
 /**
@@ -155,10 +155,10 @@ template <> inline const uint64_t Property::getValue() const {
  *
  * @return Real value
  */
-template <> inline const float Property::getValue() const {
+template <> inline const f32 Property::getValue() const {
   QuollAssert(mType == REAL, "Property type is not a real number");
 
-  return std::any_cast<float>(mValue);
+  return std::any_cast<f32>(mValue);
 }
 
 /**

--- a/engine/src/quoll/core/RingBuffer.h
+++ b/engine/src/quoll/core/RingBuffer.h
@@ -20,7 +20,7 @@ public:
    *
    * @param maxSize Maximum size
    */
-  RingBuffer(size_t maxSize) : mBuffer(maxSize) {}
+  RingBuffer(usize maxSize) : mBuffer(maxSize) {}
 
   /**
    * @brief Push item to the end of buffer
@@ -68,7 +68,7 @@ public:
    *
    * @return Buffer size
    */
-  inline size_t size() const { return mSize; }
+  inline usize size() const { return mSize; }
 
   /**
    * @brief Check if ring buffer is empty
@@ -79,9 +79,9 @@ public:
   inline bool empty() const { return mSize == 0; }
 
 private:
-  size_t mStart = 0;
-  size_t mEnd = 0;
-  size_t mSize = 0;
+  usize mStart = 0;
+  usize mEnd = 0;
+  usize mSize = 0;
   std::vector<TItem> mBuffer;
 };
 

--- a/engine/src/quoll/core/SparseSet.h
+++ b/engine/src/quoll/core/SparseSet.h
@@ -25,9 +25,9 @@ namespace quoll {
  * @tparam TData Data type
  */
 template <class TData> class SparseSet {
-  static constexpr size_t SparseDataSize = 100;
+  static constexpr usize SparseDataSize = 100;
 
-  static constexpr size_t Empty = std::numeric_limits<size_t>::max();
+  static constexpr usize Empty = std::numeric_limits<usize>::max();
   using Iterator = typename std::vector<TData>::iterator;
 
 public:
@@ -42,7 +42,7 @@ public:
    * @param item Item data
    * @return Item key
    */
-  size_t insert(const TData &item) {
+  usize insert(const TData &item) {
     auto newKey = size();
     if (!mEmptyData.empty()) {
       newKey = mEmptyData.back();
@@ -61,7 +61,7 @@ public:
    *
    * @param key Item key
    */
-  void erase(size_t key) {
+  void erase(usize key) {
     QuollAssert(key < mSparseData.size(), "Index out of bounds");
 
     auto lastKey = size() - 1;
@@ -90,9 +90,9 @@ public:
    * @param key Item key
    * @return item data
    */
-  inline TData &at(size_t key) {
+  inline TData &at(usize key) {
     QuollAssert(key < mSparseData.size(), "Index out of bounds");
-    size_t denseIndex = mSparseData.at(key);
+    usize denseIndex = mSparseData.at(key);
 
     QuollAssert(denseIndex != Empty, "No data at key");
 
@@ -105,9 +105,9 @@ public:
    * @param key Item key
    * @return item data
    */
-  inline const TData &at(size_t key) const {
+  inline const TData &at(usize key) const {
     QuollAssert(key < mSparseData.size(), "Index out of bounds");
-    size_t denseIndex = mSparseData.at(key);
+    usize denseIndex = mSparseData.at(key);
 
     QuollAssert(denseIndex != Empty, "No data at key");
 
@@ -121,7 +121,7 @@ public:
    * @retval true Item exists
    * @retval false Item does not exist
    */
-  bool contains(size_t key) {
+  bool contains(usize key) {
     return key < mSparseData.size() && mSparseData.at(key) != Empty;
   }
 
@@ -138,7 +138,7 @@ public:
    *
    * @return Sparse set size
    */
-  inline size_t size() const { return mDenseData.size(); }
+  inline usize size() const { return mDenseData.size(); }
 
   /**
    * @brief Get begin iterator
@@ -155,10 +155,10 @@ public:
   inline Iterator end() { return mRealData.end(); }
 
 private:
-  std::vector<size_t> mDenseData;
-  std::vector<size_t> mSparseData;
+  std::vector<usize> mDenseData;
+  std::vector<usize> mSparseData;
   std::vector<TData> mRealData;
-  std::vector<size_t> mEmptyData;
+  std::vector<usize> mEmptyData;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/core/SwappableVector.h
+++ b/engine/src/quoll/core/SwappableVector.h
@@ -29,7 +29,7 @@ public:
      * @param container Swappaple vector container
      * @param index Index
      */
-    Iterator(const SwappableVector<TItem> &container, size_t index)
+    Iterator(const SwappableVector<TItem> &container, usize index)
         : mContainer(container), mIndex(index) {}
 
     /**
@@ -60,7 +60,7 @@ public:
 
   private:
     const SwappableVector<TItem> &mContainer;
-    size_t mIndex;
+    usize mIndex;
   };
 
 public:
@@ -83,9 +83,9 @@ public:
    *
    * @param index Index
    */
-  void erase(size_t index) {
+  void erase(usize index) {
     QuollAssert(index < mSize, "Index out of bounds");
-    size_t lastItem = mSize - 1;
+    usize lastItem = mSize - 1;
     mBuffer.at(index) = mBuffer.at(lastItem);
     mSize--;
   }
@@ -96,7 +96,7 @@ public:
    * @param index Index
    * @return Item
    */
-  inline TItem &at(size_t index) {
+  inline TItem &at(usize index) {
     QuollAssert(index < mSize, "Index out of bounds");
     return mBuffer.at(index);
   }
@@ -107,7 +107,7 @@ public:
    * @param index Index
    * @return Item
    */
-  inline const TItem &at(size_t index) const {
+  inline const TItem &at(usize index) const {
     QuollAssert(index < mSize, "Index out of bounds");
     return mBuffer.at(index);
   }
@@ -116,7 +116,7 @@ public:
    * @brief Get size of vector
    * @return Vector size
    */
-  inline size_t size() const { return mSize; }
+  inline usize size() const { return mSize; }
 
   /**
    * @brief Check if vector is empty
@@ -141,7 +141,7 @@ public:
   inline Iterator end() const { return Iterator(*this, mSize); }
 
 private:
-  size_t mSize = 0;
+  usize mSize = 0;
   std::vector<TItem> mBuffer;
 };
 

--- a/engine/src/quoll/core/Version.h
+++ b/engine/src/quoll/core/Version.h
@@ -11,11 +11,10 @@ namespace quoll {
  * @param build Build number
  * @return Version uint
  */
-constexpr inline uint64_t createVersion(uint8_t major, uint8_t minor = 0,
-                                        uint8_t patch = 0, uint32_t build = 0) {
-  return (static_cast<uint64_t>(major) << 56) |
-         (static_cast<uint64_t>(minor) << 48) |
-         (static_cast<uint64_t>(patch) << 40) | (static_cast<uint64_t>(build));
+constexpr inline u64 createVersion(u8 major, u8 minor = 0, u8 patch = 0,
+                                   u32 build = 0) {
+  return (static_cast<u64>(major) << 56) | (static_cast<u64>(minor) << 48) |
+         (static_cast<u64>(patch) << 40) | (static_cast<u64>(build));
 }
 
 } // namespace quoll

--- a/engine/src/quoll/entity/Entity.h
+++ b/engine/src/quoll/entity/Entity.h
@@ -2,6 +2,6 @@
 
 namespace quoll {
 
-enum class Entity : uint32_t { Null = 0 };
+enum class Entity : u32 { Null = 0 };
 
 } // namespace quoll

--- a/engine/src/quoll/entity/EntitySpawner.cpp
+++ b/engine/src/quoll/entity/EntitySpawner.cpp
@@ -22,11 +22,10 @@ std::vector<Entity> EntitySpawner::spawnPrefab(PrefabAssetHandle handle,
   const auto &assetName = mAssetRegistry.getPrefabs().getAsset(handle).name;
   const auto &asset = mAssetRegistry.getPrefabs().getAsset(handle).data;
 
-  std::unordered_map<uint32_t, size_t> entityMap;
+  std::unordered_map<u32, usize> entityMap;
   std::vector<Entity> entities;
 
-  auto getOrCreateEntity = [&entityMap, &entities,
-                            this](uint32_t localId) mutable {
+  auto getOrCreateEntity = [&entityMap, &entities, this](u32 localId) mutable {
     if (entityMap.find(localId) == entityMap.end()) {
       auto entity = mEntityDatabase.create();
       mEntityDatabase.set<LocalTransform>(entity, {});
@@ -99,11 +98,11 @@ std::vector<Entity> EntitySpawner::spawnPrefab(PrefabAssetHandle handle,
     const auto &asset =
         mAssetRegistry.getSkeletons().getAsset(pSkeleton.value).data;
 
-    size_t numJoints = asset.jointLocalPositions.size();
+    usize numJoints = asset.jointLocalPositions.size();
 
     Skeleton skeleton{};
     skeleton.assetHandle = pSkeleton.value;
-    skeleton.numJoints = static_cast<uint32_t>(numJoints);
+    skeleton.numJoints = static_cast<u32>(numJoints);
     skeleton.jointNames.resize(numJoints);
     skeleton.jointParents.resize(numJoints);
     skeleton.jointLocalPositions.resize(numJoints);
@@ -113,7 +112,7 @@ std::vector<Entity> EntitySpawner::spawnPrefab(PrefabAssetHandle handle,
     skeleton.jointWorldTransforms.resize(numJoints, glm::mat4{1.0f});
     skeleton.jointFinalTransforms.resize(numJoints, glm::mat4{1.0f});
 
-    for (size_t i = 0; i < numJoints; ++i) {
+    for (usize i = 0; i < numJoints; ++i) {
       skeleton.jointNames.at(i) = asset.jointNames.at(i);
       skeleton.jointParents.at(i) = asset.jointParents.at(i);
       skeleton.jointLocalPositions.at(i) = asset.jointLocalPositions.at(i);

--- a/engine/src/quoll/entity/EntityStorageSparseSet.cpp
+++ b/engine/src/quoll/entity/EntityStorageSparseSet.cpp
@@ -21,7 +21,7 @@ Entity EntityStorageSparseSet::create() {
   }
 
   auto eid = mLastEntity;
-  mLastEntity = Entity{static_cast<uint32_t>(mLastEntity) + 1};
+  mLastEntity = Entity{static_cast<u32>(mLastEntity) + 1};
   return eid;
 }
 
@@ -51,13 +51,13 @@ void EntityStorageSparseSet::destroy() {
 
 void EntityStorageSparseSet::deleteAllEntityComponents(Entity entity) {
   for (auto &[index, pool] : mComponentPools) {
-    size_t sEntity = static_cast<size_t>(entity);
+    usize sEntity = static_cast<usize>(entity);
 
     if (sEntity < pool.entityIndices.size() &&
         pool.entityIndices[sEntity] < DeadIndex) {
 
-      size_t movedEntity = static_cast<size_t>(pool.entities.back());
-      size_t entityIndexToDelete = pool.entityIndices[sEntity];
+      usize movedEntity = static_cast<usize>(pool.entities.back());
+      usize entityIndexToDelete = pool.entityIndices[sEntity];
 
       auto &observers = mRemoveObserverPools.at(index);
       for (auto &observer : observers) {

--- a/engine/src/quoll/entity/EntityStorageSparseSet.h
+++ b/engine/src/quoll/entity/EntityStorageSparseSet.h
@@ -12,9 +12,9 @@ namespace quoll {
  * @brief Sparse set based entity storage
  */
 class EntityStorageSparseSet {
-  static constexpr size_t DeadIndex = std::numeric_limits<size_t>::max();
+  static constexpr usize DeadIndex = std::numeric_limits<usize>::max();
 
-  static constexpr size_t MaxObserverPoolSizePerComponent = 100;
+  static constexpr usize MaxObserverPoolSizePerComponent = 100;
 
 public:
   EntityStorageSparseSet() = default;
@@ -77,7 +77,7 @@ public:
    *
    * @return Number of entities
    */
-  inline const size_t getEntityCount() const { return mNumEntities; }
+  inline const usize getEntityCount() const { return mNumEntities; }
 
   /**
    * @brief Delete entity
@@ -99,19 +99,19 @@ public:
    */
   template <class TComponentType>
   void set(Entity entity, const TComponentType &value) {
-    QuollAssert(exists(entity),
-                "Entity " + std::to_string(static_cast<uint32_t>(entity)) +
-                    " does not exist");
+    QuollAssert(exists(entity), "Entity " +
+                                    std::to_string(static_cast<u32>(entity)) +
+                                    " does not exist");
 
     auto &pool = getPoolForComponent<TComponentType>();
 
-    size_t sEntity = static_cast<size_t>(entity);
+    usize sEntity = static_cast<usize>(entity);
     if (sEntity >= pool.entityIndices.size()) {
       // TODO: Make this better
       pool.entityIndices.resize((sEntity + 1) * 2, DeadIndex);
     }
 
-    size_t index = pool.entityIndices[sEntity];
+    usize index = pool.entityIndices[sEntity];
     if (index != DeadIndex) {
       pool.components[index] = value;
       pool.entities[index] = entity;
@@ -134,11 +134,11 @@ public:
     QuollAssert(has<TComponentType>(entity),
                 "Component named " + String(typeid(TComponentType).name()) +
                     " does not exist for entity " +
-                    std::to_string(static_cast<uint32_t>(entity)));
+                    std::to_string(static_cast<u32>(entity)));
     const auto &pool = getPoolForComponent<TComponentType>();
 
     return std::any_cast<const TComponentType &>(
-        pool.components[pool.entityIndices[static_cast<size_t>(entity)]]);
+        pool.components[pool.entityIndices[static_cast<usize>(entity)]]);
   }
 
   /**
@@ -152,11 +152,11 @@ public:
     QuollAssert(has<TComponentType>(entity),
                 "Component named " + String(typeid(TComponentType).name()) +
                     " does not exist for entity " +
-                    std::to_string(static_cast<uint32_t>(entity)));
+                    std::to_string(static_cast<u32>(entity)));
     auto &pool = getPoolForComponent<TComponentType>();
 
     return std::any_cast<TComponentType &>(
-        pool.components[pool.entityIndices[static_cast<size_t>(entity)]]);
+        pool.components[pool.entityIndices[static_cast<usize>(entity)]]);
   }
 
   /**
@@ -168,7 +168,7 @@ public:
    * @retval false Entity does not have component
    */
   template <class TComponentType> bool has(Entity entity) const {
-    size_t sEntity = static_cast<size_t>(entity);
+    usize sEntity = static_cast<usize>(entity);
     const auto &pool = getPoolForComponent<TComponentType>();
     return sEntity < pool.entityIndices.size() &&
            pool.entityIndices[sEntity] != DeadIndex;
@@ -181,15 +181,15 @@ public:
    * @param entity Entity
    */
   template <class TComponentType> void remove(Entity entity) {
-    size_t sEntity = static_cast<size_t>(entity);
+    usize sEntity = static_cast<usize>(entity);
 
     auto &pool = getPoolForComponent<TComponentType>();
     QuollAssert(sEntity < pool.entityIndices.size(),
                 "Component named " + String(typeid(TComponentType).name()) +
                     " does not exist for entity " +
-                    std::to_string(static_cast<uint32_t>(entity)));
+                    std::to_string(static_cast<u32>(entity)));
 
-    size_t entityIndexToDelete = pool.entityIndices[sEntity];
+    usize entityIndexToDelete = pool.entityIndices[sEntity];
 
     auto &observers = getRemoveObserverPoolForComponent<TComponentType>();
     for (auto &observer : observers) {
@@ -203,7 +203,7 @@ public:
     pool.entities[entityIndexToDelete] = movedEntity;
 
     // Change index of moved entity to the index of deleted entity
-    pool.entityIndices[static_cast<size_t>(movedEntity)] = entityIndexToDelete;
+    pool.entityIndices[static_cast<usize>(movedEntity)] = entityIndexToDelete;
 
     // Delete last item from entities array
     pool.entities.pop_back();
@@ -223,7 +223,7 @@ public:
    * @tparam TComponentType Component type
    * @return Number of entities
    */
-  template <class TComponentType> size_t getEntityCountForComponent() const {
+  template <class TComponentType> usize getEntityCountForComponent() const {
     return getPoolForComponent<TComponentType>().entities.size();
   }
 
@@ -367,7 +367,7 @@ private:
    * @param iterFn Iterator function
    * @param sequence Index sequence of picked components
    */
-  template <class... TPickComponents, size_t... TPickComponentIndices>
+  template <class... TPickComponents, usize... TPickComponentIndices>
   void iterateEntitiesInternal(
       const std::function<void(Entity, TPickComponents &...)> &iterFn,
       std::index_sequence<TPickComponentIndices...> sequence) {
@@ -385,11 +385,11 @@ private:
 
     const auto &smallestEntities = smallestPool->entities;
 
-    for (size_t i = 0; i < smallestEntities.size(); ++i) {
+    for (usize i = 0; i < smallestEntities.size(); ++i) {
       Entity entity = smallestEntities[i];
 
       bool isDead = false;
-      for (size_t i = 0; i < pickedPools.size() && !isDead; ++i) {
+      for (usize i = 0; i < pickedPools.size() && !isDead; ++i) {
         auto *pool = pickedPools.at(i);
         isDead = entity >= pool->entityIndices.size() ||
                  pool->entityIndices[entity] == DeadIndex;
@@ -447,7 +447,7 @@ private:
 
   Entity mLastEntity{1};
   std::list<Entity> mDeleted;
-  size_t mNumEntities = 0;
+  usize mNumEntities = 0;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/entity/EntityStorageSparseSetComponentPool.h
+++ b/engine/src/quoll/entity/EntityStorageSparseSetComponentPool.h
@@ -9,7 +9,7 @@ struct EntityStorageSparseSetComponentPool {
   /**
    * List of entity indices
    */
-  std::vector<size_t> entityIndices;
+  std::vector<usize> entityIndices;
 
   /**
    * List of Entities

--- a/engine/src/quoll/entity/EntityStorageSparseSetObserver.h
+++ b/engine/src/quoll/entity/EntityStorageSparseSetObserver.h
@@ -22,7 +22,7 @@ public:
      * @param index Index
      * @param pool Picked pools
      */
-    Iterator(size_t index, EntityStorageSparseSetComponentPool *pool)
+    Iterator(usize index, EntityStorageSparseSetComponentPool *pool)
         : mIndex(index), mPool(pool) {}
 
     /**
@@ -64,7 +64,7 @@ public:
     }
 
   private:
-    size_t mIndex = 0;
+    usize mIndex = 0;
     EntityStorageSparseSetComponentPool *mPool;
   };
 
@@ -105,7 +105,7 @@ public:
    *
    * @return Number of observed components
    */
-  inline size_t size() { return mPool->entities.size(); }
+  inline usize size() { return mPool->entities.size(); }
 
   /**
    * @brief Clear observed items

--- a/engine/src/quoll/entity/EntityStorageSparseSetView.h
+++ b/engine/src/quoll/entity/EntityStorageSparseSetView.h
@@ -13,7 +13,7 @@ template <class... TComponentTypes> class EntityStorageSparseSetView {
   using PickedPools = std::array<EntityStorageSparseSetComponentPool *,
                                  sizeof...(TComponentTypes)>;
 
-  static constexpr size_t DeadIndex = std::numeric_limits<size_t>::max();
+  static constexpr usize DeadIndex = std::numeric_limits<usize>::max();
 
 public:
   /**
@@ -28,7 +28,7 @@ public:
      * @param pools Picked pools
      * @param smallestPool Smallest pool
      */
-    Iterator(size_t index, PickedPools &pools,
+    Iterator(usize index, PickedPools &pools,
              EntityStorageSparseSetComponentPool *smallestPool)
         : mIndex(index), mPools(pools), mSmallestPool(smallestPool) {}
 
@@ -83,14 +83,14 @@ public:
      * @param sequence Index sequence
      * @return Tuple with first item as entity and rest as components
      */
-    template <size_t... TComponentIndices>
+    template <usize... TComponentIndices>
     std::tuple<Entity, TComponentTypes &...>
     get(std::index_sequence<TComponentIndices...> sequence) {
       auto entity = mSmallestPool->entities.at(mIndex);
 
       const auto &indices =
           std::array{std::get<TComponentIndices>(mPools)
-                         ->entityIndices[static_cast<size_t>(entity)]...};
+                         ->entityIndices[static_cast<usize>(entity)]...};
 
       return {mSmallestPool->entities.at(mIndex),
               std::any_cast<TComponentTypes &>(
@@ -99,7 +99,7 @@ public:
     }
 
   private:
-    size_t mIndex = 0;
+    usize mIndex = 0;
     PickedPools &mPools;
     EntityStorageSparseSetComponentPool *mSmallestPool = nullptr;
   };
@@ -128,7 +128,7 @@ public:
       }
     }
 
-    size_t index = 0;
+    usize index = 0;
     while (index < mSmallestPool->entities.size() &&
            !isValidIndex(index, mPools, mSmallestPool)) {
       index++;
@@ -160,11 +160,11 @@ private:
    * @retval true Index is valid
    * @retval false Index is not valid
    */
-  static bool isValidIndex(size_t index, PickedPools &pools,
+  static bool isValidIndex(usize index, PickedPools &pools,
                            EntityStorageSparseSetComponentPool *smallestPool) {
     bool isValid = true;
-    auto entity = static_cast<size_t>(smallestPool->entities.at(index));
-    for (size_t i = 0; i < pools.size() && isValid; ++i) {
+    auto entity = static_cast<usize>(smallestPool->entities.at(index));
+    for (usize i = 0; i < pools.size() && isValid; ++i) {
       auto *pool = pools.at(i);
       isValid = entity < pool->entityIndices.size() &&
                 pool->entityIndices[entity] != DeadIndex;

--- a/engine/src/quoll/events/EventObserver.h
+++ b/engine/src/quoll/events/EventObserver.h
@@ -2,8 +2,8 @@
 
 namespace quoll {
 
-using EventObserverId = size_t;
+using EventObserverId = usize;
 
-static constexpr size_t EventObserverMax = std::numeric_limits<size_t>::max();
+static constexpr usize EventObserverMax = std::numeric_limits<usize>::max();
 
 } // namespace quoll

--- a/engine/src/quoll/events/EventPool.h
+++ b/engine/src/quoll/events/EventPool.h
@@ -38,7 +38,7 @@ public:
   /**
    * Default pool size
    */
-  static constexpr size_t DEFAULT_SIZE = 500;
+  static constexpr usize DEFAULT_SIZE = 500;
 
 public:
   /**

--- a/engine/src/quoll/events/EventSystem.h
+++ b/engine/src/quoll/events/EventSystem.h
@@ -114,7 +114,7 @@ private:
    * @tparam Index Tuple index to loop
    * @tparam Size Tuple size
    */
-  template <size_t Index, size_t Size> inline void poll() {
+  template <usize Index, usize Size> inline void poll() {
     if constexpr (Index < Size) {
       std::get<Index>(mPools).poll();
       poll<Index + 1, Size>();

--- a/engine/src/quoll/imgui/ImguiRenderer.h
+++ b/engine/src/quoll/imgui/ImguiRenderer.h
@@ -43,7 +43,7 @@ class ImguiRenderer {
     /**
      * Vertex buffer size
      */
-    size_t vertexBufferSize = 0;
+    usize vertexBufferSize = 0;
 
     /**
      * Vertex buffer data
@@ -58,7 +58,7 @@ class ImguiRenderer {
     /**
      * Index buffer size
      */
-    size_t indexBufferSize = 0;
+    usize indexBufferSize = 0;
 
     /**
      * Index buffer data
@@ -126,7 +126,7 @@ public:
    *
    * @param frameIndex
    */
-  void updateFrameData(uint32_t frameIndex);
+  void updateFrameData(u32 frameIndex);
 
   /**
    * @brief Send imgui data to command list
@@ -136,7 +136,7 @@ public:
    * @param frameIndex Frame index
    */
   void draw(rhi::RenderCommandList &commandList, rhi::PipelineHandle pipeline,
-            uint32_t frameIndex);
+            u32 frameIndex);
 
 private:
   /**
@@ -151,7 +151,7 @@ private:
    */
   void setupRenderStates(ImDrawData *data, rhi::RenderCommandList &commandList,
                          int fbWidth, int fbHeight,
-                         rhi::PipelineHandle pipeline, uint32_t frameIndex);
+                         rhi::PipelineHandle pipeline, u32 frameIndex);
 
 private:
   RenderStorage &mRenderStorage;

--- a/engine/src/quoll/imgui/ImguiUtils.cpp
+++ b/engine/src/quoll/imgui/ImguiUtils.cpp
@@ -18,14 +18,14 @@ constexpr ImVec2 &operator+=(ImVec2 &a, const ImVec2 &b) {
 namespace quoll::imgui {
 
 inline ImTextureID getImguiTexture(quoll::rhi::TextureHandle handle) {
-  return reinterpret_cast<ImTextureID>(static_cast<uintptr_t>(handle));
+  return reinterpret_cast<ImTextureID>(static_cast<uptr>(handle));
 }
 
 void image(quoll::rhi::TextureHandle handle, const ImVec2 &size,
            const ImVec2 &uv0, const ImVec2 &uv1, ImGuiID id,
            const ImVec4 &tint_col, const ImVec4 &border_col) {
 
-  static constexpr float BorderWidth = 2.0f;
+  static constexpr f32 BorderWidth = 2.0f;
 
   ImGuiWindow *window = ImGui::GetCurrentWindow();
   if (window->SkipItems)

--- a/engine/src/quoll/input/InputDevice.h
+++ b/engine/src/quoll/input/InputDevice.h
@@ -4,7 +4,7 @@ namespace quoll {
 
 enum class InputDeviceType { Keyboard, Mouse, Gamepad, Unknown };
 
-using InputStateValue = std::variant<bool, float, glm::vec2>;
+using InputStateValue = std::variant<bool, f32, glm::vec2>;
 
 /**
  * @brief Input device
@@ -23,7 +23,7 @@ struct InputDevice {
   /**
    * Device index
    */
-  uint32_t index = 0;
+  u32 index = 0;
 
   /**
    * Device state function

--- a/engine/src/quoll/input/InputDeviceManager.cpp
+++ b/engine/src/quoll/input/InputDeviceManager.cpp
@@ -14,7 +14,7 @@ void InputDeviceManager::addDevice(InputDevice device) {
       << "Device \"" << device.name << "\" connected";
 }
 
-void InputDeviceManager::removeDevice(InputDeviceType type, uint32_t index) {
+void InputDeviceManager::removeDevice(InputDeviceType type, u32 index) {
   auto it =
       std::find_if(mDevices.begin(), mDevices.end(),
                    [type, index](const InputDevice &existing) {

--- a/engine/src/quoll/input/InputDeviceManager.h
+++ b/engine/src/quoll/input/InputDeviceManager.h
@@ -35,7 +35,7 @@ public:
    * @param type Input device type
    * @param index Input device index
    */
-  void removeDevice(InputDeviceType type, uint32_t index);
+  void removeDevice(InputDeviceType type, u32 index);
 
   /**
    * @brief Get input devices

--- a/engine/src/quoll/input/InputMap.h
+++ b/engine/src/quoll/input/InputMap.h
@@ -19,7 +19,7 @@ struct InputMapAssetRef {
   /**
    * Default scheme
    */
-  size_t defaultScheme = 0;
+  usize defaultScheme = 0;
 };
 
 /**
@@ -29,7 +29,7 @@ struct InputMapBindingTable {
   /**
    * Input key to command map
    */
-  std::unordered_map<int, size_t> inputKeyToCommandMap;
+  std::unordered_map<int, usize> inputKeyToCommandMap;
 
   /**
    * Used to identify what part of a value
@@ -52,7 +52,7 @@ struct InputMap {
   /**
    * Command name to internal command key map
    */
-  std::unordered_map<String, size_t> commandNameMap;
+  std::unordered_map<String, usize> commandNameMap;
 
   /**
    * Command values
@@ -67,12 +67,12 @@ struct InputMap {
   /**
    * Scheme name to internal scheme key map
    */
-  std::unordered_map<String, size_t> schemeNameMap;
+  std::unordered_map<String, usize> schemeNameMap;
 
   /**
    * Currently active scheme
    */
-  size_t activeScheme = 0;
+  usize activeScheme = 0;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/input/InputMapLuaTable.cpp
+++ b/engine/src/quoll/input/InputMapLuaTable.cpp
@@ -11,7 +11,7 @@ namespace quoll {
 InputMapLuaTable::InputMapLuaTable(Entity entity, ScriptGlobals scriptGlobals)
     : mEntity(entity), mScriptGlobals(scriptGlobals) {}
 
-sol_maybe<size_t> InputMapLuaTable::getCommand(String name) {
+sol_maybe<usize> InputMapLuaTable::getCommand(String name) {
   if (!mScriptGlobals.entityDatabase.has<InputMap>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -28,7 +28,7 @@ sol_maybe<size_t> InputMapLuaTable::getCommand(String name) {
   return inputMap.commandNameMap.at(name);
 }
 
-sol_maybe<bool> InputMapLuaTable::getCommandValueBoolean(size_t command) {
+sol_maybe<bool> InputMapLuaTable::getCommandValueBoolean(usize command) {
   if (!mScriptGlobals.entityDatabase.has<InputMap>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -53,8 +53,8 @@ sol_maybe<bool> InputMapLuaTable::getCommandValueBoolean(size_t command) {
   return sol::nil;
 }
 
-std::tuple<sol_maybe<float>, sol_maybe<float>>
-InputMapLuaTable::getCommandValueAxis2d(size_t command) {
+std::tuple<sol_maybe<f32>, sol_maybe<f32>>
+InputMapLuaTable::getCommandValueAxis2d(usize command) {
   if (!mScriptGlobals.entityDatabase.has<InputMap>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);

--- a/engine/src/quoll/input/InputMapLuaTable.h
+++ b/engine/src/quoll/input/InputMapLuaTable.h
@@ -23,7 +23,7 @@ public:
    * @param name Command name
    * @return Command id
    */
-  sol_maybe<size_t> getCommand(String name);
+  sol_maybe<usize> getCommand(String name);
 
   /**
    * @brief Check if command is pressed
@@ -31,7 +31,7 @@ public:
    * @param command Command id
    * @return Command boolean value
    */
-  sol_maybe<bool> getCommandValueBoolean(size_t command);
+  sol_maybe<bool> getCommandValueBoolean(usize command);
 
   /**
    * @brief Get axis 2d command value
@@ -39,8 +39,8 @@ public:
    * @param command Command id
    * @return Command 2d axis value
    */
-  std::tuple<sol_maybe<float>, sol_maybe<float>>
-  getCommandValueAxis2d(size_t command);
+  std::tuple<sol_maybe<f32>, sol_maybe<f32>>
+  getCommandValueAxis2d(usize command);
 
   /**
    * @brief Set scheme

--- a/engine/src/quoll/input/InputMapSystem.cpp
+++ b/engine/src/quoll/input/InputMapSystem.cpp
@@ -30,7 +30,7 @@ void InputMapSystem::update(EntityDatabase &entityDatabase) {
   }
 
   for (auto [_, inputMap] : entityDatabase.view<InputMap>()) {
-    for (size_t i = 0; i < inputMap.commandValues.size(); ++i) {
+    for (usize i = 0; i < inputMap.commandValues.size(); ++i) {
       auto type = inputMap.commandDataTypes.at(i);
       if (type == InputDataType::Boolean) {
         inputMap.commandValues.at(i) = false;
@@ -54,7 +54,7 @@ void InputMapSystem::update(EntityDatabase &entityDatabase) {
 
           if (auto *inputValue = std::get_if<bool>(&variant)) {
             commandValue |= *inputValue;
-          } else if (auto *inputValue = std::get_if<float>(&variant)) {
+          } else if (auto *inputValue = std::get_if<f32>(&variant)) {
             commandValue |= (*inputValue != 0.0f);
           } else if (auto *inputValue = std::get_if<glm::vec2>(&variant)) {
             commandValue |= (inputValue->x != 0.0f || inputValue->y != 0.0f);
@@ -76,7 +76,7 @@ void InputMapSystem::update(EntityDatabase &entityDatabase) {
               commandValue.y += 1.0f;
             }
 
-          } else if (auto *inputValue = std::get_if<float>(&variant)) {
+          } else if (auto *inputValue = std::get_if<f32>(&variant)) {
             auto field = scheme.inputKeyFields.at(key);
             if (field == InputDataTypeField::X) {
               commandValue.x += *inputValue;
@@ -109,7 +109,7 @@ void InputMapSystem::update(EntityDatabase &entityDatabase) {
 }
 
 InputMap InputMapSystem::createInputMap(InputMapAsset &asset,
-                                        size_t defaultScheme) {
+                                        usize defaultScheme) {
   InputMap inputMap{};
 
   inputMap.activeScheme = std::min(defaultScheme, asset.schemes.size() - 1);
@@ -118,12 +118,12 @@ InputMap InputMapSystem::createInputMap(InputMapAsset &asset,
   inputMap.commandValues.resize(asset.commands.size());
   inputMap.schemes.resize(asset.schemes.size());
 
-  size_t schemeIndex = 0;
+  usize schemeIndex = 0;
   for (const auto &scheme : asset.schemes) {
     inputMap.schemeNameMap.insert_or_assign(scheme.name, schemeIndex++);
   }
 
-  size_t commandIndex = 0;
+  usize commandIndex = 0;
   for (const auto &command : asset.commands) {
     inputMap.commandNameMap.insert_or_assign(command.name, commandIndex++);
     inputMap.commandDataTypes.push_back(command.type);

--- a/engine/src/quoll/input/InputMapSystem.h
+++ b/engine/src/quoll/input/InputMapSystem.h
@@ -31,7 +31,7 @@ public:
   void update(EntityDatabase &entityDatabase);
 
 private:
-  InputMap createInputMap(InputMapAsset &asset, size_t defaultScheme);
+  InputMap createInputMap(InputMapAsset &asset, usize defaultScheme);
 
 private:
   InputDeviceManager &mDeviceManager;

--- a/engine/src/quoll/loaders/ImageTextureLoader.cpp
+++ b/engine/src/quoll/loaders/ImageTextureLoader.cpp
@@ -32,9 +32,8 @@ rhi::TextureHandle ImageTextureLoader::loadFromFile(const Path &path) {
   TextureUtils::copyDataToTexture(
       mRenderStorage.getDevice(), data, texture,
       rhi::ImageLayout::ShaderReadOnlyOptimal, 1,
-      {TextureAssetLevel{0, static_cast<size_t>(width) * height * channels,
-                         static_cast<uint32_t>(width),
-                         static_cast<uint32_t>(height)}});
+      {TextureAssetLevel{0, static_cast<usize>(width) * height * channels,
+                         static_cast<u32>(width), static_cast<u32>(height)}});
 
   return texture;
 }

--- a/engine/src/quoll/loop/MainLoop.cpp
+++ b/engine/src/quoll/loop/MainLoop.cpp
@@ -9,7 +9,7 @@ namespace quoll {
 MainLoop::MainLoop(Window &window, FPSCounter &fpsCounter)
     : mWindow(window), mFpsCounter(fpsCounter) {}
 
-void MainLoop::setUpdateFn(const std::function<bool(float)> &updateFn) {
+void MainLoop::setUpdateFn(const std::function<bool(f32)> &updateFn) {
   mUpdateFn = updateFn;
 }
 
@@ -20,12 +20,12 @@ void MainLoop::setRenderFn(const std::function<void()> &renderFn) {
 void MainLoop::run() {
   bool running = true;
 
-  static constexpr uint32_t OneSecondInMs = 1000;
-  static constexpr double MaxUpdateTime = 0.25;
-  static constexpr double TimeDelta = 0.01;
+  static constexpr u32 OneSecondInMs = 1000;
+  static constexpr f64 MaxUpdateTime = 0.25;
+  static constexpr f64 TimeDelta = 0.01;
 
-  uint32_t frames = 0;
-  double accumulator = 0.0;
+  u32 frames = 0;
+  f64 accumulator = 0.0;
 
   auto prevGameTime = std::chrono::high_resolution_clock::now();
   auto prevFrameTime = prevGameTime;
@@ -39,15 +39,15 @@ void MainLoop::run() {
 
     mWindow.pollEvents();
 
-    double frameTime = std::clamp(
-        std::chrono::duration<double>(currentTime - prevGameTime).count(), 0.0,
+    f64 frameTime = std::clamp(
+        std::chrono::duration<f64>(currentTime - prevGameTime).count(), 0.0,
         MaxUpdateTime);
 
     prevGameTime = currentTime;
     accumulator += frameTime;
 
     while (accumulator >= TimeDelta) {
-      running = mUpdateFn(static_cast<float>(TimeDelta));
+      running = mUpdateFn(static_cast<f32>(TimeDelta));
       accumulator -= TimeDelta;
     }
 

--- a/engine/src/quoll/loop/MainLoop.h
+++ b/engine/src/quoll/loop/MainLoop.h
@@ -32,7 +32,7 @@ public:
    *
    * @param updateFn Update function
    */
-  void setUpdateFn(const std::function<bool(float)> &updateFn);
+  void setUpdateFn(const std::function<bool(f32)> &updateFn);
 
   /**
    * @brief Set render function
@@ -44,7 +44,7 @@ public:
 private:
   Window &mWindow;
   FPSCounter &mFpsCounter;
-  std::function<bool(float)> mUpdateFn;
+  std::function<bool(f32)> mUpdateFn;
   std::function<void()> mRenderFn;
 };
 } // namespace quoll

--- a/engine/src/quoll/physics/CollidableLuaTable.cpp
+++ b/engine/src/quoll/physics/CollidableLuaTable.cpp
@@ -21,7 +21,7 @@ void CollidableLuaTable::setDefaultMaterial() {
   }
 }
 
-sol_maybe<float> CollidableLuaTable::getStaticFriction() {
+sol_maybe<f32> CollidableLuaTable::getStaticFriction() {
   if (!mScriptGlobals.entityDatabase.has<Collidable>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -32,7 +32,7 @@ sol_maybe<float> CollidableLuaTable::getStaticFriction() {
       .materialDesc.staticFriction;
 }
 
-void CollidableLuaTable::setStaticFriction(float staticFriction) {
+void CollidableLuaTable::setStaticFriction(f32 staticFriction) {
   if (!mScriptGlobals.entityDatabase.has<Collidable>(mEntity)) {
     Collidable collidable{};
     collidable.materialDesc.staticFriction = staticFriction;
@@ -43,7 +43,7 @@ void CollidableLuaTable::setStaticFriction(float staticFriction) {
   }
 }
 
-sol_maybe<float> CollidableLuaTable::getDynamicFriction() {
+sol_maybe<f32> CollidableLuaTable::getDynamicFriction() {
   if (!mScriptGlobals.entityDatabase.has<Collidable>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -54,7 +54,7 @@ sol_maybe<float> CollidableLuaTable::getDynamicFriction() {
       .materialDesc.dynamicFriction;
 }
 
-void CollidableLuaTable::setDynamicFriction(float dynamicFriction) {
+void CollidableLuaTable::setDynamicFriction(f32 dynamicFriction) {
   if (!mScriptGlobals.entityDatabase.has<Collidable>(mEntity)) {
     Collidable collidable{};
     collidable.materialDesc.dynamicFriction = dynamicFriction;
@@ -65,7 +65,7 @@ void CollidableLuaTable::setDynamicFriction(float dynamicFriction) {
   }
 }
 
-sol_maybe<float> CollidableLuaTable::getRestitution() {
+sol_maybe<f32> CollidableLuaTable::getRestitution() {
   if (!mScriptGlobals.entityDatabase.has<Collidable>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -76,7 +76,7 @@ sol_maybe<float> CollidableLuaTable::getRestitution() {
       .materialDesc.restitution;
 }
 
-void CollidableLuaTable::setRestitution(float restitution) {
+void CollidableLuaTable::setRestitution(f32 restitution) {
   if (!mScriptGlobals.entityDatabase.has<Collidable>(mEntity)) {
     Collidable collidable{};
     collidable.materialDesc.restitution = restitution;
@@ -87,7 +87,7 @@ void CollidableLuaTable::setRestitution(float restitution) {
   }
 }
 
-void CollidableLuaTable::setBoxGeometry(float hx, float hy, float hz) {
+void CollidableLuaTable::setBoxGeometry(f32 hx, f32 hy, f32 hz) {
   glm::vec3 halfExtents{hx, hy, hz};
 
   if (!mScriptGlobals.entityDatabase.has<Collidable>(mEntity)) {
@@ -102,7 +102,7 @@ void CollidableLuaTable::setBoxGeometry(float hx, float hy, float hz) {
   }
 }
 
-void CollidableLuaTable::setSphereGeometry(float radius) {
+void CollidableLuaTable::setSphereGeometry(f32 radius) {
   if (!mScriptGlobals.entityDatabase.has<Collidable>(mEntity)) {
     Collidable collidable{};
     collidable.geometryDesc.type = PhysicsGeometryType::Sphere;
@@ -115,7 +115,7 @@ void CollidableLuaTable::setSphereGeometry(float radius) {
   }
 }
 
-void CollidableLuaTable::setCapsuleGeometry(float radius, float halfHeight) {
+void CollidableLuaTable::setCapsuleGeometry(f32 radius, f32 halfHeight) {
   if (!mScriptGlobals.entityDatabase.has<Collidable>(mEntity)) {
     Collidable collidable{};
     collidable.geometryDesc.type = PhysicsGeometryType::Capsule;
@@ -143,7 +143,7 @@ void CollidableLuaTable::setPlaneGeometry() {
 }
 
 std::tuple<bool, sol_maybe<CollisionHit>>
-CollidableLuaTable::sweep(float dx, float dy, float dz, float distance) {
+CollidableLuaTable::sweep(f32 dx, f32 dy, f32 dz, f32 distance) {
   CollisionHit hit{};
   auto result = mScriptGlobals.physicsSystem.sweep(
       mScriptGlobals.entityDatabase, mEntity, {dx, dy, dz}, distance, hit);

--- a/engine/src/quoll/physics/CollidableLuaTable.h
+++ b/engine/src/quoll/physics/CollidableLuaTable.h
@@ -28,42 +28,42 @@ public:
    *
    * @return Static friction
    */
-  sol_maybe<float> getStaticFriction();
+  sol_maybe<f32> getStaticFriction();
 
   /**
    * @brief Set static friction
    *
    * @param staticFriction Static friction
    */
-  void setStaticFriction(float staticFriction);
+  void setStaticFriction(f32 staticFriction);
 
   /**
    * @brief Get dynamic friction
    *
    * @return Dynamic friction
    */
-  sol_maybe<float> getDynamicFriction();
+  sol_maybe<f32> getDynamicFriction();
 
   /**
    * @brief Set dynamic friction
    *
    * @param dynamicFriction Dynamic friction
    */
-  void setDynamicFriction(float dynamicFriction);
+  void setDynamicFriction(f32 dynamicFriction);
 
   /**
    * @brief Get restitution
    *
    * @return Restitution
    */
-  sol_maybe<float> getRestitution();
+  sol_maybe<f32> getRestitution();
 
   /**
    * @brief Set restitution
    *
    * @param restitution Restitution
    */
-  void setRestitution(float restitution);
+  void setRestitution(f32 restitution);
 
   /**
    * @brief Set box geometry
@@ -72,14 +72,14 @@ public:
    * @param hy Half extent in y axis
    * @param hz Half extent in z axis
    */
-  void setBoxGeometry(float hx, float hy, float hz);
+  void setBoxGeometry(f32 hx, f32 hy, f32 hz);
 
   /**
    * @brief Set sphere geometry
    *
    * @param radius Sphere radius
    */
-  void setSphereGeometry(float radius);
+  void setSphereGeometry(f32 radius);
 
   /**
    * @brief Set capsule geometry
@@ -87,7 +87,7 @@ public:
    * @param radius Capsule radius
    * @param halfHeight Capsule half height
    */
-  void setCapsuleGeometry(float radius, float halfHeight);
+  void setCapsuleGeometry(f32 radius, f32 halfHeight);
 
   /**
    * @brief Set plane geometry
@@ -103,8 +103,8 @@ public:
    * @param distance Sweep distance
    * @return Collision hit
    */
-  std::tuple<bool, sol_maybe<CollisionHit>> sweep(float dx, float dy, float dz,
-                                                  float distance);
+  std::tuple<bool, sol_maybe<CollisionHit>> sweep(f32 dx, f32 dy, f32 dz,
+                                                  f32 distance);
 
   /**
    * @brief Delete component

--- a/engine/src/quoll/physics/PhysicsBackend.h
+++ b/engine/src/quoll/physics/PhysicsBackend.h
@@ -33,7 +33,7 @@ public:
    * @param dt Time delta
    * @param entityDatabase Entity database
    */
-  virtual void update(float dt, EntityDatabase &entityDatabase) = 0;
+  virtual void update(f32 dt, EntityDatabase &entityDatabase) = 0;
 
   /**
    * @brief Cleanup physics data
@@ -61,7 +61,7 @@ public:
    * @retval false Entity not collided
    */
   virtual bool sweep(EntityDatabase &entityDatabase, Entity entity,
-                     const glm::vec3 &direction, float distance,
+                     const glm::vec3 &direction, f32 distance,
                      CollisionHit &hit) = 0;
 };
 

--- a/engine/src/quoll/physics/PhysicsObjects.h
+++ b/engine/src/quoll/physics/PhysicsObjects.h
@@ -9,17 +9,17 @@ struct PhysicsMaterialDesc {
   /**
    * Static friction
    */
-  float staticFriction = 0.0f;
+  f32 staticFriction = 0.0f;
 
   /**
    * Dynamic friction
    */
-  float dynamicFriction = 0.0f;
+  f32 dynamicFriction = 0.0f;
 
   /**
    * Restitution
    */
-  float restitution = 1.0f;
+  f32 restitution = 1.0f;
 };
 
 /**
@@ -55,7 +55,7 @@ struct PhysicsGeometrySphere {
   /**
    * Sphere radius
    */
-  float radius = 1.0f;
+  f32 radius = 1.0f;
 };
 
 /**
@@ -73,12 +73,12 @@ struct PhysicsGeometryCapsule {
   /**
    * Capsule radius
    */
-  float radius = 1.0f;
+  f32 radius = 1.0f;
 
   /**
    * Capsule half height
    */
-  float halfHeight = 0.5f;
+  f32 halfHeight = 0.5f;
 };
 
 /**
@@ -122,7 +122,7 @@ struct PhysicsDynamicRigidBodyDesc {
   /**
    * Mass
    */
-  float mass = 1.0f;
+  f32 mass = 1.0f;
 
   /**
    * Inertia

--- a/engine/src/quoll/physics/PhysicsSystem.h
+++ b/engine/src/quoll/physics/PhysicsSystem.h
@@ -34,7 +34,7 @@ public:
    * @param dt Time delta
    * @param entityDatabase Entity database
    */
-  inline void update(float dt, EntityDatabase &entityDatabase) {
+  inline void update(f32 dt, EntityDatabase &entityDatabase) {
     mBackend->update(dt, entityDatabase);
   }
 
@@ -68,7 +68,7 @@ public:
    * @retval false Entity not collided
    */
   inline bool sweep(EntityDatabase &entityDatabase, Entity entity,
-                    const glm::vec3 &direction, float distance,
+                    const glm::vec3 &direction, f32 distance,
                     CollisionHit &hit) {
     return mBackend->sweep(entityDatabase, entity, direction, distance, hit);
   }

--- a/engine/src/quoll/physics/RigidBodyLuaTable.cpp
+++ b/engine/src/quoll/physics/RigidBodyLuaTable.cpp
@@ -15,7 +15,7 @@ void RigidBodyLuaTable::setDefaultParams() {
   mScriptGlobals.entityDatabase.set<RigidBody>(mEntity, {});
 }
 
-sol_maybe<float> RigidBodyLuaTable::getMass() {
+sol_maybe<f32> RigidBodyLuaTable::getMass() {
   if (!mScriptGlobals.entityDatabase.has<RigidBody>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -25,7 +25,7 @@ sol_maybe<float> RigidBodyLuaTable::getMass() {
   return mScriptGlobals.entityDatabase.get<RigidBody>(mEntity).dynamicDesc.mass;
 }
 
-void RigidBodyLuaTable::setMass(float mass) {
+void RigidBodyLuaTable::setMass(f32 mass) {
   if (!mScriptGlobals.entityDatabase.has<RigidBody>(mEntity)) {
     RigidBody rigidBody{};
     rigidBody.dynamicDesc.mass = mass;
@@ -36,7 +36,7 @@ void RigidBodyLuaTable::setMass(float mass) {
   }
 }
 
-std::tuple<sol_maybe<float>, sol_maybe<float>, sol_maybe<float>>
+std::tuple<sol_maybe<f32>, sol_maybe<f32>, sol_maybe<f32>>
 RigidBodyLuaTable::getInertia() {
   if (!mScriptGlobals.entityDatabase.has<RigidBody>(mEntity)) {
     Engine::getUserLogger().error()
@@ -50,7 +50,7 @@ RigidBodyLuaTable::getInertia() {
   return {inertia.x, inertia.y, inertia.z};
 }
 
-void RigidBodyLuaTable::setInertia(float x, float y, float z) {
+void RigidBodyLuaTable::setInertia(f32 x, f32 y, f32 z) {
   glm::vec3 inertia{x, y, z};
 
   if (!mScriptGlobals.entityDatabase.has<RigidBody>(mEntity)) {
@@ -85,12 +85,12 @@ void RigidBodyLuaTable::applyGravity(bool apply) {
   }
 }
 
-void RigidBodyLuaTable::applyForce(float x, float y, float z) {
+void RigidBodyLuaTable::applyForce(f32 x, f32 y, f32 z) {
   glm::vec3 force{x, y, z};
   mScriptGlobals.entityDatabase.set<Force>(mEntity, {force});
 }
 
-void RigidBodyLuaTable::applyTorque(float x, float y, float z) {
+void RigidBodyLuaTable::applyTorque(f32 x, f32 y, f32 z) {
   glm::vec3 torque{x, y, z};
   mScriptGlobals.entityDatabase.set<Torque>(mEntity, {torque});
 }

--- a/engine/src/quoll/physics/RigidBodyLuaTable.h
+++ b/engine/src/quoll/physics/RigidBodyLuaTable.h
@@ -27,21 +27,21 @@ public:
    *
    * @return Mass
    */
-  sol_maybe<float> getMass();
+  sol_maybe<f32> getMass();
 
   /**
    * @brief Set mass
    *
    * @param mass Mass
    */
-  void setMass(float mass);
+  void setMass(f32 mass);
 
   /**
    * @brief Get inertia
    *
    * @return Inertia
    */
-  std::tuple<sol_maybe<float>, sol_maybe<float>, sol_maybe<float>> getInertia();
+  std::tuple<sol_maybe<f32>, sol_maybe<f32>, sol_maybe<f32>> getInertia();
 
   /**
    * @brief Set inertia
@@ -50,7 +50,7 @@ public:
    * @param y Inertia in y axis
    * @param z Inertia in z axis
    */
-  void setInertia(float x, float y, float z);
+  void setInertia(f32 x, f32 y, f32 z);
 
   /**
    * @brief Check if gravity is applied
@@ -74,7 +74,7 @@ public:
    * @param y Force in y axis
    * @param z Force in z axis
    */
-  void applyForce(float x, float y, float z);
+  void applyForce(f32 x, f32 y, f32 z);
 
   /**
    * @brief Apply torque
@@ -83,7 +83,7 @@ public:
    * @param y Torque in y axis
    * @param z Torque in z axis
    */
-  void applyTorque(float x, float y, float z);
+  void applyTorque(f32 x, f32 y, f32 z);
 
   /**
    * @brief Clear force and torque

--- a/engine/src/quoll/physx/PhysxBackend.cpp
+++ b/engine/src/quoll/physx/PhysxBackend.cpp
@@ -98,8 +98,8 @@ static PxFilterFlags phyxFilterAllCollisionShader(
 
 PhysxBackend::PhysxBackend(EventSystem &eventSystem)
     : mSimulationEventCallback(eventSystem) {
-  static constexpr uint32_t PvdPort = 5425;
-  static constexpr uint32_t PvdTimeoutInMs = 2000;
+  static constexpr u32 PvdPort = 5425;
+  static constexpr u32 PvdTimeoutInMs = 2000;
   static constexpr glm::vec3 Gravity(0.0f, -9.8f, 0.0f);
 
   mFoundation = PxCreateFoundation(PX_PHYSICS_VERSION, mDefaultAllocator,
@@ -145,7 +145,7 @@ PhysxBackend::~PhysxBackend() {
   mFoundation->release();
 }
 
-void PhysxBackend::update(float dt, EntityDatabase &entityDatabase) {
+void PhysxBackend::update(f32 dt, EntityDatabase &entityDatabase) {
   QUOLL_PROFILE_EVENT("PhysicsSystem::update");
 
   synchronizeComponents(entityDatabase);
@@ -184,7 +184,7 @@ void PhysxBackend::observeChanges(EntityDatabase &entityDatabase) {
 }
 
 bool PhysxBackend::sweep(EntityDatabase &entityDatabase, Entity entity,
-                         const glm::vec3 &direction, float distance,
+                         const glm::vec3 &direction, f32 distance,
                          CollisionHit &hit) {
   QuollAssert(entityDatabase.has<PhysxInstance>(entity),
               "Physx instance not found");
@@ -302,7 +302,7 @@ void PhysxBackend::synchronizeComponents(EntityDatabase &entityDatabase) {
             PhysxMapping::getPhysxTransform(world.worldTransform));
         physx.rigidStatic->attachShape(*physx.shape);
         physx.rigidStatic->userData =
-            reinterpret_cast<void *>(static_cast<uintptr_t>(entity));
+            reinterpret_cast<void *>(static_cast<uptr>(entity));
 
         mScene->addActor(*physx.rigidStatic);
       } else if (physx.rigidStatic) {
@@ -327,7 +327,7 @@ void PhysxBackend::synchronizeComponents(EntityDatabase &entityDatabase) {
         physx.rigidDynamic = mPhysics->createRigidDynamic(
             PhysxMapping::getPhysxTransform(world.worldTransform));
         physx.rigidDynamic->userData =
-            reinterpret_cast<void *>(static_cast<uintptr_t>(entity));
+            reinterpret_cast<void *>(static_cast<uptr>(entity));
 
         mScene->addActor(*physx.rigidDynamic);
 
@@ -393,7 +393,7 @@ void PhysxBackend::synchronizeComponents(EntityDatabase &entityDatabase) {
 
 void PhysxBackend::synchronizeTransforms(EntityDatabase &entityDatabase) {
   QUOLL_PROFILE_EVENT("PhysicsSystem::synchronizeTransforms");
-  uint32_t count = 0;
+  u32 count = 0;
   auto **actors = mScene->getActiveActors(count);
 
   {
@@ -401,7 +401,7 @@ void PhysxBackend::synchronizeTransforms(EntityDatabase &entityDatabase) {
     // calculate world transforms first so that local
     // transforms are calculated from the most recent
     // values
-    for (uint32_t i = 0; i < count; ++i) {
+    for (u32 i = 0; i < count; ++i) {
       if (actors[i]->getType() != PxActorType::eRIGID_DYNAMIC) {
         continue;
       }
@@ -409,7 +409,7 @@ void PhysxBackend::synchronizeTransforms(EntityDatabase &entityDatabase) {
       const auto &globalTransform = actor->getGlobalPose();
 
       Entity entity =
-          static_cast<Entity>(reinterpret_cast<uintptr_t>(actor->userData));
+          static_cast<Entity>(reinterpret_cast<uptr>(actor->userData));
 
       glm::vec3 position(globalTransform.p.x, globalTransform.p.y,
                          globalTransform.p.z);
@@ -437,7 +437,7 @@ void PhysxBackend::synchronizeTransforms(EntityDatabase &entityDatabase) {
   {
     QUOLL_PROFILE_EVENT("Synchronize local transforms");
     // Calculate local transforms from parent world transforms
-    for (uint32_t i = 0; i < count; ++i) {
+    for (u32 i = 0; i < count; ++i) {
       if (actors[i]->getType() != PxActorType::eRIGID_DYNAMIC) {
         continue;
       }
@@ -445,7 +445,7 @@ void PhysxBackend::synchronizeTransforms(EntityDatabase &entityDatabase) {
       const auto &globalTransform = actor->getGlobalPose();
 
       Entity entity =
-          static_cast<Entity>(reinterpret_cast<uintptr_t>(actor->userData));
+          static_cast<Entity>(reinterpret_cast<uptr>(actor->userData));
 
       glm::vec3 position(globalTransform.p.x, globalTransform.p.y,
                          globalTransform.p.z);

--- a/engine/src/quoll/physx/PhysxBackend.h
+++ b/engine/src/quoll/physx/PhysxBackend.h
@@ -45,7 +45,7 @@ public:
    * @param dt Time delta
    * @param entityDatabase Entity database
    */
-  void update(float dt, EntityDatabase &entityDatabase) override;
+  void update(f32 dt, EntityDatabase &entityDatabase) override;
 
   /**
    * @brief Cleanup Physx actors and shapes
@@ -73,7 +73,7 @@ public:
    * @retval false Entity not collided
    */
   bool sweep(EntityDatabase &entityDatabase, Entity entity,
-             const glm::vec3 &direction, float distance,
+             const glm::vec3 &direction, f32 distance,
              CollisionHit &hit) override;
 
 private:

--- a/engine/src/quoll/physx/PhysxSimulationEventCallback.cpp
+++ b/engine/src/quoll/physx/PhysxSimulationEventCallback.cpp
@@ -24,10 +24,8 @@ void PhysxSimulationEventCallback::onContact(
   auto *actor1 = pairHeader.actors[0];
   auto *actor2 = pairHeader.actors[1];
 
-  Entity e1 =
-      static_cast<Entity>(reinterpret_cast<uintptr_t>(actor1->userData));
-  Entity e2 =
-      static_cast<Entity>(reinterpret_cast<uintptr_t>(actor2->userData));
+  Entity e1 = static_cast<Entity>(reinterpret_cast<uptr>(actor1->userData));
+  Entity e2 = static_cast<Entity>(reinterpret_cast<uptr>(actor2->userData));
 
   for (PxU32 i = 0; i < nbPairs; ++i) {
     const PxContactPair &cp = pairs[i];

--- a/engine/src/quoll/profiler/FPSCounter.cpp
+++ b/engine/src/quoll/profiler/FPSCounter.cpp
@@ -3,6 +3,6 @@
 
 namespace quoll {
 
-void FPSCounter::collectFPS(uint32_t fps) { mFps = fps; }
+void FPSCounter::collectFPS(u32 fps) { mFps = fps; }
 
 } // namespace quoll

--- a/engine/src/quoll/profiler/FPSCounter.h
+++ b/engine/src/quoll/profiler/FPSCounter.h
@@ -12,17 +12,17 @@ public:
    *
    * @param fps Frames per second
    */
-  void collectFPS(uint32_t fps);
+  void collectFPS(u32 fps);
 
   /**
    * @brief Get frames per second
    *
    * @return Frames per second
    */
-  inline uint32_t getFPS() const { return mFps; }
+  inline u32 getFPS() const { return mFps; }
 
 private:
-  uint32_t mFps = 0;
+  u32 mFps = 0;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/profiler/ImguiDebugLayer.cpp
+++ b/engine/src/quoll/profiler/ImguiDebugLayer.cpp
@@ -30,11 +30,11 @@ void ImguiDebugLayer::render() {
 }
 
 void ImguiDebugLayer::renderPerformanceMetrics() {
-  const uint32_t ONE_SECOND_IN_MS = 1000;
+  const u32 ONE_SECOND_IN_MS = 1000;
   if (!mPerformanceMetricsVisible)
     return;
 
-  uint32_t fps = mFpsCounter.getFPS();
+  u32 fps = mFpsCounter.getFPS();
 
   if (ImGui::Begin("Performance Metrics", &mPerformanceMetricsVisible,
                    ImGuiWindowFlags_NoDocking)) {
@@ -61,15 +61,15 @@ void ImguiDebugLayer::renderUsageMetrics() {
                    ImGuiWindowFlags_NoDocking)) {
 
     static const std::array<String, 3> Units{"bytes", "Kb", "Mb"};
-    static constexpr float Kilo = 1024.0f;
+    static constexpr f32 Kilo = 1024.0f;
 
-    auto getSizeString = [](size_t size) {
-      if (size < static_cast<size_t>(Kilo)) {
+    auto getSizeString = [](usize size) {
+      if (size < static_cast<usize>(Kilo)) {
         return std::to_string(size) + " " + Units.at(0);
       }
-      float humanReadableSize = static_cast<float>(size);
+      f32 humanReadableSize = static_cast<f32>(size);
 
-      size_t i = 1;
+      usize i = 1;
       for (; i < Units.size() && humanReadableSize >= Kilo; ++i) {
         humanReadableSize /= Kilo;
       }

--- a/engine/src/quoll/renderer/BindlessDrawParameters.cpp
+++ b/engine/src/quoll/renderer/BindlessDrawParameters.cpp
@@ -4,7 +4,7 @@
 namespace quoll {
 
 void BindlessDrawParameters::build(rhi::RenderDevice *device) {
-  size_t maxSize = 0;
+  usize maxSize = 0;
   for (auto &range : mRanges) {
     maxSize = std::max(range.size, maxSize);
   }
@@ -21,7 +21,7 @@ void BindlessDrawParameters::build(rhi::RenderDevice *device) {
 
     mBuffer = device->createBuffer(description);
 
-    uint8_t *data = static_cast<uint8_t *>(mBuffer.map());
+    u8 *data = static_cast<u8 *>(mBuffer.map());
     for (const auto &range : mRanges) {
       memcpy(data + range.offset, range.data, range.size);
     }
@@ -48,7 +48,7 @@ void BindlessDrawParameters::build(rhi::RenderDevice *device) {
 
     rhi::DescriptorBufferInfo info{};
     info.offset = 0;
-    info.range = static_cast<uint32_t>(maxSize);
+    info.range = static_cast<u32>(maxSize);
     info.buffer = mBuffer.getHandle();
 
     std::array<rhi::DescriptorBufferInfo, 1> bufferInfos{info};
@@ -66,8 +66,8 @@ void BindlessDrawParameters::destroy(rhi::RenderDevice *device) {
   }
 }
 
-size_t
-BindlessDrawParameters::padSizeToMinimumUniformAlignment(size_t originalSize) {
+usize BindlessDrawParameters::padSizeToMinimumUniformAlignment(
+    usize originalSize) {
   if (mMinBufferAlignment > 0) {
     return (originalSize + mMinBufferAlignment - 1) &
            ~(mMinBufferAlignment - 1);

--- a/engine/src/quoll/renderer/BindlessDrawParameters.h
+++ b/engine/src/quoll/renderer/BindlessDrawParameters.h
@@ -9,8 +9,8 @@ namespace quoll {
  */
 class BindlessDrawParameters {
   struct Range {
-    size_t offset = 0;
-    size_t size = 0;
+    usize offset = 0;
+    usize size = 0;
     void *data = nullptr;
   };
 
@@ -20,7 +20,7 @@ public:
    *
    * @param minBufferAlignment Minimum buffer alignment
    */
-  BindlessDrawParameters(size_t minBufferAlignment)
+  BindlessDrawParameters(usize minBufferAlignment)
       : mMinBufferAlignment(minBufferAlignment) {}
 
   /**
@@ -30,12 +30,12 @@ public:
    * @param data Data
    * @return Range offset
    */
-  template <class TData> size_t addRange(TData &&data) {
-    size_t structSize = sizeof(TData);
+  template <class TData> usize addRange(TData &&data) {
+    usize structSize = sizeof(TData);
     auto *bytes = new TData;
     *bytes = data;
 
-    size_t currentOffset = mLastOffset;
+    usize currentOffset = mLastOffset;
     mRanges.push_back({currentOffset, structSize, bytes});
 
     mLastOffset += padSizeToMinimumUniformAlignment(structSize);
@@ -70,12 +70,12 @@ private:
    * @param originalSize Original size
    * @return Padded size
    */
-  size_t padSizeToMinimumUniformAlignment(size_t originalSize);
+  usize padSizeToMinimumUniformAlignment(usize originalSize);
 
 private:
   std::vector<Range> mRanges;
-  size_t mLastOffset = 0;
-  size_t mMinBufferAlignment = 0;
+  usize mLastOffset = 0;
+  usize mMinBufferAlignment = 0;
 
   rhi::Buffer mBuffer;
   rhi::DescriptorLayoutHandle mDescriptorLayout =

--- a/engine/src/quoll/renderer/HandleCounter.h
+++ b/engine/src/quoll/renderer/HandleCounter.h
@@ -8,7 +8,7 @@ namespace quoll {
  * @tparam THandle Handle type
  * @tparam TStart Starting index
  */
-template <class THandle, uint32_t TStart = 1> class HandleCounter {
+template <class THandle, u32 TStart = 1> class HandleCounter {
 public:
   /**
    * @brief Create handle
@@ -16,12 +16,12 @@ public:
    * @return New handle
    */
   THandle create() {
-    uint32_t handle = mLastHandle++;
+    u32 handle = mLastHandle++;
     return static_cast<THandle>(handle);
   }
 
 private:
-  uint32_t mLastHandle = TStart;
+  u32 mLastHandle = TStart;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/Material.cpp
+++ b/engine/src/quoll/renderer/Material.cpp
@@ -10,7 +10,7 @@ Material::Material(const String &name,
                    RenderStorage &renderStorage)
     : mTextures(textures) {
 
-  for (size_t i = 0; i < properties.size(); ++i) {
+  for (usize i = 0; i < properties.size(); ++i) {
     auto &prop = properties[i];
     mProperties.push_back(prop.second);
     mPropertyMap.insert({prop.first, i});
@@ -33,7 +33,7 @@ void Material::updateProperty(StringView name, const Property &value) {
     return;
   }
 
-  size_t index = (*it).second;
+  usize index = (*it).second;
 
   if (mProperties.at(index).getType() != value.getType()) {
     Engine::getLogger().warning()
@@ -47,15 +47,15 @@ void Material::updateProperty(StringView name, const Property &value) {
   mBuffer.update(mData, size);
 }
 
-size_t Material::updateBufferData() {
+usize Material::updateBufferData() {
   if (mData) {
     delete mData;
   }
 
-  size_t size = 0;
-  size_t idx = 0;
+  usize size = 0;
+  usize idx = 0;
 
-  size_t maxValue = 0;
+  usize maxValue = 0;
   for (auto &value : mProperties) {
     maxValue = maxValue > value.getSize() ? maxValue : value.getSize();
   }
@@ -66,13 +66,13 @@ size_t Material::updateBufferData() {
 
   for (auto &value : mProperties) {
     if (value.getType() == Property::INT32) {
-      auto val = value.getValue<int32_t>();
+      auto val = value.getValue<i32>();
       memcpy(mData + idx, &val, maxValue);
     } else if (value.getType() == Property::UINT32) {
-      auto val = value.getValue<uint32_t>();
+      auto val = value.getValue<u32>();
       memcpy(mData + idx, &val, maxValue);
     } else if (value.getType() == Property::REAL) {
-      auto val = value.getValue<float>();
+      auto val = value.getValue<f32>();
       memcpy(mData + idx, &val, maxValue);
     } else if (value.getType() == Property::VECTOR2) {
       auto &val = value.getValue<glm::vec2>();

--- a/engine/src/quoll/renderer/Material.h
+++ b/engine/src/quoll/renderer/Material.h
@@ -81,7 +81,7 @@ private:
    *
    * @return Size of buffer data
    */
-  size_t updateBufferData();
+  usize updateBufferData();
 
 private:
   std::vector<rhi::TextureHandle> mTextures;
@@ -90,7 +90,7 @@ private:
   char *mData = nullptr;
 
   std::vector<Property> mProperties;
-  std::map<String, size_t> mPropertyMap;
+  std::map<String, usize> mPropertyMap;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/MaterialPBR.h
+++ b/engine/src/quoll/renderer/MaterialPBR.h
@@ -37,7 +37,7 @@ public:
     /**
      * Base color texture coordinate index
      */
-    int8_t baseColorTextureCoord = -1;
+    i8 baseColorTextureCoord = -1;
 
     /**
      * Base color factor
@@ -52,17 +52,17 @@ public:
     /**
      * Metallic roughness texture coordinate index
      */
-    int8_t metallicRoughnessTextureCoord = -1;
+    i8 metallicRoughnessTextureCoord = -1;
 
     /**
      * Metallic factor
      */
-    float metallicFactor = 0.0f;
+    f32 metallicFactor = 0.0f;
 
     /**
      * Roughness factor
      */
-    float roughnessFactor = 0.0f;
+    f32 roughnessFactor = 0.0f;
 
     /**
      * Normal texture
@@ -72,12 +72,12 @@ public:
     /**
      * Normal texture coordinate index
      */
-    int8_t normalTextureCoord = -1;
+    i8 normalTextureCoord = -1;
 
     /**
      * Normal scale
      */
-    float normalScale = 0.0f;
+    f32 normalScale = 0.0f;
 
     /**
      * Occlusion texture
@@ -87,12 +87,12 @@ public:
     /**
      * Occlusion texture coordinate index
      */
-    int8_t occlusionTextureCoord = -1;
+    i8 occlusionTextureCoord = -1;
 
     /**
      * Occlusion strength
      */
-    float occlusionStrength = 0.0f;
+    f32 occlusionStrength = 0.0f;
 
     /**
      * Emissive texture
@@ -102,7 +102,7 @@ public:
     /**
      * Emissive texture coordinate index
      */
-    int8_t emissiveTextureCoord = -1;
+    i8 emissiveTextureCoord = -1;
 
     /**
      * Emissive factor

--- a/engine/src/quoll/renderer/MeshRenderUtils.cpp
+++ b/engine/src/quoll/renderer/MeshRenderUtils.cpp
@@ -3,9 +3,9 @@
 
 namespace quoll {
 
-static constexpr size_t PositionsIndex = 0;
-static constexpr size_t JointsIndex = 5;
-static constexpr size_t WeightsIndex = 6;
+static constexpr usize PositionsIndex = 0;
+static constexpr usize JointsIndex = 5;
+static constexpr usize WeightsIndex = 6;
 
 std::array<rhi::BufferHandle, 1>
 MeshRenderUtils::getGeometryBuffers(const MeshAsset &mesh) {
@@ -13,7 +13,7 @@ MeshRenderUtils::getGeometryBuffers(const MeshAsset &mesh) {
   return std::array{mesh.vertexBuffers.at(PositionsIndex)};
 }
 
-std::array<uint64_t, 1>
+std::array<u64, 1>
 MeshRenderUtils::getGeometryBufferOffsets(const MeshAsset &mesh) {
   return std::array{mesh.vertexBufferOffsets.at(PositionsIndex)};
 }
@@ -25,7 +25,7 @@ MeshRenderUtils::getSkinnedGeometryBuffers(const MeshAsset &mesh) {
                     mesh.vertexBuffers.at(WeightsIndex)};
 }
 
-std::array<uint64_t, MeshRenderUtils::SkinGeometryContributors>
+std::array<u64, MeshRenderUtils::SkinGeometryContributors>
 MeshRenderUtils::getSkinnedGeometryBufferOffsets(const MeshAsset &mesh) {
   return std::array{mesh.vertexBufferOffsets.at(PositionsIndex),
                     mesh.vertexBufferOffsets.at(JointsIndex),

--- a/engine/src/quoll/renderer/MeshRenderUtils.h
+++ b/engine/src/quoll/renderer/MeshRenderUtils.h
@@ -8,7 +8,7 @@ namespace quoll {
  * @brief Mesh render utilities
  */
 class MeshRenderUtils {
-  static constexpr size_t SkinGeometryContributors = 3;
+  static constexpr usize SkinGeometryContributors = 3;
 
 public:
   /**
@@ -29,8 +29,7 @@ public:
    * @param mesh Mesh asset data
    * @return Offsets
    */
-  static std::array<uint64_t, 1>
-  getGeometryBufferOffsets(const MeshAsset &mesh);
+  static std::array<u64, 1> getGeometryBufferOffsets(const MeshAsset &mesh);
 
   /**
    * @brief Get buffers required for skinned mesh geometry
@@ -50,7 +49,7 @@ public:
    * @param mesh Mesh asset data
    * @return Offsets
    */
-  static std::array<uint64_t, SkinGeometryContributors>
+  static std::array<u64, SkinGeometryContributors>
   getSkinnedGeometryBufferOffsets(const MeshAsset &mesh);
 };
 

--- a/engine/src/quoll/renderer/MeshVertexLayout.h
+++ b/engine/src/quoll/renderer/MeshVertexLayout.h
@@ -29,7 +29,7 @@ template <class TType> static rhi::Format getFormat() {
 template <typename... TTypes>
 static constexpr void
 createBindings(std::vector<rhi::PipelineVertexInputBinding> &bindings) {
-  (bindings.push_back({.binding = static_cast<uint32_t>(bindings.size()),
+  (bindings.push_back({.binding = static_cast<u32>(bindings.size()),
                        .stride = sizeof(TTypes),
                        .inputRate = rhi::VertexInputRate::Vertex}),
    ...);
@@ -38,8 +38,8 @@ createBindings(std::vector<rhi::PipelineVertexInputBinding> &bindings) {
 template <typename... TTypes>
 static constexpr void
 createAttributes(std::vector<rhi::PipelineVertexInputAttribute> &attributes) {
-  (attributes.push_back({.slot = static_cast<uint32_t>(attributes.size()),
-                         .binding = static_cast<uint32_t>(attributes.size()),
+  (attributes.push_back({.slot = static_cast<u32>(attributes.size()),
+                         .binding = static_cast<u32>(attributes.size()),
                          .format = getFormat<TTypes>(),
                          .offset = 0}),
    ...);

--- a/engine/src/quoll/renderer/Presenter.cpp
+++ b/engine/src/quoll/renderer/Presenter.cpp
@@ -103,13 +103,13 @@ void Presenter::updateFramebuffers(const rhi::Swapchain &swapchain) {
   }
 
   mFramebuffers.resize(swapchain.textures.size());
-  for (size_t i = 0; i < mFramebuffers.size(); ++i) {
+  for (usize i = 0; i < mFramebuffers.size(); ++i) {
     if (!rhi::isHandleValid(mFramebuffers.at(i))) {
       mFramebuffers.at(i) = mRenderStorage.getNewFramebufferHandle();
     }
   }
 
-  for (size_t i = 0; i < mFramebuffers.size(); ++i) {
+  for (usize i = 0; i < mFramebuffers.size(); ++i) {
     rhi::FramebufferDescription framebufferDescription{};
     framebufferDescription.width = mExtent.x;
     framebufferDescription.height = mExtent.y;
@@ -125,7 +125,7 @@ void Presenter::updateFramebuffers(const rhi::Swapchain &swapchain) {
 }
 
 void Presenter::present(rhi::RenderCommandList &commandList,
-                        rhi::TextureHandle handle, uint32_t imageIndex) {
+                        rhi::TextureHandle handle, u32 imageIndex) {
 
   if (handle != mPresentTexture) {
     mPresentTexture = handle;

--- a/engine/src/quoll/renderer/Presenter.h
+++ b/engine/src/quoll/renderer/Presenter.h
@@ -35,7 +35,7 @@ public:
    * @param imageIndex Swapchain image index
    */
   void present(rhi::RenderCommandList &commandList, rhi::TextureHandle handle,
-               uint32_t imageIndex);
+               u32 imageIndex);
 
   /**
    * @brief Set flag to update framebuffers

--- a/engine/src/quoll/renderer/RenderGraph.h
+++ b/engine/src/quoll/renderer/RenderGraph.h
@@ -16,8 +16,7 @@ enum class GraphDirty { None, PassChanges, SizeUpdate };
  */
 class RenderGraph {
   using RGTexture = RenderGraphResource<rhi::TextureHandle>;
-  using RGTextureCreator =
-      std::function<rhi::TextureDescription(uint32_t, uint32_t)>;
+  using RGTextureCreator = std::function<rhi::TextureDescription(u32, u32)>;
   template <class THandle>
   using RGBuildCallback = std::function<void(THandle, RenderStorage &)>;
 
@@ -67,9 +66,9 @@ public:
    * @param layerCount Layer count
    * @return Render graph texture
    */
-  RGTexture createView(RGTexture texture, uint32_t baseMipLevel = 0,
-                       uint32_t mipLevelCount = 1, uint32_t baseLayer = 0,
-                       uint32_t layerCount = 1);
+  RGTexture createView(RGTexture texture, u32 baseMipLevel = 0,
+                       u32 mipLevelCount = 1, u32 baseLayer = 0,
+                       u32 layerCount = 1);
 
   /**
    * @brief Import existing texture to render graph
@@ -85,7 +84,7 @@ public:
    * @param commandList Command list
    * @param frameIndex Frame index
    */
-  void execute(rhi::RenderCommandList &commandList, uint32_t frameIndex);
+  void execute(rhi::RenderCommandList &commandList, u32 frameIndex);
 
   /**
    * @brief Build render graph

--- a/engine/src/quoll/renderer/RenderGraphPass.cpp
+++ b/engine/src/quoll/renderer/RenderGraphPass.cpp
@@ -47,7 +47,7 @@ void RenderGraphPass::addPipeline(rhi::PipelineHandle handle) {
 }
 
 void RenderGraphPass::execute(rhi::RenderCommandList &commandList,
-                              uint32_t frameIndex) {
+                              u32 frameIndex) {
   mExecutor(commandList, frameIndex);
 }
 

--- a/engine/src/quoll/renderer/RenderGraphPass.h
+++ b/engine/src/quoll/renderer/RenderGraphPass.h
@@ -102,7 +102,7 @@ enum class RenderGraphPassType { Graphics, Compute };
  * @brief Render graph pass
  */
 class RenderGraphPass {
-  using ExecutorFn = std::function<void(rhi::RenderCommandList &, uint32_t)>;
+  using ExecutorFn = std::function<void(rhi::RenderCommandList &, u32)>;
   friend RenderGraph;
 
 public:
@@ -155,7 +155,7 @@ public:
    * @param commandList Command list
    * @param frameIndex Frame index
    */
-  void execute(rhi::RenderCommandList &commandList, uint32_t frameIndex);
+  void execute(rhi::RenderCommandList &commandList, u32 frameIndex);
 
   /**
    * @brief Set output texture

--- a/engine/src/quoll/renderer/RenderGraphRegistry.h
+++ b/engine/src/quoll/renderer/RenderGraphRegistry.h
@@ -12,27 +12,27 @@ struct RGTextureViewDescription {
   /**
    * Texture index in render graph registry
    */
-  size_t textureIndex = 0;
+  usize textureIndex = 0;
 
   /**
    * Base mip level
    */
-  uint32_t baseMipLevel = 0;
+  u32 baseMipLevel = 0;
 
   /**
    * Mip level count
    */
-  uint32_t mipLevelCount = 1;
+  u32 mipLevelCount = 1;
 
   /**
    * Base layer
    */
-  uint32_t baseLayer = 0;
+  u32 baseLayer = 0;
 
   /**
    * Layer count
    */
-  uint32_t layerCount = 1;
+  u32 layerCount = 1;
 };
 
 enum class RGResourceState { Transient, Real };
@@ -53,7 +53,7 @@ public:
    * @param description Description
    * @return Resource index
    */
-  size_t allocate(TDescription description) {
+  usize allocate(TDescription description) {
     auto index = mRealResources.size();
     mRealResources.push_back(THandle{0});
     mDescriptions.push_back(description);
@@ -69,7 +69,7 @@ public:
    * @param handle Resource handle
    * @return Resource index
    */
-  size_t allocate(THandle handle) {
+  usize allocate(THandle handle) {
     auto index = mRealResources.size();
     mRealResources.push_back(handle);
     mDescriptions.push_back({});
@@ -85,7 +85,7 @@ public:
    * @param index Resource index
    * @return Render graph resource state
    */
-  RGResourceState getResourceState(size_t index) const {
+  RGResourceState getResourceState(usize index) const {
     return mResourceStates.at(index);
   }
 
@@ -95,7 +95,7 @@ public:
    * @param index Resource indexResourceType
    * @return Resource handleindex
    */
-  THandle get(size_t index) { return mRealResources.at(index); }
+  THandle get(usize index) { return mRealResources.at(index); }
 
   /**
    * @brief Get real resources
@@ -112,7 +112,7 @@ public:
    * @param index Resource index
    * @return Resource index
    */
-  inline const TDescription &getDescription(size_t index) const {
+  inline const TDescription &getDescription(usize index) const {
     return mDescriptions.at(index);
   }
 
@@ -123,7 +123,7 @@ public:
    * @param index Resource index
    * @param handle Handle
    */
-  void set(size_t index, THandle handle) { mRealResources.at(index) = handle; }
+  void set(usize index, THandle handle) { mRealResources.at(index) = handle; }
 
   /**
    * @brief Set on resource ready function
@@ -132,7 +132,7 @@ public:
    * @param resourceReadyFn Resource ready function
    */
   template <class TFunction>
-  void setResourceReady(size_t index, TFunction &&resourceReadyFn) {
+  void setResourceReady(usize index, TFunction &&resourceReadyFn) {
     mResourceReadyFns.at(index) = resourceReadyFn;
   }
 
@@ -142,7 +142,7 @@ public:
    * @param index Resource index
    * @param storage Render storage
    */
-  void callResourceReady(size_t index, RenderStorage &storage) {
+  void callResourceReady(usize index, RenderStorage &storage) {
     mResourceReadyFns.at(index)(mRealResources.at(index), storage);
   }
 
@@ -174,7 +174,7 @@ public:
    * @param index Index
    * @return Resource handle
    */
-  template <class THandle> inline THandle get(size_t index) {
+  template <class THandle> inline THandle get(usize index) {
     return getCache<THandle>().get(index);
   }
 
@@ -185,7 +185,7 @@ public:
    * @param index Index
    * @return Resource handle
    */
-  template <class THandle> inline auto getDescription(size_t index) {
+  template <class THandle> inline auto getDescription(usize index) {
     return getCache<THandle>().getDescription(index);
   }
 
@@ -206,7 +206,7 @@ public:
    * @param handle Handle
    * @return Newly created resource index
    */
-  template <class THandle> size_t allocate(THandle handle = THandle::Null) {
+  template <class THandle> usize allocate(THandle handle = THandle::Null) {
     return getCache<THandle>().allocate(handle);
   }
 
@@ -219,7 +219,7 @@ public:
    * @return Newly created resource index
    */
   template <class THandle, class TDescription>
-  size_t allocate(TDescription description) {
+  usize allocate(TDescription description) {
     return getCache<THandle>().allocate(description);
   }
 
@@ -231,7 +231,7 @@ public:
    * @return Render graph resource type
    */
   template <class THandle>
-  inline RGResourceState getResourceState(size_t index) const {
+  inline RGResourceState getResourceState(usize index) const {
     return getCache<THandle>().getResourceState(index);
   }
 
@@ -242,7 +242,7 @@ public:
    * @param index Resource index
    * @param handle Handle
    */
-  template <class THandle> void set(size_t index, THandle handle) {
+  template <class THandle> void set(usize index, THandle handle) {
     getCache<THandle>().set(index, handle);
   }
 
@@ -253,7 +253,7 @@ public:
    * @param resourceReadyFn Resource ready function
    */
   template <class THandle, class TFunction>
-  inline void setResourceReady(size_t index, TFunction &&resourceReadyFn) {
+  inline void setResourceReady(usize index, TFunction &&resourceReadyFn) {
     getCache<THandle>().setResourceReady(index, resourceReadyFn);
   }
 
@@ -264,7 +264,7 @@ public:
    * @param storage Render storage
    */
   template <class THandle>
-  inline void callResourceReady(size_t index, RenderStorage &storage) {
+  inline void callResourceReady(usize index, RenderStorage &storage) {
     getCache<THandle>().callResourceReady(index, storage);
   }
 

--- a/engine/src/quoll/renderer/RenderGraphResource.h
+++ b/engine/src/quoll/renderer/RenderGraphResource.h
@@ -17,7 +17,7 @@ public:
    * @param registry Render graph registry
    * @param index Resource index
    */
-  RenderGraphResource(RenderGraphRegistry &registry, size_t index)
+  RenderGraphResource(RenderGraphRegistry &registry, usize index)
       : mRegistry(registry), mIndex(index) {}
 
   /**
@@ -32,7 +32,7 @@ public:
    *
    * @return Render graph index
    */
-  inline size_t getIndex() const { return mIndex; }
+  inline usize getIndex() const { return mIndex; }
 
   /**
    * @brief Get real resource handle
@@ -56,7 +56,7 @@ public:
 
 private:
   RenderGraphRegistry &mRegistry;
-  size_t mIndex;
+  usize mIndex;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/RenderStorage.cpp
+++ b/engine/src/quoll/renderer/RenderStorage.cpp
@@ -3,11 +3,11 @@
 
 namespace quoll {
 
-static constexpr uint32_t Hundred = 100;
+static constexpr u32 Hundred = 100;
 
 RenderStorage::RenderStorage(rhi::RenderDevice *device) : mDevice(device) {
-  static constexpr uint32_t NumSamplers = 1000;
-  static constexpr uint32_t MaxBuffers = 1000;
+  static constexpr u32 NumSamplers = 1000;
+  static constexpr u32 MaxBuffers = 1000;
 
   {
     rhi::DescriptorLayoutBindingDescription binding0{};

--- a/engine/src/quoll/renderer/RenderStorage.h
+++ b/engine/src/quoll/renderer/RenderStorage.h
@@ -183,7 +183,7 @@ public:
   inline rhi::GraphicsPipelineDescription &
   getGraphicsPipelineDescription(rhi::PipelineHandle handle) {
     return std::get<rhi::GraphicsPipelineDescription>(
-        mPipelineDescriptions.at(static_cast<size_t>(handle) - 1));
+        mPipelineDescriptions.at(static_cast<usize>(handle) - 1));
   }
 
   /**
@@ -195,7 +195,7 @@ public:
   inline rhi::ComputePipelineDescription &
   getComputePipelineDescription(rhi::PipelineHandle handle) {
     return std::get<rhi::ComputePipelineDescription>(
-        mPipelineDescriptions.at(static_cast<size_t>(handle) - 1));
+        mPipelineDescriptions.at(static_cast<usize>(handle) - 1));
   }
 
 private:
@@ -206,10 +206,10 @@ private:
   std::vector<std::variant<rhi::GraphicsPipelineDescription,
                            rhi::ComputePipelineDescription>>
       mPipelineDescriptions;
-  std::vector<size_t> mGraphicsPipelineIndices;
-  std::vector<size_t> mComputePipelineIndices;
+  std::vector<usize> mGraphicsPipelineIndices;
+  std::vector<usize> mComputePipelineIndices;
 
-  static constexpr uint32_t TextureStart = 10;
+  static constexpr u32 TextureStart = 10;
   HandleCounter<rhi::ShaderHandle> mShaderCounter;
   HandleCounter<rhi::TextureHandle, TextureStart> mTextureCounter;
   HandleCounter<rhi::RenderPassHandle> mRenderPassCounter;

--- a/engine/src/quoll/renderer/Renderer.cpp
+++ b/engine/src/quoll/renderer/Renderer.cpp
@@ -37,8 +37,7 @@ void Renderer::rebuildIfSettingsChanged() {
   mOptionsChanged = false;
 }
 
-void Renderer::execute(rhi::RenderCommandList &commandList,
-                       uint32_t frameIndex) {
+void Renderer::execute(rhi::RenderCommandList &commandList, u32 frameIndex) {
 
   mGraph.execute(commandList, frameIndex);
 }

--- a/engine/src/quoll/renderer/Renderer.h
+++ b/engine/src/quoll/renderer/Renderer.h
@@ -102,7 +102,7 @@ public:
    * @param commandList Render command list
    * @param frameIndex Frame index
    */
-  void execute(rhi::RenderCommandList &commandList, uint32_t frameIndex);
+  void execute(rhi::RenderCommandList &commandList, u32 frameIndex);
 
   /**
    * @brief Get final texture

--- a/engine/src/quoll/renderer/SceneRenderer.cpp
+++ b/engine/src/quoll/renderer/SceneRenderer.cpp
@@ -24,8 +24,8 @@ SceneRenderer::SceneRenderer(AssetRegistry &assetRegistry,
 
   mMaxSampleCounts = std::max(1u, mMaxSampleCounts);
 
-  static constexpr uint32_t MaxSamples = 8;
-  for (uint32_t i = MaxSamples; i > 1; i = i / 2) {
+  static constexpr u32 MaxSamples = 8;
+  for (u32 i = MaxSamples; i > 1; i = i / 2) {
     if ((mMaxSampleCounts & i) == i) {
       mMaxSampleCounts = i;
       break;
@@ -98,7 +98,7 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
     frameData.getBindlessParams().destroy(mRenderStorage.getDevice());
   }
 
-  static constexpr uint32_t ShadowMapDimensions = 4096;
+  static constexpr u32 ShadowMapDimensions = 4096;
 
   rhi::TextureDescription shadowMapDesc{};
   shadowMapDesc.usage = rhi::TextureUsage::Depth | rhi::TextureUsage::Sampled;
@@ -168,7 +168,7 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
       rhi::DeviceAddress shadows;
     };
 
-    size_t shadowDrawOffset = 0;
+    usize shadowDrawOffset = 0;
     for (auto &frameData : mFrameData) {
       shadowDrawOffset =
           frameData.getBindlessParams().addRange(ShadowDrawParams{
@@ -212,10 +212,10 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
 
     pass.setExecutor([pipeline, skinnedPipeline, shadowmap, shadowDrawOffset,
                       this](rhi::RenderCommandList &commandList,
-                            uint32_t frameIndex) {
+                            u32 frameIndex) {
       auto &frameData = mFrameData.at(frameIndex);
 
-      std::array<uint32_t, 1> offsets{static_cast<uint32_t>(shadowDrawOffset)};
+      std::array<u32, 1> offsets{static_cast<u32>(shadowDrawOffset)};
       {
         QUOLL_PROFILE_EVENT("shadowPass::meshes");
         commandList.bindPipeline(pipeline);
@@ -224,11 +224,10 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
             pipeline, 0, frameData.getBindlessParams().getDescriptor(),
             offsets);
 
-        for (int32_t index = 0;
-             index < static_cast<int32_t>(frameData.getNumShadowMaps());
-             ++index) {
+        for (i32 index = 0;
+             index < static_cast<i32>(frameData.getNumShadowMaps()); ++index) {
           commandList.pushConstants(pipeline, rhi::ShaderStage::Vertex, 0,
-                                    sizeof(uint32_t), &index);
+                                    sizeof(u32), &index);
 
           renderShadowsMesh(commandList, pipeline, frameIndex);
         }
@@ -241,12 +240,11 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
             pipeline, 0, frameData.getBindlessParams().getDescriptor(),
             offsets);
 
-        for (int32_t index = 0;
-             index < static_cast<int32_t>(frameData.getNumShadowMaps());
-             ++index) {
+        for (i32 index = 0;
+             index < static_cast<i32>(frameData.getNumShadowMaps()); ++index) {
 
           commandList.pushConstants(pipeline, rhi::ShaderStage::Vertex, 0,
-                                    sizeof(uint32_t), &index);
+                                    sizeof(u32), &index);
 
           renderShadowsSkinnedMesh(commandList, skinnedPipeline, frameIndex);
         }
@@ -270,7 +268,7 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
       rhi::SamplerHandle sampler;
     };
 
-    size_t pbrOffset = 0;
+    usize pbrOffset = 0;
     for (auto &frameData : mFrameData) {
       pbrOffset = frameData.getBindlessParams().addRange(MeshDrawParams{
           frameData.getFlattenedMaterialsBuffer(),
@@ -319,14 +317,13 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
     pass.addPipeline(pipeline);
     pass.addPipeline(skinnedPipeline);
 
-    pass.setExecutor([this, pipeline, skinnedPipeline, pbrOffset,
-                      shadowmap](rhi::RenderCommandList &commandList,
-                                 uint32_t frameIndex) {
+    pass.setExecutor([this, pipeline, skinnedPipeline, pbrOffset, shadowmap](
+                         rhi::RenderCommandList &commandList, u32 frameIndex) {
       auto &frameData = mFrameData.at(frameIndex);
 
       commandList.bindPipeline(pipeline);
 
-      std::array<uint32_t, 1> offsets{static_cast<uint32_t>(pbrOffset)};
+      std::array<u32, 1> offsets{static_cast<u32>(pbrOffset)};
       {
         QUOLL_PROFILE_EVENT("meshPass::meshes");
 
@@ -383,7 +380,7 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
 
     pass.addPipeline(pipeline);
 
-    size_t spriteOffset = 0;
+    usize spriteOffset = 0;
     for (auto &frameData : mFrameData) {
       spriteOffset = frameData.getBindlessParams().addRange(SpriteDrawParams{
           frameData.getCameraBuffer(), frameData.getSpriteTransformsBuffer(),
@@ -391,12 +388,11 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
           mRenderStorage.getDefaultSampler()});
     }
 
-    pass.setExecutor([pipeline, spriteOffset,
-                      this](rhi::RenderCommandList &commandList,
-                            uint32_t frameIndex) {
+    pass.setExecutor([pipeline, spriteOffset, this](
+                         rhi::RenderCommandList &commandList, u32 frameIndex) {
       auto &frameData = mFrameData.at(frameIndex);
 
-      std::array<uint32_t, 1> offsets{static_cast<uint32_t>(spriteOffset)};
+      std::array<u32, 1> offsets{static_cast<u32>(spriteOffset)};
 
       commandList.bindPipeline(pipeline);
       commandList.bindDescriptor(pipeline, 0,
@@ -405,7 +401,7 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
           pipeline, 1, frameData.getBindlessParams().getDescriptor(), offsets);
 
       commandList.draw(
-          4, 0, static_cast<uint32_t>(frameData.getSpriteEntities().size()), 0);
+          4, 0, static_cast<u32>(frameData.getSpriteEntities().size()), 0);
     });
   } // sprite pass
 
@@ -416,7 +412,7 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
       rhi::SamplerHandle defaultSampler;
     };
 
-    size_t skyboxOffset = 0;
+    usize skyboxOffset = 0;
     for (auto &frameData : mFrameData) {
       skyboxOffset = frameData.getBindlessParams().addRange(SkyboxDrawParams{
           frameData.getCameraBuffer(), frameData.getSkyboxBuffer(),
@@ -443,10 +439,9 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
 
     pass.addPipeline(pipeline);
 
-    pass.setExecutor([pipeline, skyboxOffset,
-                      this](rhi::RenderCommandList &commandList,
-                            uint32_t frameIndex) {
-      std::array<uint32_t, 1> offsets{static_cast<uint32_t>(skyboxOffset)};
+    pass.setExecutor([pipeline, skyboxOffset, this](
+                         rhi::RenderCommandList &commandList, u32 frameIndex) {
+      std::array<u32, 1> offsets{static_cast<u32>(skyboxOffset)};
 
       auto &frameData = mFrameData.at(frameIndex);
 
@@ -461,17 +456,17 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
                              .getAsset(mAssetRegistry.getDefaultObjects().cube)
                              .data;
 
-      std::array<uint64_t, 1> vbOffsets{0};
+      std::array<u64, 1> vbOffsets{0};
       commandList.bindVertexBuffers(std::array{cube.vertexBuffers.at(0)},
                                     vbOffsets);
       commandList.bindIndexBuffer(cube.indexBuffer, rhi::IndexType::Uint32);
 
       commandList.drawIndexed(
-          static_cast<uint32_t>(cube.geometries.at(0).indices.size()), 0, 0);
+          static_cast<u32>(cube.geometries.at(0).indices.size()), 0, 0);
     });
   } // skybox pass
 
-  static constexpr uint32_t BloomMipChainSize = 7;
+  static constexpr u32 BloomMipChainSize = 7;
 
   rhi::TextureDescription description{};
   description.debugName = "Bloom";
@@ -500,7 +495,7 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
     std::vector<BloomMip> bloomChain;
     bloomChain.push_back({bloomTexture, options.size});
     bloomChain.reserve(BloomMipChainSize);
-    for (uint32_t i = 1; i < BloomMipChainSize; ++i) {
+    for (u32 i = 1; i < BloomMipChainSize; ++i) {
       auto view = graph.createView(bloomTexture, i)
                       .onReady([](auto handle, auto &storage) {
                         storage.addToDescriptor(handle);
@@ -527,23 +522,21 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
             "bloom upsample"});
     pass.addPipeline(upsamplePipeline);
 
-    static constexpr uint32_t WorkGroupSize = 32;
+    static constexpr u32 WorkGroupSize = 32;
 
     pass.setExecutor([extractBrightColorsPipeline, downsamplePipeline,
                       upsamplePipeline, bloomTexture, sceneColorResolved,
-                      &options, bloomChain,
-                      this](rhi::RenderCommandList &commandList,
-                            uint32_t frameIndex) {
+                      &options, bloomChain, this](
+                         rhi::RenderCommandList &commandList, u32 frameIndex) {
       // Extract bright colors
       {
         commandList.bindDescriptor(
             extractBrightColorsPipeline, 0,
             mRenderStorage.getGlobalTexturesDescriptor());
 
-        glm::uvec4 texture{
-            static_cast<uint32_t>(sceneColorResolved.getHandle()),
-            static_cast<uint32_t>(bloomTexture.getHandle()),
-            static_cast<uint32_t>(mBloomSampler), 0};
+        glm::uvec4 texture{static_cast<u32>(sceneColorResolved.getHandle()),
+                           static_cast<u32>(bloomTexture.getHandle()),
+                           static_cast<u32>(mBloomSampler), 0};
         commandList.pushConstants(extractBrightColorsPipeline,
                                   rhi::ShaderStage::Compute, 0,
                                   sizeof(glm::uvec4), glm::value_ptr(texture));
@@ -560,8 +553,8 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
             mRenderStorage.getGlobalTexturesDescriptor());
         commandList.bindPipeline(downsamplePipeline);
 
-        for (uint32_t level = 1;
-             level < static_cast<uint32_t>(bloomChain.size()); ++level) {
+        for (u32 level = 1; level < static_cast<u32>(bloomChain.size());
+             ++level) {
 
           const auto &source = bloomChain.at(level - 1);
           const auto &target = bloomChain.at(level);
@@ -581,9 +574,9 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
 
           commandList.pipelineBarrier({}, imageBarriers, {});
 
-          glm::uvec4 texture{static_cast<uint32_t>(source.texture.getHandle()),
-                             static_cast<uint32_t>(target.texture.getHandle()),
-                             static_cast<uint32_t>(mBloomSampler), level - 1};
+          glm::uvec4 texture{static_cast<u32>(source.texture.getHandle()),
+                             static_cast<u32>(target.texture.getHandle()),
+                             static_cast<u32>(mBloomSampler), level - 1};
           commandList.pushConstants(
               downsamplePipeline, rhi::ShaderStage::Compute, 0,
               sizeof(glm::uvec4), glm::value_ptr(texture));
@@ -597,8 +590,8 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
         commandList.bindDescriptor(
             upsamplePipeline, 0, mRenderStorage.getGlobalTexturesDescriptor());
         commandList.bindPipeline(upsamplePipeline);
-        for (uint32_t level = static_cast<uint32_t>(bloomChain.size() - 1);
-             level > 0; --level) {
+        for (u32 level = static_cast<u32>(bloomChain.size() - 1); level > 0;
+             --level) {
 
           rhi::ImageBarrier imageBarrierSrc{};
           imageBarrierSrc.baseLevel = level;
@@ -630,9 +623,9 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
           const auto &source = bloomChain.at(level);
           const auto &target = bloomChain.at(level - 1);
 
-          glm::uvec4 texture{static_cast<uint32_t>(source.texture.getHandle()),
-                             static_cast<uint32_t>(target.texture.getHandle()),
-                             static_cast<uint32_t>(mBloomSampler), 0};
+          glm::uvec4 texture{static_cast<u32>(source.texture.getHandle()),
+                             static_cast<u32>(target.texture.getHandle()),
+                             static_cast<u32>(mBloomSampler), 0};
           commandList.pushConstants(upsamplePipeline, rhi::ShaderStage::Compute,
                                     0, sizeof(glm::uvec4),
                                     glm::value_ptr(texture));
@@ -664,9 +657,8 @@ SceneRenderPassData SceneRenderer::attach(RenderGraph &graph,
     auto pipeline = mRenderStorage.addPipeline(pipelineDescription);
     pass.addPipeline(pipeline);
 
-    pass.setExecutor([pipeline, sceneColorResolved, bloomTexture,
-                      this](rhi::RenderCommandList &commandList,
-                            uint32_t frameIndex) {
+    pass.setExecutor([pipeline, sceneColorResolved, bloomTexture, this](
+                         rhi::RenderCommandList &commandList, u32 frameIndex) {
       commandList.bindPipeline(pipeline);
       commandList.bindDescriptor(pipeline, 0,
                                  mRenderStorage.getGlobalTexturesDescriptor());
@@ -714,7 +706,7 @@ void SceneRenderer::attachText(RenderGraph &graph,
     rhi::DeviceAddress pad0;
   };
 
-  size_t textOffset = 0;
+  usize textOffset = 0;
   for (auto &frameData : mFrameData) {
     textOffset = frameData.getBindlessParams().addRange(TextDrawParams{
         frameData.getTextTransformsBuffer(), frameData.getCameraBuffer(),
@@ -747,11 +739,10 @@ void SceneRenderer::attachText(RenderGraph &graph,
   pass.addPipeline(textPipeline);
 
   pass.setExecutor([textPipeline, textOffset,
-                    this](rhi::RenderCommandList &commandList,
-                          uint32_t frameIndex) {
+                    this](rhi::RenderCommandList &commandList, u32 frameIndex) {
     auto &frameData = mFrameData.at(frameIndex);
 
-    std::array<uint32_t, 1> offsets{static_cast<uint32_t>(textOffset)};
+    std::array<u32, 1> offsets{static_cast<u32>(textOffset)};
     commandList.bindPipeline(textPipeline);
     commandList.bindDescriptor(textPipeline, 1,
                                frameData.getBindlessParams().getDescriptor(),
@@ -765,7 +756,7 @@ void SceneRenderer::attachText(RenderGraph &graph,
 }
 
 void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
-                                    Entity camera, uint32_t frameIndex) {
+                                    Entity camera, u32 frameIndex) {
   QuollAssert(entityDatabase.has<Camera>(camera),
               "Entity does not have a camera");
 
@@ -827,9 +818,9 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
     const auto &font = mAssetRegistry.getFonts().getAsset(text.font).data;
 
     std::vector<SceneRendererFrameData::GlyphData> glyphs(text.text.length());
-    float advanceX = 0;
-    float advanceY = 0;
-    for (size_t i = 0; i < text.text.length(); ++i) {
+    f32 advanceX = 0;
+    f32 advanceY = 0;
+    for (usize i = 0; i < text.text.length(); ++i) {
       char c = text.text.at(i);
 
       if (c == '\n') {
@@ -901,13 +892,13 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
 }
 
 void SceneRenderer::render(rhi::RenderCommandList &commandList,
-                           rhi::PipelineHandle pipeline, uint32_t frameIndex) {
+                           rhi::PipelineHandle pipeline, u32 frameIndex) {
   auto &frameData = mFrameData.at(frameIndex);
 
-  uint32_t instanceStart = 0;
+  u32 instanceStart = 0;
   for (auto &[handle, meshData] : frameData.getMeshGroups()) {
     const auto &mesh = mAssetRegistry.getMeshes().getAsset(handle).data;
-    uint32_t numInstances = static_cast<uint32_t>(meshData.transforms.size());
+    u32 numInstances = static_cast<u32>(meshData.transforms.size());
 
     commandList.bindVertexBuffers(mesh.vertexBuffers, mesh.vertexBufferOffsets);
     commandList.bindIndexBuffer(mesh.indexBuffer, rhi::IndexType::Uint32);
@@ -918,14 +909,14 @@ void SceneRenderer::render(rhi::RenderCommandList &commandList,
 
 void SceneRenderer::renderSkinned(rhi::RenderCommandList &commandList,
                                   rhi::PipelineHandle pipeline,
-                                  uint32_t frameIndex) {
+                                  u32 frameIndex) {
   auto &frameData = mFrameData.at(frameIndex);
 
-  uint32_t instanceStart = 0;
+  u32 instanceStart = 0;
 
   for (auto &[handle, meshData] : frameData.getSkinnedMeshGroups()) {
     const auto &mesh = mAssetRegistry.getMeshes().getAsset(handle).data;
-    uint32_t numInstances = static_cast<uint32_t>(meshData.transforms.size());
+    u32 numInstances = static_cast<u32>(meshData.transforms.size());
 
     commandList.bindVertexBuffers(mesh.vertexBuffers, mesh.vertexBufferOffsets);
     commandList.bindIndexBuffer(mesh.indexBuffer, rhi::IndexType::Uint32);
@@ -937,23 +928,20 @@ void SceneRenderer::renderSkinned(rhi::RenderCommandList &commandList,
 
 void SceneRenderer::renderGeometries(rhi::RenderCommandList &commandList,
                                      rhi::PipelineHandle pipeline,
-                                     const MeshAsset &mesh,
-                                     uint32_t instanceStart,
-                                     uint32_t numInstances) {
-  int32_t vertexOffset = 0;
-  uint32_t indexOffset = 0;
-  for (size_t g = 0; g < mesh.geometries.size(); ++g) {
+                                     const MeshAsset &mesh, u32 instanceStart,
+                                     u32 numInstances) {
+  i32 vertexOffset = 0;
+  u32 indexOffset = 0;
+  for (usize g = 0; g < mesh.geometries.size(); ++g) {
     auto &geometry = mesh.geometries.at(g);
 
-    auto index = static_cast<uint32_t>(g);
+    auto index = static_cast<u32>(g);
 
     commandList.pushConstants(pipeline, rhi::ShaderStage::Vertex, 0,
-                              sizeof(uint32_t), &index);
+                              sizeof(u32), &index);
 
-    uint32_t indexCount =
-        static_cast<uint32_t>(mesh.geometries.at(g).indices.size());
-    int32_t vertexCount =
-        static_cast<int32_t>(mesh.geometries.at(g).positions.size());
+    u32 indexCount = static_cast<u32>(mesh.geometries.at(g).indices.size());
+    i32 vertexCount = static_cast<i32>(mesh.geometries.at(g).positions.size());
 
     commandList.drawIndexed(indexCount, indexOffset, vertexOffset, numInstances,
                             instanceStart);
@@ -964,13 +952,13 @@ void SceneRenderer::renderGeometries(rhi::RenderCommandList &commandList,
 
 void SceneRenderer::renderShadowsMesh(rhi::RenderCommandList &commandList,
                                       rhi::PipelineHandle pipeline,
-                                      uint32_t frameIndex) {
+                                      u32 frameIndex) {
   auto &frameData = mFrameData.at(frameIndex);
 
-  uint32_t instanceStart = 0;
+  u32 instanceStart = 0;
   for (auto &[handle, meshData] : frameData.getMeshGroups()) {
     const auto &mesh = mAssetRegistry.getMeshes().getAsset(handle).data;
-    uint32_t numInstances = static_cast<uint32_t>(meshData.transforms.size());
+    u32 numInstances = static_cast<u32>(meshData.transforms.size());
 
     commandList.bindVertexBuffers(
         MeshRenderUtils::getGeometryBuffers(mesh),
@@ -984,13 +972,13 @@ void SceneRenderer::renderShadowsMesh(rhi::RenderCommandList &commandList,
 
 void SceneRenderer::renderShadowsSkinnedMesh(
     rhi::RenderCommandList &commandList, rhi::PipelineHandle pipeline,
-    uint32_t frameIndex) {
+    u32 frameIndex) {
   auto &frameData = mFrameData.at(frameIndex);
 
-  uint32_t instanceStart = 0;
+  u32 instanceStart = 0;
   for (auto &[handle, meshData] : frameData.getSkinnedMeshGroups()) {
     const auto &mesh = mAssetRegistry.getMeshes().getAsset(handle).data;
-    uint32_t numInstances = static_cast<uint32_t>(meshData.transforms.size());
+    u32 numInstances = static_cast<u32>(meshData.transforms.size());
 
     commandList.bindVertexBuffers(
         MeshRenderUtils::getSkinnedGeometryBuffers(mesh),
@@ -1005,17 +993,15 @@ void SceneRenderer::renderShadowsSkinnedMesh(
 void SceneRenderer::renderShadowsGeometries(rhi::RenderCommandList &commandList,
                                             rhi::PipelineHandle pipeline,
                                             const MeshAsset &mesh,
-                                            uint32_t instanceStart,
-                                            uint32_t numInstances) {
-  int32_t vertexOffset = 0;
-  uint32_t indexOffset = 0;
-  for (size_t g = 0; g < mesh.geometries.size(); ++g) {
+                                            u32 instanceStart,
+                                            u32 numInstances) {
+  i32 vertexOffset = 0;
+  u32 indexOffset = 0;
+  for (usize g = 0; g < mesh.geometries.size(); ++g) {
     auto &geometry = mesh.geometries.at(g);
 
-    uint32_t indexCount =
-        static_cast<uint32_t>(mesh.geometries.at(g).indices.size());
-    int32_t vertexCount =
-        static_cast<int32_t>(mesh.geometries.at(g).positions.size());
+    u32 indexCount = static_cast<u32>(mesh.geometries.at(g).indices.size());
+    i32 vertexCount = static_cast<i32>(mesh.geometries.at(g).positions.size());
 
     commandList.drawIndexed(indexCount, indexOffset, vertexOffset, numInstances,
                             instanceStart);
@@ -1025,11 +1011,10 @@ void SceneRenderer::renderShadowsGeometries(rhi::RenderCommandList &commandList,
 }
 
 void SceneRenderer::renderText(rhi::RenderCommandList &commandList,
-                               rhi::PipelineHandle pipeline,
-                               uint32_t frameIndex) {
+                               rhi::PipelineHandle pipeline, u32 frameIndex) {
   auto &frameData = mFrameData.at(frameIndex);
-  static constexpr uint32_t QuadNumVertices = 6;
-  for (size_t i = 0; i < frameData.getTexts().size(); ++i) {
+  static constexpr u32 QuadNumVertices = 6;
+  for (usize i = 0; i < frameData.getTexts().size(); ++i) {
     const auto &text = frameData.getTexts().at(i);
 
     commandList.bindDescriptor(pipeline, 0,
@@ -1044,16 +1029,16 @@ void SceneRenderer::renderText(rhi::RenderCommandList &commandList,
         pipeline, rhi::ShaderStage::Vertex | rhi::ShaderStage::Fragment, 0,
         sizeof(glm::uvec4), glm::value_ptr(textConstants));
 
-    commandList.draw(QuadNumVertices * static_cast<uint32_t>(text.length), 0, 1,
-                     static_cast<uint32_t>(i));
+    commandList.draw(QuadNumVertices * static_cast<u32>(text.length), 0, 1,
+                     static_cast<u32>(i));
   }
 }
 
 void SceneRenderer::generateBrdfLut() {
   auto *device = mRenderStorage.getDevice();
 
-  static constexpr uint32_t GroupSize = 16;
-  static constexpr uint32_t TextureSize = 512;
+  static constexpr u32 GroupSize = 16;
+  static constexpr u32 TextureSize = 512;
 
   rhi::DescriptorLayoutBindingDescription binding0{};
   binding0.type = rhi::DescriptorLayoutBindingType::Static;

--- a/engine/src/quoll/renderer/SceneRenderer.h
+++ b/engine/src/quoll/renderer/SceneRenderer.h
@@ -35,7 +35,7 @@ struct SceneRenderPassData {
   /**
    * Sample count
    */
-  uint32_t sampleCount = 0;
+  u32 sampleCount = 0;
 };
 
 /**
@@ -86,7 +86,7 @@ public:
    * @param frameIndex Frame index
    */
   void updateFrameData(EntityDatabase &entityDatabase, Entity camera,
-                       uint32_t frameIndex);
+                       u32 frameIndex);
 
   /**
    * @brief Get frame data
@@ -106,7 +106,7 @@ private:
    * @param frameIndex Frame index
    */
   void render(rhi::RenderCommandList &commandList, rhi::PipelineHandle pipeline,
-              uint32_t frameIndex);
+              u32 frameIndex);
 
   /**
    * @brief Render skinned meshes
@@ -116,7 +116,7 @@ private:
    * @param frameIndex Frame index
    */
   void renderSkinned(rhi::RenderCommandList &commandList,
-                     rhi::PipelineHandle pipeline, uint32_t frameIndex);
+                     rhi::PipelineHandle pipeline, u32 frameIndex);
 
   /**
    * @brief Render geometries
@@ -129,7 +129,7 @@ private:
    */
   void renderGeometries(rhi::RenderCommandList &commandList,
                         rhi::PipelineHandle pipeline, const MeshAsset &mesh,
-                        uint32_t instanceStart, uint32_t numInstances);
+                        u32 instanceStart, u32 numInstances);
 
   /**
    * @brief Render meshes for shadows
@@ -139,7 +139,7 @@ private:
    * @param frameIndex Frame index
    */
   void renderShadowsMesh(rhi::RenderCommandList &commandList,
-                         rhi::PipelineHandle pipeline, uint32_t frameIndex);
+                         rhi::PipelineHandle pipeline, u32 frameIndex);
 
   /**
    * @brief Render skinned meshes for shadows
@@ -149,8 +149,7 @@ private:
    * @param frameIndex Frame index
    */
   void renderShadowsSkinnedMesh(rhi::RenderCommandList &commandList,
-                                rhi::PipelineHandle pipeline,
-                                uint32_t frameIndex);
+                                rhi::PipelineHandle pipeline, u32 frameIndex);
 
   /**
    * @brief Render geometries for shadows
@@ -163,8 +162,8 @@ private:
    */
   void renderShadowsGeometries(rhi::RenderCommandList &commandList,
                                rhi::PipelineHandle pipeline,
-                               const MeshAsset &mesh, uint32_t instanceStart,
-                               uint32_t numInstances);
+                               const MeshAsset &mesh, u32 instanceStart,
+                               u32 numInstances);
 
   /**
    * @brief Render texts
@@ -174,7 +173,7 @@ private:
    * @param frameIndex Frame index
    */
   void renderText(rhi::RenderCommandList &commandList,
-                  rhi::PipelineHandle pipeline, uint32_t frameIndex);
+                  rhi::PipelineHandle pipeline, u32 frameIndex);
 
   /**
    * @brief Generate BRDF lookup table
@@ -186,7 +185,7 @@ private:
    *
    * @return Framebuffer samples
    */
-  inline uint32_t getFramebufferSamples() const { return mMaxSampleCounts; }
+  inline u32 getFramebufferSamples() const { return mMaxSampleCounts; }
 
 private:
   glm::vec4 mClearColor{DefaultClearColor};
@@ -196,7 +195,7 @@ private:
 
   rhi::SamplerHandle mBloomSampler;
 
-  uint32_t mMaxSampleCounts = 1;
+  u32 mMaxSampleCounts = 1;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/SceneRendererFrameData.cpp
+++ b/engine/src/quoll/renderer/SceneRendererFrameData.cpp
@@ -6,7 +6,7 @@
 namespace quoll {
 
 SceneRendererFrameData::SceneRendererFrameData(RenderStorage &renderStorage,
-                                               size_t reservedSpace)
+                                               usize reservedSpace)
     : mReservedSpace(reservedSpace),
       mBindlessParams(renderStorage.getDevice()
                           ->getDeviceInformation()
@@ -152,7 +152,7 @@ void SceneRendererFrameData::updateBuffers() {
                               mFlatMaterials.size() *
                                   sizeof(rhi::DeviceAddress));
   {
-    size_t offset = 0;
+    usize offset = 0;
     auto *bufferData = static_cast<glm::mat4 *>(mMeshTransformsBuffer.map());
     for (auto &[_, data] : mMeshGroups) {
       memcpy(bufferData + offset, data.transforms.data(),
@@ -162,7 +162,7 @@ void SceneRendererFrameData::updateBuffers() {
   }
 
   {
-    size_t offset = 0;
+    usize offset = 0;
     auto *bufferData = static_cast<MaterialRange *>(mMeshMaterialsBuffer.map());
     for (auto &[_, data] : mMeshGroups) {
       memcpy(bufferData + offset, data.materialRanges.data(),
@@ -172,11 +172,11 @@ void SceneRendererFrameData::updateBuffers() {
   }
 
   {
-    size_t transformsOffset = 0;
+    usize transformsOffset = 0;
     auto *transformsBuffer =
         static_cast<glm::mat4 *>(mSkinnedMeshTransformsBuffer.map());
 
-    size_t skeletonsOffset = 0;
+    usize skeletonsOffset = 0;
     auto *skeletonsBuffer = static_cast<glm::mat4 *>(mSkeletonsBuffer.map());
     for (auto &[_, data] : mSkinnedMeshGroups) {
       memcpy(transformsBuffer + transformsOffset, data.transforms.data(),
@@ -190,7 +190,7 @@ void SceneRendererFrameData::updateBuffers() {
   }
 
   {
-    size_t offset = 0;
+    usize offset = 0;
     auto *bufferData =
         static_cast<MaterialRange *>(mSkinnedMeshMaterialsBuffer.map());
     for (auto &[_, data] : mSkinnedMeshGroups) {
@@ -216,7 +216,7 @@ void SceneRendererFrameData::updateBuffers() {
   mSkyboxBuffer.update(&mSkyboxData, sizeof(SkyboxData));
 
   mSpriteTexturesBuffer.update(mSpriteTextures.data(),
-                               mSpriteTextures.size() * sizeof(uint32_t));
+                               mSpriteTextures.size() * sizeof(u32));
   mSpriteTransformsBuffer.update(mSpriteTransforms.data(),
                                  mSpriteTransforms.size() * sizeof(glm::mat4));
 }
@@ -228,12 +228,12 @@ void SceneRendererFrameData::setDefaultMaterial(rhi::DeviceAddress material) {
 void SceneRendererFrameData::addMesh(
     MeshAssetHandle handle, quoll::Entity entity, const glm::mat4 &transform,
     const std::vector<rhi::DeviceAddress> &materials) {
-  uint32_t start = static_cast<uint32_t>(mFlatMaterials.size());
+  u32 start = static_cast<u32>(mFlatMaterials.size());
   for (const auto &material : materials) {
     mFlatMaterials.push_back(material);
   }
-  auto newMaterialSize = static_cast<uint32_t>(mFlatMaterials.size());
-  uint32_t end = newMaterialSize == start ? 0 : newMaterialSize - 1;
+  auto newMaterialSize = static_cast<u32>(mFlatMaterials.size());
+  u32 end = newMaterialSize == start ? 0 : newMaterialSize - 1;
 
   if (mMeshGroups.find(handle) == mMeshGroups.end()) {
     MeshData data{};
@@ -249,12 +249,12 @@ void SceneRendererFrameData::addSkinnedMesh(
     MeshAssetHandle handle, Entity entity, const glm::mat4 &transform,
     const std::vector<glm::mat4> &skeleton,
     const std::vector<rhi::DeviceAddress> &materials) {
-  uint32_t start = static_cast<uint32_t>(mFlatMaterials.size());
+  u32 start = static_cast<u32>(mFlatMaterials.size());
   for (const auto &material : materials) {
     mFlatMaterials.push_back(material);
   }
-  auto newMaterialSize = static_cast<uint32_t>(mFlatMaterials.size());
-  uint32_t end = newMaterialSize == start ? 0 : newMaterialSize - 1;
+  auto newMaterialSize = static_cast<u32>(mFlatMaterials.size());
+  u32 end = newMaterialSize == start ? 0 : newMaterialSize - 1;
 
   if (mSkinnedMeshGroups.find(handle) == mSkinnedMeshGroups.end()) {
     mSkinnedMeshGroups.insert({handle, SkinnedMeshData{}});
@@ -266,8 +266,8 @@ void SceneRendererFrameData::addSkinnedMesh(
   group.transforms.push_back(transform);
   group.materialRanges.push_back({start, end});
 
-  size_t currentOffset = group.lastSkeleton * MaxNumJoints;
-  size_t newSize = currentOffset + MaxNumJoints;
+  usize currentOffset = group.lastSkeleton * MaxNumJoints;
+  usize newSize = currentOffset + MaxNumJoints;
 
   // Resize skeletons if new skeleton does not fit
   if (group.skeletonCapacity < newSize) {
@@ -279,18 +279,18 @@ void SceneRendererFrameData::addSkinnedMesh(
   }
 
   auto *currentSkeleton = group.skeletons.get() + currentOffset;
-  size_t dataSize = std::min(skeleton.size(), MaxNumJoints);
+  usize dataSize = std::min(skeleton.size(), MaxNumJoints);
   memcpy(currentSkeleton, skeleton.data(), dataSize * sizeof(glm::mat4));
   group.lastSkeleton++;
 }
 
 void SceneRendererFrameData::setBrdfLookupTable(rhi::TextureHandle brdfLut) {
-  mSceneData.textures.z = static_cast<uint32_t>(brdfLut);
+  mSceneData.textures.z = static_cast<u32>(brdfLut);
 }
 
 void SceneRendererFrameData::addCascadedShadowMaps(
     const DirectionalLight &light, const CascadedShadowMap &shadowMap) {
-  uint32_t numCascades = static_cast<uint32_t>(shadowMap.numCascades);
+  u32 numCascades = static_cast<u32>(shadowMap.numCascades);
 
   // Calculate split distances by combining
   // logarithmic and uniform splitting
@@ -298,25 +298,24 @@ void SceneRendererFrameData::addCascadedShadowMaps(
   // log_i = near * (far/near)^(i / size)
   // uniform_i = near + (far - near) * (1 / size)
   // distance_i = lambda * log_i + (1 - lambda) * uniform_i
-  std::array<float, CascadedShadowMap::MaxCascades + 1> splitDistances{};
+  std::array<f32, CascadedShadowMap::MaxCascades + 1> splitDistances{};
 
-  float splitLambda = shadowMap.splitLambda;
+  f32 splitLambda = shadowMap.splitLambda;
 
-  float far = mCameraLens.far;
-  float near = mCameraLens.near;
+  f32 far = mCameraLens.far;
+  f32 near = mCameraLens.near;
 
-  float range = far - near;
-  float ratio = far / near;
+  f32 range = far - near;
+  f32 ratio = far / near;
 
-  const float fovY =
+  const f32 fovY =
       2.0f * atanf(mCameraLens.sensorSize.y / (2.0f * mCameraLens.focalLength));
 
-  for (size_t i = 0; i < static_cast<size_t>(numCascades + 1); ++i) {
-    float p =
-        static_cast<float>(i + 1) / static_cast<float>(splitDistances.size());
-    float log = near * std::pow(ratio, p);
-    float uniform = near + range * p;
-    float d = splitLambda * log + (1.0f - splitLambda) * uniform;
+  for (usize i = 0; i < static_cast<usize>(numCascades + 1); ++i) {
+    f32 p = static_cast<f32>(i + 1) / static_cast<f32>(splitDistances.size());
+    f32 log = near * std::pow(ratio, p);
+    f32 uniform = near + range * p;
+    f32 d = splitLambda * log + (1.0f - splitLambda) * uniform;
 
     splitDistances.at(i) = mCameraLens.far * ((d - near) / range);
   }
@@ -329,9 +328,9 @@ void SceneRendererFrameData::addCascadedShadowMaps(
       glm::vec3(1.0f, -1.0f, 1.0f),  glm::vec3(-1.0f, -1.0f, 1.0f),
   };
 
-  float prevSplitDistance = mCameraLens.near;
-  for (size_t i = 0; i < numCascades; ++i) {
-    float splitDistance = splitDistances.at(i);
+  f32 prevSplitDistance = mCameraLens.near;
+  for (usize i = 0; i < numCascades; ++i) {
+    f32 splitDistance = splitDistances.at(i);
 
     auto splitProjectionMatrix = glm::perspective(
         fovY, mCameraLens.aspectRatio, prevSplitDistance, splitDistance);
@@ -341,7 +340,7 @@ void SceneRendererFrameData::addCascadedShadowMaps(
 
     std::array<glm::vec4, FrustumCornersNDC.size()> frustumCorners{};
 
-    for (size_t i = 0; i < frustumCorners.size(); ++i) {
+    for (usize i = 0; i < frustumCorners.size(); ++i) {
       auto pt = invProjView * glm::vec4(FrustumCornersNDC.at(i), 1.0f);
       frustumCorners.at(i) = pt / pt.w;
     }
@@ -353,20 +352,20 @@ void SceneRendererFrameData::addCascadedShadowMaps(
     for (const auto &v : frustumCorners) {
       frustumCenter += glm::vec3(v);
     }
-    frustumCenter /= static_cast<float>(frustumCorners.size());
+    frustumCenter /= static_cast<f32>(frustumCorners.size());
 
-    float radius = 0.0f;
+    f32 radius = 0.0f;
     for (const auto &corner : frustumCorners) {
-      float distance = glm::length(glm::vec3(corner) - frustumCenter);
+      f32 distance = glm::length(glm::vec3(corner) - frustumCenter);
       radius = glm::max(radius, distance);
     }
 
-    static constexpr float Sixteen = 16.0f;
+    static constexpr f32 Sixteen = 16.0f;
     radius = std::ceil(radius * Sixteen) / Sixteen;
     glm::vec3 maxBounds = glm::vec3(radius);
     glm::vec3 minBounds = -maxBounds;
 
-    float cascadeZ = maxBounds.z - minBounds.z;
+    f32 cascadeZ = maxBounds.z - minBounds.z;
     auto lightViewMatrix =
         glm::lookAt(frustumCenter - light.direction * radius, frustumCenter,
                     glm::vec3(0.0f, 1.0f, 0.0f));
@@ -386,11 +385,11 @@ void SceneRendererFrameData::addCascadedShadowMaps(
 
 void SceneRendererFrameData::addLight(const DirectionalLight &light,
                                       const CascadedShadowMap &shadowMap) {
-  uint32_t shadowIndex = static_cast<uint32_t>(mShadowMaps.size());
-  uint32_t numCascades = static_cast<uint32_t>(shadowMap.numCascades);
+  u32 shadowIndex = static_cast<u32>(mShadowMaps.size());
+  u32 numCascades = static_cast<u32>(shadowMap.numCascades);
 
   bool canCastShadows =
-      (shadowIndex + numCascades) <= static_cast<uint32_t>(MaxShadowMaps);
+      (shadowIndex + numCascades) <= static_cast<u32>(MaxShadowMaps);
 
   if (canCastShadows) {
     addCascadedShadowMaps(light, shadowMap);
@@ -400,7 +399,7 @@ void SceneRendererFrameData::addLight(const DirectionalLight &light,
       glm::vec4(light.direction, light.intensity), light.color,
       glm::uvec4(canCastShadows ? 1 : 0, shadowIndex, numCascades, 0)};
   mDirectionalLights.push_back(data);
-  mSceneData.data.x = static_cast<int32_t>(mDirectionalLights.size());
+  mSceneData.data.x = static_cast<i32>(mDirectionalLights.size());
 }
 
 void SceneRendererFrameData::addLight(const DirectionalLight &light) {
@@ -408,7 +407,7 @@ void SceneRendererFrameData::addLight(const DirectionalLight &light) {
                             light.color};
   mDirectionalLights.push_back(data);
 
-  mSceneData.data.x = static_cast<int32_t>(mDirectionalLights.size());
+  mSceneData.data.x = static_cast<i32>(mDirectionalLights.size());
 }
 
 void SceneRendererFrameData::addLight(const PointLight &light,
@@ -424,7 +423,7 @@ void SceneRendererFrameData::addLight(const PointLight &light,
   PointLightData data{glm::vec4(position, light.intensity),
                       glm::vec4(light.range), glm::vec4(light.color)};
   mPointLights.push_back(data);
-  mSceneData.data.y = static_cast<int32_t>(mPointLights.size());
+  mSceneData.data.y = static_cast<i32>(mPointLights.size());
 }
 
 void SceneRendererFrameData::addSprite(Entity entity,
@@ -444,8 +443,8 @@ void SceneRendererFrameData::addText(Entity entity,
 
   TextItem textData{};
   textData.fontTexture = fontTexture;
-  textData.glyphStart = static_cast<uint32_t>(mTextGlyphs.size());
-  textData.length = static_cast<uint32_t>(glyphs.size());
+  textData.glyphStart = static_cast<u32>(mTextGlyphs.size());
+  textData.length = static_cast<u32>(glyphs.size());
 
   for (auto &glyph : glyphs) {
     mTextGlyphs.push_back(glyph);
@@ -455,7 +454,7 @@ void SceneRendererFrameData::addText(Entity entity,
 }
 
 void SceneRendererFrameData::setSkyboxTexture(rhi::TextureHandle texture) {
-  mSkyboxData.data.x = static_cast<uint32_t>(texture);
+  mSkyboxData.data.x = static_cast<u32>(texture);
 }
 
 void SceneRendererFrameData::setSkyboxColor(const glm::vec4 &color) {

--- a/engine/src/quoll/renderer/SceneRendererFrameData.h
+++ b/engine/src/quoll/renderer/SceneRendererFrameData.h
@@ -20,22 +20,22 @@ public:
   /**
    * Default reserved space for buffers
    */
-  static constexpr size_t DefaultReservedSpace = 10000;
+  static constexpr usize DefaultReservedSpace = 10000;
 
   /**
    * Maximum number of joints
    */
-  static constexpr size_t MaxNumJoints = 32;
+  static constexpr usize MaxNumJoints = 32;
 
   /**
    * Maximum number of lights
    */
-  static constexpr size_t MaxNumLights = 256;
+  static constexpr usize MaxNumLights = 256;
 
   /**
    * Maximum number of shadow maps
    */
-  static constexpr size_t MaxShadowMaps = 16;
+  static constexpr usize MaxShadowMaps = 16;
 
   /**
    * @brief Directional light data
@@ -169,12 +169,12 @@ public:
     /**
      * Range start
      */
-    uint32_t start = 0;
+    u32 start = 0;
 
     /**
      * Range end
      */
-    uint32_t end = 0;
+    u32 end = 0;
   };
 
   /**
@@ -210,12 +210,12 @@ public:
     /**
      * Last skeleton index
      */
-    size_t lastSkeleton = 0;
+    usize lastSkeleton = 0;
 
     /**
      * Skeleton capacity
      */
-    size_t skeletonCapacity = 0;
+    usize skeletonCapacity = 0;
   };
 
   /**
@@ -248,12 +248,12 @@ public:
     /**
      * Glyph start position in glyphs buffer
      */
-    uint32_t glyphStart = 0;
+    u32 glyphStart = 0;
 
     /**
      * Text length
      */
-    uint32_t length = 0;
+    u32 length = 0;
   };
 
 public:
@@ -264,7 +264,7 @@ public:
    * @param reservedSpace Reserved space for buffer data
    */
   SceneRendererFrameData(RenderStorage &renderStorage,
-                         size_t reservedSpace = DefaultReservedSpace);
+                         usize reservedSpace = DefaultReservedSpace);
 
   /**
    * @brief Update storage buffers
@@ -330,14 +330,14 @@ public:
    *
    * @return Number of lights
    */
-  inline uint32_t getNumLights() const { return mSceneData.data.x; }
+  inline u32 getNumLights() const { return mSceneData.data.x; }
 
   /**
    * @brief Get number shadow maps
    *
    * @return Number of shadow maps
    */
-  inline const size_t getNumShadowMaps() const { return mShadowMaps.size(); }
+  inline const usize getNumShadowMaps() const { return mShadowMaps.size(); }
 
   /**
    * @brief Set default material
@@ -480,7 +480,7 @@ public:
    *
    * @return Reserved space
    */
-  inline size_t getReservedSpace() const { return mReservedSpace; }
+  inline usize getReservedSpace() const { return mReservedSpace; }
 
   /**
    * @brief Get bindless parameters
@@ -661,7 +661,7 @@ private:
   Camera mCameraData;
   PerspectiveLens mCameraLens;
 
-  size_t mLastSkeleton = 0;
+  usize mLastSkeleton = 0;
 
   std::vector<rhi::DeviceAddress> mFlatMaterials;
   rhi::Buffer mFlatMaterialsBuffer;
@@ -695,7 +695,7 @@ private:
   rhi::Buffer mTextTransformsBuffer;
   rhi::Buffer mTextGlyphsBuffer;
 
-  size_t mReservedSpace = 0;
+  usize mReservedSpace = 0;
 
   BindlessDrawParameters mBindlessParams;
 };

--- a/engine/src/quoll/renderer/TextureUtils.cpp
+++ b/engine/src/quoll/renderer/TextureUtils.cpp
@@ -5,7 +5,7 @@ namespace quoll {
 
 void TextureUtils::copyDataToTexture(
     rhi::RenderDevice *device, void *source, rhi::TextureHandle destination,
-    rhi::ImageLayout destinationLayout, uint32_t destinationLayers,
+    rhi::ImageLayout destinationLayout, u32 destinationLayers,
     const std::vector<TextureAssetLevel> &destinationLevels) {
 
   rhi::BufferDescription stagingBufferDesc{};
@@ -19,7 +19,7 @@ void TextureUtils::copyDataToTexture(
 
   rhi::ImageBarrier barrier{};
   barrier.baseLevel = 0;
-  barrier.levelCount = static_cast<uint32_t>(destinationLevels.size());
+  barrier.levelCount = static_cast<u32>(destinationLevels.size());
   barrier.srcAccess = rhi::Access::None;
   barrier.dstAccess = rhi::Access::TransferWrite;
   barrier.srcLayout = rhi::ImageLayout::Undefined;
@@ -32,16 +32,16 @@ void TextureUtils::copyDataToTexture(
   commandList.pipelineBarrier({}, preBarriers, {});
 
   std::vector<rhi::CopyRegion> copies(destinationLevels.size());
-  for (size_t i = 0; i < copies.size(); ++i) {
+  for (usize i = 0; i < copies.size(); ++i) {
     auto &copy = copies.at(i);
     auto &dstLevel = destinationLevels.at(i);
 
-    copy.bufferOffset = static_cast<uint32_t>(dstLevel.offset);
+    copy.bufferOffset = static_cast<u32>(dstLevel.offset);
     copy.imageBaseArrayLayer = 0;
     copy.imageLayerCount = destinationLayers;
     copy.imageExtent = {dstLevel.width, dstLevel.height, 1};
     copy.imageOffset = {0, 0, 0};
-    copy.imageLevel = static_cast<uint32_t>(i);
+    copy.imageLevel = static_cast<u32>(i);
   }
 
   commandList.copyBufferToTexture(stagingBuffer.getHandle(), destination,
@@ -63,7 +63,7 @@ void TextureUtils::copyDataToTexture(
 
 void TextureUtils::copyTextureToData(
     rhi::RenderDevice *device, rhi::TextureHandle source,
-    rhi::ImageLayout sourceLayout, uint32_t sourceLayers,
+    rhi::ImageLayout sourceLayout, u32 sourceLayers,
     const std::vector<TextureAssetLevel> &sourceLevels, void *destination) {
   rhi::BufferDescription stagingBufferDesc{};
   stagingBufferDesc.size = getBufferSizeFromLevels(sourceLevels);
@@ -76,7 +76,7 @@ void TextureUtils::copyTextureToData(
 
   rhi::ImageBarrier barrier{};
   barrier.baseLevel = 0;
-  barrier.levelCount = static_cast<uint32_t>(sourceLevels.size());
+  barrier.levelCount = static_cast<u32>(sourceLevels.size());
   barrier.srcAccess = rhi::Access::None;
   barrier.dstAccess = rhi::Access::TransferRead;
   barrier.srcLayout = rhi::ImageLayout::Undefined;
@@ -89,16 +89,16 @@ void TextureUtils::copyTextureToData(
   commandList.pipelineBarrier({}, preBarriers, {});
 
   std::vector<rhi::CopyRegion> copies(sourceLevels.size());
-  for (size_t i = 0; i < copies.size(); ++i) {
+  for (usize i = 0; i < copies.size(); ++i) {
     auto &copy = copies.at(i);
     auto &srcLevel = sourceLevels.at(i);
 
-    copy.bufferOffset = static_cast<uint32_t>(srcLevel.offset);
+    copy.bufferOffset = static_cast<u32>(srcLevel.offset);
     copy.imageBaseArrayLayer = 0;
     copy.imageLayerCount = sourceLayers;
     copy.imageExtent = {srcLevel.width, srcLevel.height, 1};
     copy.imageOffset = {0, 0, 0};
-    copy.imageLevel = static_cast<uint32_t>(i);
+    copy.imageLevel = static_cast<u32>(i);
   }
 
   commandList.copyTextureToBuffer(source, stagingBuffer.getHandle(), copies);
@@ -124,8 +124,8 @@ void TextureUtils::copyTextureToData(
 void TextureUtils::generateMipMapsForTexture(rhi::RenderDevice *device,
                                              rhi::TextureHandle texture,
                                              rhi::ImageLayout layout,
-                                             uint32_t layers, uint32_t levels,
-                                             uint32_t width, uint32_t height) {
+                                             u32 layers, u32 levels, u32 width,
+                                             u32 height) {
   auto commandList = device->requestImmediateCommandList();
 
   rhi::ImageBarrier barrier;
@@ -148,10 +148,10 @@ void TextureUtils::generateMipMapsForTexture(rhi::RenderDevice *device,
   barrier.dstLayout = rhi::ImageLayout::TransferSourceOptimal;
   barrier.levelCount = 1;
 
-  uint32_t mipWidth = width;
-  uint32_t mipHeight = height;
+  u32 mipWidth = width;
+  u32 mipHeight = height;
 
-  for (uint32_t i = 1; i < levels; ++i) {
+  for (u32 i = 1; i < levels; ++i) {
     barrier.baseLevel = i - 1;
     barrier.srcStage = rhi::PipelineStage::Transfer;
     barrier.dstStage = rhi::PipelineStage::Transfer;
@@ -195,9 +195,9 @@ void TextureUtils::generateMipMapsForTexture(rhi::RenderDevice *device,
   device->submitImmediate(commandList);
 }
 
-size_t TextureUtils::getBufferSizeFromLevels(
+usize TextureUtils::getBufferSizeFromLevels(
     const std::vector<TextureAssetLevel> &levels) {
-  size_t size = 0;
+  usize size = 0;
   for (auto &level : levels) {
     size += level.size;
   }

--- a/engine/src/quoll/renderer/TextureUtils.h
+++ b/engine/src/quoll/renderer/TextureUtils.h
@@ -23,10 +23,11 @@ public:
    * @param destinationLayers Destination texture layers
    * @param destinationLevels Destination texture levels
    */
-  static void copyDataToTexture(
-      rhi::RenderDevice *device, void *source, rhi::TextureHandle destination,
-      rhi::ImageLayout destinationLayout, uint32_t destinationLayers,
-      const std::vector<TextureAssetLevel> &destinationLevels);
+  static void
+  copyDataToTexture(rhi::RenderDevice *device, void *source,
+                    rhi::TextureHandle destination,
+                    rhi::ImageLayout destinationLayout, u32 destinationLayers,
+                    const std::vector<TextureAssetLevel> &destinationLevels);
 
   /**
    * @brief Copy texture to data
@@ -40,7 +41,7 @@ public:
    */
   static void
   copyTextureToData(rhi::RenderDevice *device, rhi::TextureHandle source,
-                    rhi::ImageLayout sourceLayout, uint32_t sourceLayers,
+                    rhi::ImageLayout sourceLayout, u32 sourceLayers,
                     const std::vector<TextureAssetLevel> &sourceLevels,
                     void *destination);
 
@@ -60,9 +61,8 @@ public:
    */
   static void generateMipMapsForTexture(rhi::RenderDevice *device,
                                         rhi::TextureHandle texture,
-                                        rhi::ImageLayout layout,
-                                        uint32_t layers, uint32_t levels,
-                                        uint32_t width, uint32_t height);
+                                        rhi::ImageLayout layout, u32 layers,
+                                        u32 levels, u32 width, u32 height);
 
   /**
    * @brief Get buffer size from texture level data
@@ -70,7 +70,7 @@ public:
    * @param levels Levels
    * @return Buffer size
    */
-  static size_t
+  static usize
   getBufferSizeFromLevels(const std::vector<TextureAssetLevel> &levels);
 };
 

--- a/engine/src/quoll/scene/CameraAspectRatioUpdater.cpp
+++ b/engine/src/quoll/scene/CameraAspectRatioUpdater.cpp
@@ -11,8 +11,7 @@ void CameraAspectRatioUpdater::update(EntityDatabase &entityDatabase) {
 
   for (auto [_, lens, _1] :
        entityDatabase.view<PerspectiveLens, AutoAspectRatio>()) {
-    lens.aspectRatio =
-        static_cast<float>(mSize.x) / static_cast<float>(mSize.y);
+    lens.aspectRatio = static_cast<f32>(mSize.x) / static_cast<f32>(mSize.y);
   }
 }
 

--- a/engine/src/quoll/scene/CascadedShadowMap.h
+++ b/engine/src/quoll/scene/CascadedShadowMap.h
@@ -9,7 +9,7 @@ struct CascadedShadowMap {
   /**
    * @brief Maximum number of shadow cascades
    */
-  static constexpr uint32_t MaxCascades = 6;
+  static constexpr u32 MaxCascades = 6;
 
   /**
    * Split lambda for calculating splits
@@ -21,7 +21,7 @@ struct CascadedShadowMap {
    * uniform_i = near + (far - near) * (1 / size)
    * distance_i = lambda * log_i + (1 - lambda) * uniform_i
    */
-  float splitLambda = 0.8f;
+  f32 splitLambda = 0.8f;
 
   /**
    * Use soft shadows
@@ -31,7 +31,7 @@ struct CascadedShadowMap {
   /**
    * Number of cascades
    */
-  uint32_t numCascades = 4;
+  u32 numCascades = 4;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/scene/DirectionalLight.h
+++ b/engine/src/quoll/scene/DirectionalLight.h
@@ -14,7 +14,7 @@ struct DirectionalLight {
   /**
    * Light intensity
    */
-  float intensity = 1.0f;
+  f32 intensity = 1.0f;
 
   /**
    * Light direction

--- a/engine/src/quoll/scene/Joint.h
+++ b/engine/src/quoll/scene/Joint.h
@@ -2,6 +2,6 @@
 
 namespace quoll {
 
-using JointId = uint8_t;
+using JointId = u8;
 
 } // namespace quoll

--- a/engine/src/quoll/scene/JointAttachment.h
+++ b/engine/src/quoll/scene/JointAttachment.h
@@ -11,7 +11,7 @@ struct JointAttachment {
   /**
    * Joint index
    */
-  int16_t joint = -1;
+  i16 joint = -1;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/scene/PerspectiveLens.h
+++ b/engine/src/quoll/scene/PerspectiveLens.h
@@ -16,41 +16,41 @@ struct PerspectiveLens {
   /**
    * Default focal length
    */
-  static constexpr float DefaultFocalLength = 23.0f;
+  static constexpr f32 DefaultFocalLength = 23.0f;
 
   /**
    * Default aperture
    */
-  static constexpr float DefaultAperture = 16.0f;
+  static constexpr f32 DefaultAperture = 16.0f;
 
   /**
    * Default shutter speed
    */
-  static constexpr float DefaultShutterSpeed = 1.0f / 250.0f;
+  static constexpr f32 DefaultShutterSpeed = 1.0f / 250.0f;
 
   /**
    * Default sensitivity
    */
-  static constexpr uint32_t DefaultSensitivity = 200;
+  static constexpr u32 DefaultSensitivity = 200;
 
   /**
    * Near plane
    *
    * Measured in meters
    */
-  float near = 0.1f;
+  f32 near = 0.1f;
 
   /**
    * Far plane
    *
    * Measured in meters
    */
-  float far = 1000.0f;
+  f32 far = 1000.0f;
 
   /**
    * Aspect ratio
    */
-  float aspectRatio = 1.0f;
+  f32 aspectRatio = 1.0f;
 
   /**
    * Sensor size
@@ -64,7 +64,7 @@ struct PerspectiveLens {
    *
    * Measured in millimeters
    */
-  float focalLength = DefaultFocalLength;
+  f32 focalLength = DefaultFocalLength;
 
   /**
    * Lens aperture
@@ -73,7 +73,7 @@ struct PerspectiveLens {
    *
    * Example: f3.5, f1.6, f22
    */
-  float aperture = DefaultAperture;
+  f32 aperture = DefaultAperture;
 
   /**
    * Camera shutter speed
@@ -86,7 +86,7 @@ struct PerspectiveLens {
    *
    * Example: 1/125s, 1/1000s, 1s
    */
-  float shutterSpeed = DefaultShutterSpeed;
+  f32 shutterSpeed = DefaultShutterSpeed;
 
   /**
    * Camera sensitivity to light
@@ -96,7 +96,7 @@ struct PerspectiveLens {
    *
    * Example: ISO 100, ISO 400, ISO 1600
    */
-  uint32_t sensitivity = DefaultSensitivity;
+  u32 sensitivity = DefaultSensitivity;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/scene/PerspectiveLensLuaTable.cpp
+++ b/engine/src/quoll/scene/PerspectiveLensLuaTable.cpp
@@ -12,7 +12,7 @@ PerspectiveLensLuaTable::PerspectiveLensLuaTable(Entity entity,
                                                  ScriptGlobals scriptGlobals)
     : mEntity(entity), mScriptGlobals(scriptGlobals) {}
 
-sol_maybe<float> PerspectiveLensLuaTable::getNear() {
+sol_maybe<f32> PerspectiveLensLuaTable::getNear() {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -26,7 +26,7 @@ sol_maybe<float> PerspectiveLensLuaTable::getNear() {
   return lens.near;
 }
 
-void PerspectiveLensLuaTable::setNear(float near) {
+void PerspectiveLensLuaTable::setNear(f32 near) {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     PerspectiveLens lens{};
     lens.near = near;
@@ -36,7 +36,7 @@ void PerspectiveLensLuaTable::setNear(float near) {
   }
 }
 
-sol_maybe<float> PerspectiveLensLuaTable::getFar() {
+sol_maybe<f32> PerspectiveLensLuaTable::getFar() {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -50,7 +50,7 @@ sol_maybe<float> PerspectiveLensLuaTable::getFar() {
   return lens.far;
 }
 
-void PerspectiveLensLuaTable::setFar(float far) {
+void PerspectiveLensLuaTable::setFar(f32 far) {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     PerspectiveLens lens{};
     lens.far = far;
@@ -60,7 +60,7 @@ void PerspectiveLensLuaTable::setFar(float far) {
   }
 }
 
-std::tuple<sol_maybe<float>, sol_maybe<float>>
+std::tuple<sol_maybe<f32>, sol_maybe<f32>>
 PerspectiveLensLuaTable::getSensorSize() {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     Engine::getUserLogger().error()
@@ -75,7 +75,7 @@ PerspectiveLensLuaTable::getSensorSize() {
   return {lens.sensorSize.x, lens.sensorSize.y};
 }
 
-void PerspectiveLensLuaTable::setSensorSize(float width, float height) {
+void PerspectiveLensLuaTable::setSensorSize(f32 width, f32 height) {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     PerspectiveLens lens{};
     lens.sensorSize = {width, height};
@@ -86,7 +86,7 @@ void PerspectiveLensLuaTable::setSensorSize(float width, float height) {
   }
 }
 
-sol_maybe<float> PerspectiveLensLuaTable::getFocalLength() {
+sol_maybe<f32> PerspectiveLensLuaTable::getFocalLength() {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -100,7 +100,7 @@ sol_maybe<float> PerspectiveLensLuaTable::getFocalLength() {
   return lens.focalLength;
 }
 
-void PerspectiveLensLuaTable::setFocalLength(float focalLength) {
+void PerspectiveLensLuaTable::setFocalLength(f32 focalLength) {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     PerspectiveLens lens{};
     lens.focalLength = focalLength;
@@ -111,7 +111,7 @@ void PerspectiveLensLuaTable::setFocalLength(float focalLength) {
   }
 }
 
-sol_maybe<float> PerspectiveLensLuaTable::getAperture() {
+sol_maybe<f32> PerspectiveLensLuaTable::getAperture() {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -125,7 +125,7 @@ sol_maybe<float> PerspectiveLensLuaTable::getAperture() {
   return lens.aperture;
 }
 
-void PerspectiveLensLuaTable::setAperture(float aperture) {
+void PerspectiveLensLuaTable::setAperture(f32 aperture) {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     PerspectiveLens lens{};
     lens.aperture = aperture;
@@ -136,7 +136,7 @@ void PerspectiveLensLuaTable::setAperture(float aperture) {
   }
 }
 
-sol_maybe<float> PerspectiveLensLuaTable::getShutterSpeed() {
+sol_maybe<f32> PerspectiveLensLuaTable::getShutterSpeed() {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -150,8 +150,8 @@ sol_maybe<float> PerspectiveLensLuaTable::getShutterSpeed() {
   return 1.0f / lens.shutterSpeed;
 }
 
-void PerspectiveLensLuaTable::setShutterSpeed(float shutterSpeed) {
-  float value = 1.0f / shutterSpeed;
+void PerspectiveLensLuaTable::setShutterSpeed(f32 shutterSpeed) {
+  f32 value = 1.0f / shutterSpeed;
 
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     PerspectiveLens lens{};
@@ -163,7 +163,7 @@ void PerspectiveLensLuaTable::setShutterSpeed(float shutterSpeed) {
   }
 }
 
-sol_maybe<uint32_t> PerspectiveLensLuaTable::getSensitivity() {
+sol_maybe<u32> PerspectiveLensLuaTable::getSensitivity() {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     Engine::getUserLogger().error()
         << LuaMessages::componentDoesNotExist(getName(), mEntity);
@@ -177,7 +177,7 @@ sol_maybe<uint32_t> PerspectiveLensLuaTable::getSensitivity() {
   return lens.sensitivity;
 }
 
-void PerspectiveLensLuaTable::setSensitivity(uint32_t sensitivity) {
+void PerspectiveLensLuaTable::setSensitivity(u32 sensitivity) {
   if (!mScriptGlobals.entityDatabase.has<PerspectiveLens>(mEntity)) {
     PerspectiveLens lens{};
     lens.sensitivity = sensitivity;

--- a/engine/src/quoll/scene/PerspectiveLensLuaTable.h
+++ b/engine/src/quoll/scene/PerspectiveLensLuaTable.h
@@ -22,35 +22,35 @@ public:
    *
    * @return Near plane value
    */
-  sol_maybe<float> getNear();
+  sol_maybe<f32> getNear();
 
   /**
    * @brief Set near plane value
    *
    * @param near Near plane value
    */
-  void setNear(float near);
+  void setNear(f32 near);
 
   /**
    * @brief Get far plane value
    *
    * @return Far plane value
    */
-  sol_maybe<float> getFar();
+  sol_maybe<f32> getFar();
 
   /**
    * @brief Set far plane value
    *
    * @param far Far plane vavoid *statelue
    */
-  void setFar(float far);
+  void setFar(f32 far);
 
   /**
    * @brief Get sensor size
    *
    * @return Sensor width and height
    */
-  std::tuple<sol_maybe<float>, sol_maybe<float>> getSensorSize();
+  std::tuple<sol_maybe<f32>, sol_maybe<f32>> getSensorSize();
 
   /**
    * @brief Set sensor size
@@ -58,63 +58,63 @@ public:
    * @param width Sensor width
    * @param height Sensor height
    */
-  void setSensorSize(float width, float height);
+  void setSensorSize(f32 width, f32 height);
 
   /**
    * @brief Get near plane value
    *
    * @return Focal length
    */
-  sol_maybe<float> getFocalLength();
+  sol_maybe<f32> getFocalLength();
 
   /**
    * @brief Set focal length
    *
    * @param focalLength Focal length
    */
-  void setFocalLength(float focalLength);
+  void setFocalLength(f32 focalLength);
 
   /**
    * @brief Get aperture
    *
    * @return Aperture
    */
-  sol_maybe<float> getAperture();
+  sol_maybe<f32> getAperture();
 
   /**
    * @brief Set aperture
    *
    * @param aperture Aperture
    */
-  void setAperture(float aperture);
+  void setAperture(f32 aperture);
 
   /**
    * @brief Get shutter speed
    *
    * @return Shutter speed
    */
-  sol_maybe<float> getShutterSpeed();
+  sol_maybe<f32> getShutterSpeed();
 
   /**
    * @brief Set shutter speed
    *
    * @param shutterSpeed Shutter speed
    */
-  void setShutterSpeed(float shutterSpeed);
+  void setShutterSpeed(f32 shutterSpeed);
 
   /**
    * @brief Get sensitivity
    *
    * @return Sensitivity
    */
-  sol_maybe<uint32_t> getSensitivity();
+  sol_maybe<u32> getSensitivity();
 
   /**
    * @brief Set sensitivity
    *
    * @param sensitivity Sensitivity
    */
-  void setSensitivity(uint32_t sensitivity);
+  void setSensitivity(u32 sensitivity);
 
   /**
    * @brief Delete component

--- a/engine/src/quoll/scene/PointLight.h
+++ b/engine/src/quoll/scene/PointLight.h
@@ -14,12 +14,12 @@ struct PointLight {
   /**
    * Light intensity
    */
-  float intensity = 1.0f;
+  f32 intensity = 1.0f;
 
   /**
    * Light range cutoff
    */
-  float range = 10.0f;
+  f32 range = 10.0f;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/scene/SceneIO.cpp
+++ b/engine/src/quoll/scene/SceneIO.cpp
@@ -29,7 +29,7 @@ std::vector<Entity> SceneIO::loadScene(SceneAssetHandle scene) {
     }
   }
 
-  for (size_t i = 0; i < entities.size(); ++i) {
+  for (usize i = 0; i < entities.size(); ++i) {
     auto &node = yamlNodes.at(i);
 
     sceneLoader.loadComponents(node, entities.at(i), mEntityIdCache);
@@ -75,7 +75,7 @@ void SceneIO::reset() {
 
 Result<Entity> SceneIO::createEntityFromNode(const YAML::Node &node) {
   if (node["id"] && node["id"].IsScalar()) {
-    auto id = node["id"].as<uint64_t>(0);
+    auto id = node["id"].as<u64>(0);
 
     if (id > 0 && mEntityIdCache.find(id) == mEntityIdCache.end()) {
       auto entity = mScene.entityDatabase.create();

--- a/engine/src/quoll/scene/SceneIO.h
+++ b/engine/src/quoll/scene/SceneIO.h
@@ -50,7 +50,7 @@ private:
   Scene &mScene;
   AssetRegistry &mAssetRegistry;
 
-  std::unordered_map<uint64_t, Entity> mEntityIdCache;
+  std::unordered_map<u64, Entity> mEntityIdCache;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/scene/SceneUpdater.cpp
+++ b/engine/src/quoll/scene/SceneUpdater.cpp
@@ -36,13 +36,13 @@ void SceneUpdater::updateTransforms(EntityDatabase &entityDatabase) {
                                glm::toMat4(local.localRotation) *
                                glm::scale(identity, local.localScale);
 
-    int16_t jointId = -1;
+    i16 jointId = -1;
     if (entityDatabase.has<JointAttachment>(entity) &&
         entityDatabase.has<Skeleton>(parent.parent)) {
       jointId = entityDatabase.get<JointAttachment>(entity).joint;
     }
 
-    if (jointId >= 0 && static_cast<size_t>(jointId) <
+    if (jointId >= 0 && static_cast<usize>(jointId) <
                             entityDatabase.get<Skeleton>(parent.parent)
                                 .jointWorldTransforms.size()) {
       const auto &jointTransform = entityDatabase.get<Skeleton>(parent.parent)
@@ -61,7 +61,7 @@ void SceneUpdater::updateCameras(EntityDatabase &entityDatabase) {
   for (auto [entity, lens, world, camera] :
        entityDatabase.view<PerspectiveLens, WorldTransform, Camera>()) {
 
-    const float fovY =
+    const f32 fovY =
         2.0f * atanf(lens.sensorSize.y / (2.0f * lens.focalLength));
 
     camera.projectionMatrix =
@@ -70,9 +70,8 @@ void SceneUpdater::updateCameras(EntityDatabase &entityDatabase) {
     camera.viewMatrix = glm::inverse(world.worldTransform);
     camera.projectionViewMatrix = camera.projectionMatrix * camera.viewMatrix;
 
-    const float ev100 =
-        std::log2f(powf(lens.aperture, 2.0f) * lens.shutterSpeed * 100.0f /
-                   static_cast<float>(lens.sensitivity));
+    const f32 ev100 = std::log2f(powf(lens.aperture, 2.0f) * lens.shutterSpeed *
+                                 100.0f / static_cast<f32>(lens.sensitivity));
     camera.exposure.x = ev100;
   }
 }

--- a/engine/src/quoll/scene/Skeleton.h
+++ b/engine/src/quoll/scene/Skeleton.h
@@ -16,7 +16,7 @@ struct Skeleton {
   /**
    * Number of joints
    */
-  uint32_t numJoints = 0;
+  u32 numJoints = 0;
 
   /**
    * List of joint parents

--- a/engine/src/quoll/scene/SkeletonUpdater.cpp
+++ b/engine/src/quoll/scene/SkeletonUpdater.cpp
@@ -22,7 +22,7 @@ void SkeletonUpdater::updateSkeletons(EntityDatabase &entityDatabase) {
           glm::scale(identity, skeleton.jointLocalScales.at(0));
     }
 
-    for (uint32_t i = 1; i < skeleton.numJoints; ++i) {
+    for (u32 i = 1; i < skeleton.numJoints; ++i) {
       glm::mat4 identity{1.0f};
       auto localTransform =
           glm::translate(identity, skeleton.jointLocalPositions.at(i)) *
@@ -34,7 +34,7 @@ void SkeletonUpdater::updateSkeletons(EntityDatabase &entityDatabase) {
       skeleton.jointWorldTransforms.at(i) = parentWorld * localTransform;
     }
 
-    for (size_t i = 0; i < skeleton.numJoints; ++i) {
+    for (usize i = 0; i < skeleton.numJoints; ++i) {
       skeleton.jointFinalTransforms.at(i) =
           skeleton.jointWorldTransforms.at(i) *
           skeleton.jointInverseBindMatrices.at(i);
@@ -46,11 +46,10 @@ void SkeletonUpdater::updateDebugBones(EntityDatabase &entityDatabase) {
   QUOLL_PROFILE_EVENT("SkeletonUpdater::updateDebug");
   for (auto [entity, skeleton, debug] :
        entityDatabase.view<Skeleton, SkeletonDebug>()) {
-    QuollAssert(static_cast<uint32_t>(debug.bones.size()) ==
-                    skeleton.numJoints * 2,
+    QuollAssert(static_cast<u32>(debug.bones.size()) == skeleton.numJoints * 2,
                 "Debug bones must be twice the size skeleton joint size");
 
-    for (size_t i = 0; i < debug.bones.size(); ++i) {
+    for (usize i = 0; i < debug.bones.size(); ++i) {
       debug.boneTransforms.at(i) =
           skeleton.jointWorldTransforms.at(debug.bones.at(i));
     }

--- a/engine/src/quoll/scene/TransformLuaTable.cpp
+++ b/engine/src/quoll/scene/TransformLuaTable.cpp
@@ -11,18 +11,18 @@ namespace quoll {
 TransformLuaTable::TransformLuaTable(Entity entity, ScriptGlobals scriptGlobals)
     : mEntity(entity), mScriptGlobals(scriptGlobals) {}
 
-std::tuple<float, float, float> TransformLuaTable::getPosition() {
+std::tuple<f32, f32, f32> TransformLuaTable::getPosition() {
   auto pos =
       mScriptGlobals.entityDatabase.get<LocalTransform>(mEntity).localPosition;
   return {pos.x, pos.y, pos.z};
 }
 
-void TransformLuaTable::setPosition(float x, float y, float z) {
+void TransformLuaTable::setPosition(f32 x, f32 y, f32 z) {
   mScriptGlobals.entityDatabase.get<LocalTransform>(mEntity).localPosition =
       glm::vec3{x, y, z};
 }
 
-std::tuple<float, float, float> TransformLuaTable::getRotation() {
+std::tuple<f32, f32, f32> TransformLuaTable::getRotation() {
   const auto &rotationQuat =
       mScriptGlobals.entityDatabase.get<LocalTransform>(mEntity).localRotation;
 
@@ -34,7 +34,7 @@ std::tuple<float, float, float> TransformLuaTable::getRotation() {
   return {rotationEuler.z, rotationEuler.y, rotationEuler.x};
 }
 
-void TransformLuaTable::setRotation(float x, float y, float z) {
+void TransformLuaTable::setRotation(f32 x, f32 y, f32 z) {
   glm::vec3 rotation{x, y, z};
   auto newRotation = glm::radians(rotation);
 
@@ -46,13 +46,13 @@ void TransformLuaTable::setRotation(float x, float y, float z) {
           glm::eulerAngleXYZ(newRotation.x, newRotation.y, newRotation.z));
 }
 
-std::tuple<float, float, float> TransformLuaTable::getScale() {
+std::tuple<f32, f32, f32> TransformLuaTable::getScale() {
   auto scale =
       mScriptGlobals.entityDatabase.get<LocalTransform>(mEntity).localScale;
   return {scale.x, scale.y, scale.z};
 }
 
-void TransformLuaTable::setScale(float x, float y, float z) {
+void TransformLuaTable::setScale(f32 x, f32 y, f32 z) {
   mScriptGlobals.entityDatabase.get<LocalTransform>(mEntity).localScale =
       glm::vec3{x, y, z};
 }

--- a/engine/src/quoll/scene/TransformLuaTable.h
+++ b/engine/src/quoll/scene/TransformLuaTable.h
@@ -22,7 +22,7 @@ public:
    *
    * @return Local scale
    */
-  std::tuple<float, float, float> getScale();
+  std::tuple<f32, f32, f32> getScale();
 
   /**
    * @brief Set local scale
@@ -31,14 +31,14 @@ public:
    * @param y Local scale in y axis
    * @param z Local scale in z axis
    */
-  void setScale(float x, float y, float z);
+  void setScale(f32 x, f32 y, f32 z);
 
   /**
    * @brief Get local position
    *
    * @return Local position
    */
-  std::tuple<float, float, float> getPosition();
+  std::tuple<f32, f32, f32> getPosition();
 
   /**
    * @brief Set local position
@@ -47,14 +47,14 @@ public:
    * @param y Local position in y axis
    * @param z Local position in z axis
    */
-  void setPosition(float x, float y, float z);
+  void setPosition(f32 x, f32 y, f32 z);
 
   /**
    * @brief Get rotation
    *
    * @return Local rotation in euler angles
    */
-  std::tuple<float, float, float> getRotation();
+  std::tuple<f32, f32, f32> getRotation();
 
   /**
    * @brief Set local rotation
@@ -63,7 +63,7 @@ public:
    * @param y Local rotation as euler angles in y axis
    * @param z Local rotation as euler angles in z axis
    */
-  void setRotation(float x, float y, float z);
+  void setRotation(f32 x, f32 y, f32 z);
 
   /**
    * @brief Delete component

--- a/engine/src/quoll/scene/private/SceneLoader.cpp
+++ b/engine/src/quoll/scene/private/SceneLoader.cpp
@@ -32,7 +32,7 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
         node["transform"]["scale"].as<glm::vec3>(transform.localScale);
 
     if (node["transform"]["parent"]) {
-      auto parentId = node["transform"]["parent"].as<uint64_t>(0);
+      auto parentId = node["transform"]["parent"].as<u64>(0);
 
       auto it = entityIdCache.find(parentId);
       Entity parentEntity =
@@ -67,7 +67,7 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
   if (node["rigidBody"] && node["rigidBody"].IsMap()) {
     RigidBody rigidBody{};
     rigidBody.dynamicDesc.mass =
-        node["rigidBody"]["mass"].as<float>(rigidBody.dynamicDesc.mass);
+        node["rigidBody"]["mass"].as<f32>(rigidBody.dynamicDesc.mass);
     rigidBody.dynamicDesc.inertia = node["rigidBody"]["inertia"].as<glm::vec3>(
         rigidBody.dynamicDesc.inertia);
     rigidBody.dynamicDesc.applyGravity =
@@ -104,14 +104,14 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
       collidable.geometryDesc.params = box;
     } else if (shape == PhysicsGeometryType::Sphere) {
       quoll::PhysicsGeometrySphere sphere{};
-      sphere.radius = node["collidable"]["radius"].as<float>(sphere.radius);
+      sphere.radius = node["collidable"]["radius"].as<f32>(sphere.radius);
 
       collidable.geometryDesc.params = sphere;
     } else if (shape == PhysicsGeometryType::Capsule) {
       quoll::PhysicsGeometryCapsule capsule{};
-      capsule.radius = node["collidable"]["radius"].as<float>(capsule.radius);
+      capsule.radius = node["collidable"]["radius"].as<f32>(capsule.radius);
       capsule.halfHeight =
-          node["collidable"]["halfHeight"].as<float>(capsule.halfHeight);
+          node["collidable"]["halfHeight"].as<f32>(capsule.halfHeight);
 
       collidable.geometryDesc.params = capsule;
     } else if (shape == PhysicsGeometryType::Plane) {
@@ -119,13 +119,13 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
     }
 
     collidable.materialDesc.dynamicFriction =
-        node["collidable"]["dynamicFriction"].as<float>(
+        node["collidable"]["dynamicFriction"].as<f32>(
             collidable.materialDesc.dynamicFriction);
     collidable.materialDesc.restitution =
-        node["collidable"]["restitution"].as<float>(
+        node["collidable"]["restitution"].as<f32>(
             collidable.materialDesc.restitution);
     collidable.materialDesc.staticFriction =
-        node["collidable"]["staticFriction"].as<float>(
+        node["collidable"]["staticFriction"].as<f32>(
             collidable.materialDesc.staticFriction);
 
     mEntityDatabase.set(entity, collidable);
@@ -203,7 +203,7 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
       skeletonComponent.jointNames = skeleton.jointNames;
       skeletonComponent.assetHandle = handle;
       skeletonComponent.numJoints =
-          static_cast<uint32_t>(skeleton.jointLocalPositions.size());
+          static_cast<u32>(skeleton.jointLocalPositions.size());
       skeletonComponent.jointFinalTransforms.resize(skeletonComponent.numJoints,
                                                     glm::mat4{1.0f});
       skeletonComponent.jointWorldTransforms.resize(skeletonComponent.numJoints,
@@ -214,8 +214,8 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
   }
 
   if (node["jointAttachment"] && node["jointAttachment"].IsMap()) {
-    auto joint = node["jointAttachment"]["joint"].as<int16_t>(-1);
-    if (joint >= 0 && joint < std::numeric_limits<uint8_t>::max()) {
+    auto joint = node["jointAttachment"]["joint"].as<i16>(-1);
+    if (joint >= 0 && joint < std::numeric_limits<u8>::max()) {
       JointAttachment attachment{joint};
       mEntityDatabase.set(entity, attachment);
     }
@@ -236,12 +236,11 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
 
   if (node["light"] && node["light"].IsMap()) {
     auto light = node["light"];
-    auto type =
-        light["type"].as<uint32_t>(std::numeric_limits<uint32_t>::max());
+    auto type = light["type"].as<u32>(std::numeric_limits<u32>::max());
 
     if (type == 0) {
       DirectionalLight component{};
-      component.intensity = light["intensity"].as<float>(component.intensity);
+      component.intensity = light["intensity"].as<f32>(component.intensity);
       component.color = light["color"].as<glm::vec4>(component.color);
 
       mEntityDatabase.set(entity, component);
@@ -250,11 +249,10 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
         CascadedShadowMap shadowComponent{};
         shadowComponent.softShadows = light["shadow"]["softShadows"].as<bool>(
             shadowComponent.softShadows);
-        shadowComponent.splitLambda = light["shadow"]["splitLambda"].as<float>(
-            shadowComponent.splitLambda);
+        shadowComponent.splitLambda =
+            light["shadow"]["splitLambda"].as<f32>(shadowComponent.splitLambda);
         shadowComponent.numCascades =
-            light["shadow"]["numCascades"].as<uint32_t>(
-                shadowComponent.numCascades);
+            light["shadow"]["numCascades"].as<u32>(shadowComponent.numCascades);
 
         shadowComponent.numCascades = glm::clamp(
             shadowComponent.numCascades, 1u, shadowComponent.MaxCascades);
@@ -266,7 +264,7 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
       }
     } else if (type == 1) {
       PointLight component{};
-      component.intensity = light["intensity"].as<float>(component.intensity);
+      component.intensity = light["intensity"].as<f32>(component.intensity);
       component.color = light["color"].as<glm::vec4>(component.color);
       component.range = light["range"].as<glm::float32>(component.range);
 
@@ -276,12 +274,12 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
 
   if (node["camera"] && node["camera"].IsMap()) {
     PerspectiveLens lens{};
-    float near = node["camera"]["near"].as<float>(lens.near);
+    f32 near = node["camera"]["near"].as<f32>(lens.near);
     if (near >= 0.0f) {
       lens.near = near;
     }
 
-    float far = node["camera"]["far"].as<float>(lens.far);
+    f32 far = node["camera"]["far"].as<f32>(lens.far);
     if (far >= 0.0f) {
       lens.far = far;
     }
@@ -293,25 +291,23 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
       lens.sensorSize = sensorSize;
     }
 
-    float focalLength =
-        node["camera"]["focalLength"].as<float>(lens.focalLength);
+    f32 focalLength = node["camera"]["focalLength"].as<f32>(lens.focalLength);
     if (focalLength >= 0.0f) {
       lens.focalLength = focalLength;
     }
 
-    float aperture = node["camera"]["aperture"].as<float>(lens.aperture);
+    f32 aperture = node["camera"]["aperture"].as<f32>(lens.aperture);
     if (aperture >= 0.0f) {
       lens.aperture = aperture;
     }
 
-    float shutterSpeed =
-        node["camera"]["shutterSpeed"].as<float>(lens.shutterSpeed);
+    f32 shutterSpeed =
+        node["camera"]["shutterSpeed"].as<f32>(lens.shutterSpeed);
     if (shutterSpeed >= 0.0f) {
       lens.shutterSpeed = shutterSpeed;
     }
 
-    lens.sensitivity =
-        node["camera"]["sensitivity"].as<uint32_t>(lens.sensitivity);
+    lens.sensitivity = node["camera"]["sensitivity"].as<u32>(lens.sensitivity);
 
     bool autoRatio = true;
     if (node["camera"]["aspectRatio"] &&
@@ -326,8 +322,7 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
     if (autoRatio) {
       mEntityDatabase.set<AutoAspectRatio>(entity, {});
     } else {
-      float aspectRatio =
-          node["camera"]["aspectRatio"].as<float>(lens.aspectRatio);
+      f32 aspectRatio = node["camera"]["aspectRatio"].as<f32>(lens.aspectRatio);
       if (aspectRatio >= 0.0f) {
         lens.aspectRatio = aspectRatio;
       }
@@ -404,7 +399,7 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
       }
 
       textComponent.lineHeight =
-          node["text"]["lineHeight"].as<float>(textComponent.lineHeight);
+          node["text"]["lineHeight"].as<f32>(textComponent.lineHeight);
 
       mEntityDatabase.set(entity, textComponent);
     }
@@ -438,7 +433,7 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
 
   if (node["inputMap"] && node["inputMap"].IsMap()) {
     auto uuid = node["inputMap"]["asset"].as<Uuid>(Uuid{});
-    auto defaultScheme = node["inputMap"]["defaultScheme"].as<size_t>(0);
+    auto defaultScheme = node["inputMap"]["defaultScheme"].as<usize>(0);
     auto handle = mAssetRegistry.getInputMaps().findHandleByUuid(uuid);
 
     if (handle != InputMapAssetHandle::Null) {
@@ -459,7 +454,7 @@ Result<Entity> SceneLoader::loadStartingCamera(const YAML::Node &node,
                                                EntityIdCache &entityIdCache) {
   Entity entity = Entity::Null;
   if (node && node.IsScalar()) {
-    auto entityId = node.as<uint64_t>(0);
+    auto entityId = node.as<u64>(0);
 
     if (entityId > 0 && entityIdCache.find(entityId) != entityIdCache.end()) {
       auto foundEntity = entityIdCache.at(entityId);
@@ -480,7 +475,7 @@ Result<Entity> SceneLoader::loadStartingCamera(const YAML::Node &node,
 Result<Entity> SceneLoader::loadEnvironment(const YAML::Node &node,
                                             EntityIdCache &entityIdCache) {
   if (node && node.IsScalar()) {
-    auto entityId = node.as<uint64_t>(0);
+    auto entityId = node.as<u64>(0);
 
     if (entityId > 0 && entityIdCache.contains(entityId)) {
       auto entity = entityIdCache.at(entityId);

--- a/engine/src/quoll/scene/private/SceneLoader.h
+++ b/engine/src/quoll/scene/private/SceneLoader.h
@@ -7,7 +7,7 @@
 
 namespace quoll::detail {
 
-using EntityIdCache = std::unordered_map<uint64_t, Entity>;
+using EntityIdCache = std::unordered_map<u64, Entity>;
 
 /**
  * @brief Load scene data to entity

--- a/engine/src/quoll/scripting/InputVars.cpp
+++ b/engine/src/quoll/scripting/InputVars.cpp
@@ -7,10 +7,10 @@ InputVars::InputVars(
     std::unordered_map<String, LuaScriptInputVariable> &variables)
     : mVariables(variables) {}
 
-std::variant<String, uint32_t>
-InputVars::registerVar(String name, LuaScriptVariableType type) {
-  if (static_cast<uint32_t>(type) >=
-      static_cast<uint32_t>(LuaScriptVariableType::Invalid)) {
+std::variant<String, u32> InputVars::registerVar(String name,
+                                                 LuaScriptVariableType type) {
+  if (static_cast<u32>(type) >=
+      static_cast<u32>(LuaScriptVariableType::Invalid)) {
     // scope.error("Variable \"" + name + "\" has invalid type");
     return 0u;
   }
@@ -21,11 +21,11 @@ InputVars::registerVar(String name, LuaScriptVariableType type) {
   }
 
   if (value.isType(LuaScriptVariableType::AssetPrefab)) {
-    return static_cast<uint32_t>(value.get<PrefabAssetHandle>());
+    return static_cast<u32>(value.get<PrefabAssetHandle>());
   }
 
   if (value.isType(LuaScriptVariableType::AssetTexture)) {
-    return static_cast<uint32_t>(value.get<TextureAssetHandle>());
+    return static_cast<u32>(value.get<TextureAssetHandle>());
   }
 
   return 0u;

--- a/engine/src/quoll/scripting/InputVars.h
+++ b/engine/src/quoll/scripting/InputVars.h
@@ -24,8 +24,8 @@ public:
    * @param type Variable type
    * @return Variable value
    */
-  std::variant<String, uint32_t> registerVar(String name,
-                                             LuaScriptVariableType type);
+  std::variant<String, u32> registerVar(String name,
+                                        LuaScriptVariableType type);
 
   /**
    * @brief Create interface

--- a/engine/src/quoll/scripting/LuaInterpreter.cpp
+++ b/engine/src/quoll/scripting/LuaInterpreter.cpp
@@ -21,8 +21,7 @@ lua_State *LuaInterpreter::createState() {
 
 void LuaInterpreter::destroyState(lua_State *state) { lua_close(state); }
 
-bool LuaInterpreter::evaluate(const std::vector<uint8_t> &bytes,
-                              lua_State *state) {
+bool LuaInterpreter::evaluate(const std::vector<u8> &bytes, lua_State *state) {
 
   auto ret =
       luaL_loadstring(state, quoll::String{bytes.begin(), bytes.end()}.c_str());

--- a/engine/src/quoll/scripting/LuaInterpreter.h
+++ b/engine/src/quoll/scripting/LuaInterpreter.h
@@ -33,7 +33,7 @@ public:
    * @retval true Script evaluated sucessfully
    * @retval false Script failed to evaluate
    */
-  bool evaluate(const std::vector<uint8_t> &bytes, lua_State *state);
+  bool evaluate(const std::vector<u8> &bytes, lua_State *state);
 };
 
 } // namespace quoll

--- a/engine/src/quoll/scripting/LuaMessages.cpp
+++ b/engine/src/quoll/scripting/LuaMessages.cpp
@@ -19,13 +19,13 @@ String LuaMessages::noEntityTable(const String &interfaceName,
 String LuaMessages::entityDoesNotExist(const String &interfaceName,
                                        const String &functionName,
                                        Entity entity) {
-  return "Entity " + std::to_string(static_cast<uint32_t>(entity)) +
+  return "Entity " + std::to_string(static_cast<u32>(entity)) +
          " does not exist";
 }
 
 String LuaMessages::componentDoesNotExist(const String &componentName,
                                           Entity entity) {
-  return "Entity " + std::to_string(static_cast<uint32_t>(entity)) +
+  return "Entity " + std::to_string(static_cast<u32>(entity)) +
          " does not have " + componentName + " component";
 }
 

--- a/engine/src/quoll/scripting/LuaMessages.h
+++ b/engine/src/quoll/scripting/LuaMessages.h
@@ -93,7 +93,7 @@ private:
   template <class T> static inline String getTypename() { return "[unknown]"; }
 };
 
-template <> inline String LuaMessages::getTypename<float>() { return "number"; }
+template <> inline String LuaMessages::getTypename<f32>() { return "number"; }
 
 template <> inline String LuaMessages::getTypename<String>() {
   return "string";

--- a/engine/src/quoll/scripting/ScriptDecorator.cpp
+++ b/engine/src/quoll/scripting/ScriptDecorator.cpp
@@ -46,9 +46,10 @@ void ScriptDecorator::attachVariableInjectors(
     sol::state_view state,
     std::unordered_map<String, LuaScriptInputVariable> &variables) {
   auto inputVars = state.create_named_table("input_vars");
-  inputVars["register"] = [&variables](String name, uint32_t type)
-      -> std::variant<String, uint32_t, sol::nil_t> {
-    if (type >= static_cast<uint32_t>(LuaScriptVariableType::Invalid)) {
+  inputVars["register"] =
+      [&variables](String name,
+                   u32 type) -> std::variant<String, u32, sol::nil_t> {
+    if (type >= static_cast<u32>(LuaScriptVariableType::Invalid)) {
       //     scope.error("Variable \"" + name + "\" has invalid type");
       return sol::nil;
     }
@@ -59,11 +60,11 @@ void ScriptDecorator::attachVariableInjectors(
     }
 
     if (value.isType(LuaScriptVariableType::AssetPrefab)) {
-      return static_cast<uint32_t>(value.get<PrefabAssetHandle>());
+      return static_cast<u32>(value.get<PrefabAssetHandle>());
     }
 
     if (value.isType(LuaScriptVariableType::AssetTexture)) {
-      return static_cast<uint32_t>(value.get<TextureAssetHandle>());
+      return static_cast<u32>(value.get<TextureAssetHandle>());
     }
 
     return sol::nil;

--- a/engine/src/quoll/scripting/ScriptHandle.h
+++ b/engine/src/quoll/scripting/ScriptHandle.h
@@ -2,6 +2,6 @@
 
 namespace quoll {
 
-enum class ScriptHandle : uint32_t {};
+enum class ScriptHandle : u32 {};
 
 } // namespace quoll

--- a/engine/src/quoll/scripting/ScriptingSystem.cpp
+++ b/engine/src/quoll/scripting/ScriptingSystem.cpp
@@ -66,7 +66,7 @@ void ScriptingSystem::start(EntityDatabase &entityDatabase,
   }
 }
 
-void ScriptingSystem::update(float dt, EntityDatabase &entityDatabase) {
+void ScriptingSystem::update(f32 dt, EntityDatabase &entityDatabase) {
   QUOLL_PROFILE_EVENT("ScriptingSystem::update");
 
   for (auto [entity, script] : mScriptRemoveObserver) {

--- a/engine/src/quoll/scripting/ScriptingSystem.h
+++ b/engine/src/quoll/scripting/ScriptingSystem.h
@@ -44,7 +44,7 @@ public:
    * @param dt Delta time
    * @param entityDatabase Entity database
    */
-  void update(float dt, EntityDatabase &entityDatabase);
+  void update(f32 dt, EntityDatabase &entityDatabase);
 
   /**
    * @brief Cleanup components

--- a/engine/src/quoll/text/MsdfLoader.cpp
+++ b/engine/src/quoll/text/MsdfLoader.cpp
@@ -10,11 +10,11 @@
 namespace quoll {
 
 Result<AssetData<FontAsset>> MsdfLoader::loadFontData(const Path &path) {
-  static constexpr double MaxCornerAngle = 3.0;
-  static constexpr double MinimumScale = 32.0;
-  static constexpr double PixelRange = 2.0;
-  static constexpr uint32_t NumChannels = 4;
-  static constexpr double FontScale = 1.0;
+  static constexpr f64 MaxCornerAngle = 3.0;
+  static constexpr f64 MinimumScale = 32.0;
+  static constexpr f64 PixelRange = 2.0;
+  static constexpr u32 NumChannels = 4;
+  static constexpr f64 FontScale = 1.0;
 
   using namespace msdf_atlas;
 
@@ -53,7 +53,7 @@ Result<AssetData<FontAsset>> MsdfLoader::loadFontData(const Path &path) {
   int width = 0, height = 0;
   packer.getDimensions(width, height);
 
-  ImmediateAtlasGenerator<float, NumChannels, mtsdfGenerator,
+  ImmediateAtlasGenerator<f32, NumChannels, mtsdfGenerator,
                           BitmapAtlasStorage<byte, NumChannels>>
       generator(width, height);
 
@@ -64,10 +64,10 @@ Result<AssetData<FontAsset>> MsdfLoader::loadFontData(const Path &path) {
   generator.setThreadCount(1);
   generator.generate(msdfGlyphs.data(), static_cast<int>(msdfGlyphs.size()));
 
-  std::unordered_map<uint32_t, FontGlyph> glyphs;
+  std::unordered_map<u32, FontGlyph> glyphs;
 
-  auto fWidth = static_cast<float>(width);
-  auto fHeight = static_cast<float>(height);
+  auto fWidth = static_cast<f32>(width);
+  auto fHeight = static_cast<f32>(height);
 
   for (auto &msdfGlyph : msdfGlyphs) {
     FontGlyph glyph{};
@@ -75,26 +75,25 @@ Result<AssetData<FontAsset>> MsdfLoader::loadFontData(const Path &path) {
     const auto &rect = msdfGlyph.getBoxRect();
 
     {
-      double top = 0.0, left = 0.0, bottom = 0.0, right = 0.0;
+      f64 top = 0.0, left = 0.0, bottom = 0.0, right = 0.0;
       msdfGlyph.getQuadAtlasBounds(left, bottom, right, top);
 
-      glyph.bounds = glm::vec4(static_cast<float>(left),
-                               static_cast<float>(fHeight - bottom),
-                               static_cast<float>(right),
-                               static_cast<float>(fHeight - top)) /
-                     fWidth;
+      glyph.bounds =
+          glm::vec4(static_cast<f32>(left), static_cast<f32>(fHeight - bottom),
+                    static_cast<f32>(right), static_cast<f32>(fHeight - top)) /
+          fWidth;
     }
 
     {
-      double top = 0.0, left = 0.0, bottom = 0.0, right = 0.0;
+      f64 top = 0.0, left = 0.0, bottom = 0.0, right = 0.0;
       msdfGlyph.getQuadPlaneBounds(left, top, right, bottom);
 
       glyph.planeBounds =
-          glm::vec4(static_cast<float>(left), static_cast<float>(top),
-                    static_cast<float>(right), static_cast<float>(bottom));
+          glm::vec4(static_cast<f32>(left), static_cast<f32>(top),
+                    static_cast<f32>(right), static_cast<f32>(bottom));
     }
 
-    glyph.advanceX = static_cast<float>(msdfGlyph.getAdvance());
+    glyph.advanceX = static_cast<f32>(msdfGlyph.getAdvance());
 
     glyphs.insert_or_assign(msdfGlyph.getCodepoint(), glyph);
   }
@@ -103,13 +102,13 @@ Result<AssetData<FontAsset>> MsdfLoader::loadFontData(const Path &path) {
 
   msdfgen::BitmapConstRef<byte, NumChannels> bitmap = storage;
 
-  std::vector<std::byte> pixels(static_cast<size_t>(bitmap.width) *
+  std::vector<std::byte> pixels(static_cast<usize>(bitmap.width) *
                                 bitmap.height * NumChannels);
 
   for (int y = 0; y < bitmap.height; ++y) {
-    memcpy(&pixels[NumChannels * static_cast<size_t>(bitmap.width) * y],
+    memcpy(&pixels[NumChannels * static_cast<usize>(bitmap.width) * y],
            bitmap(0, bitmap.height - y - 1),
-           NumChannels * static_cast<size_t>(bitmap.width));
+           NumChannels * static_cast<usize>(bitmap.width));
   }
 
   AssetData<FontAsset> fontAsset{};
@@ -120,7 +119,7 @@ Result<AssetData<FontAsset>> MsdfLoader::loadFontData(const Path &path) {
   fontAsset.data.glyphs = glyphs;
   fontAsset.data.atlas = pixels;
   fontAsset.data.atlasDimensions = glm::uvec2{bitmap.width, bitmap.height};
-  fontAsset.data.fontScale = static_cast<float>(FontScale);
+  fontAsset.data.fontScale = static_cast<f32>(FontScale);
 
   msdfgen::destroyFont(font);
   msdfgen::deinitializeFreetype(ft);

--- a/engine/src/quoll/text/Text.h
+++ b/engine/src/quoll/text/Text.h
@@ -16,7 +16,7 @@ struct Text {
   /**
    * Line height
    */
-  float lineHeight = 1.0f;
+  f32 lineHeight = 1.0f;
 
   /**
    * Font used for rendering

--- a/engine/src/quoll/text/TextLuaTable.cpp
+++ b/engine/src/quoll/text/TextLuaTable.cpp
@@ -28,7 +28,7 @@ void TextLuaTable::setText(String text) {
   mScriptGlobals.entityDatabase.get<Text>(mEntity).text = text;
 }
 
-sol_maybe<float> TextLuaTable::getLineHeight() {
+sol_maybe<f32> TextLuaTable::getLineHeight() {
   if (mScriptGlobals.entityDatabase.has<Text>(mEntity)) {
     return mScriptGlobals.entityDatabase.get<Text>(mEntity).lineHeight;
   }
@@ -36,7 +36,7 @@ sol_maybe<float> TextLuaTable::getLineHeight() {
   return sol::nil;
 }
 
-void TextLuaTable::setLineHeight(float lineHeight) {
+void TextLuaTable::setLineHeight(f32 lineHeight) {
   // Text needs to exist in order to change it
   if (!mScriptGlobals.entityDatabase.has<Text>(mEntity)) {
     return;

--- a/engine/src/quoll/text/TextLuaTable.h
+++ b/engine/src/quoll/text/TextLuaTable.h
@@ -36,14 +36,14 @@ public:
    *
    * @return Line height
    */
-  sol_maybe<float> getLineHeight();
+  sol_maybe<f32> getLineHeight();
 
   /**
    * @brief Set line height
    *
    * @param lineHeight Line height
    */
-  void setLineHeight(float lineHeight);
+  void setLineHeight(f32 lineHeight);
 
   /**
    * @brief Delete component

--- a/engine/src/quoll/ui/UICanvasUpdater.cpp
+++ b/engine/src/quoll/ui/UICanvasUpdater.cpp
@@ -8,13 +8,13 @@
 
 namespace quoll {
 
-static constexpr float ImageSize = 50.0f;
+static constexpr f32 ImageSize = 50.0f;
 
 void renderView(UIComponent component, YGNodeRef node,
                 AssetRegistry &assetRegistry,
                 ImVec2 offset = ImVec2{0.0f, 0.0f}) {
-  float left = YGNodeLayoutGetLeft(node) + offset.x;
-  float top = YGNodeLayoutGetTop(node) + offset.y;
+  f32 left = YGNodeLayoutGetLeft(node) + offset.x;
+  f32 top = YGNodeLayoutGetTop(node) + offset.y;
 
   ImGui::SetCursorPos({left, top});
 
@@ -26,9 +26,9 @@ void renderView(UIComponent component, YGNodeRef node,
   } else if (auto *text = std::get_if<UIText>(&component)) {
     ImGui::Text("%s", text->content.c_str());
   } else if (auto *view = std::get_if<UIView>(&component)) {
-    for (size_t i = 0; i < view->children.size(); ++i) {
+    for (usize i = 0; i < view->children.size(); ++i) {
       const auto &childView = view->children.at(i);
-      YGNodeRef childNode = YGNodeGetChild(node, static_cast<uint32_t>(i));
+      YGNodeRef childNode = YGNodeGetChild(node, static_cast<u32>(i));
       renderView(childView, childNode, assetRegistry, {left, top});
     }
   }
@@ -46,9 +46,9 @@ void updateLayout(UIComponent component, YGNodeRef node) {
   } else if (auto *view = std::get_if<UIView>(&component)) {
     YGNodeStyleSetFlexDirection(node, view->flexDirection);
 
-    for (size_t i = 0; i < view->children.size(); ++i) {
+    for (usize i = 0; i < view->children.size(); ++i) {
       YGNodeRef childNode = YGNodeNew();
-      YGNodeInsertChild(node, childNode, static_cast<uint32_t>(i));
+      YGNodeInsertChild(node, childNode, static_cast<u32>(i));
       updateLayout(view->children.at(i), childNode);
     }
   }
@@ -97,8 +97,8 @@ void UICanvasUpdater::render(EntityDatabase &entityDatabase,
         ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoSavedSettings |
         ImGuiWindowFlags_NoScrollWithMouse;
 
-    if (ImGui::Begin(std::to_string(static_cast<uint32_t>(entity)).c_str(),
-                     nullptr, WindowFlags)) {
+    if (ImGui::Begin(std::to_string(static_cast<u32>(entity)).c_str(), nullptr,
+                     WindowFlags)) {
       renderView(canvas.rootView, canvas.flexRoot, assetRegistry);
       ImGui::End();
     }
@@ -107,8 +107,8 @@ void UICanvasUpdater::render(EntityDatabase &entityDatabase,
   }
 }
 
-void UICanvasUpdater::setViewport(float x, float y, float width, float height) {
-  static const float Epsilon = 0.01f;
+void UICanvasUpdater::setViewport(f32 x, f32 y, f32 width, f32 height) {
+  static const f32 Epsilon = 0.01f;
 
   bool xEqual = glm::epsilonEqual(x, mPosition.x, Epsilon);
   bool yEqual = glm::epsilonEqual(y, mPosition.y, Epsilon);

--- a/engine/src/quoll/ui/UICanvasUpdater.h
+++ b/engine/src/quoll/ui/UICanvasUpdater.h
@@ -26,7 +26,7 @@ public:
    * @param width Width
    * @param height Height
    */
-  void setViewport(float x, float y, float width, float height);
+  void setViewport(f32 x, f32 y, f32 width, f32 height);
 
 private:
   glm::vec2 mPosition;

--- a/engine/src/quoll/window/MouseEvent.h
+++ b/engine/src/quoll/window/MouseEvent.h
@@ -28,12 +28,12 @@ struct MouseCursorEventObject {
   /**
    * Cursor x position
    */
-  float xpos = 0.0f;
+  f32 xpos = 0.0f;
 
   /**
    * Cursor y position
    */
-  float ypos = 0.0f;
+  f32 ypos = 0.0f;
 };
 
 enum class MouseScrollEvent { Scroll };
@@ -45,12 +45,12 @@ struct MouseScrollEventObject {
   /**
    * Scroll x offset
    */
-  float xoffset = 0.0f;
+  f32 xoffset = 0.0f;
 
   /**
    * Scroll y offset
    */
-  float yoffset = 0.0f;
+  f32 yoffset = 0.0f;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/window/Window.cpp
+++ b/engine/src/quoll/window/Window.cpp
@@ -9,7 +9,7 @@
 
 namespace quoll {
 
-Window::Window(StringView title, uint32_t width, uint32_t height,
+Window::Window(StringView title, u32 width, u32 height,
                InputDeviceManager &deviceManager, EventSystem &eventSystem)
     : mDeviceManager(deviceManager), mEventSystem(eventSystem) {
   auto initReturnValue = glfwInit();
@@ -49,7 +49,7 @@ Window::Window(StringView title, uint32_t width, uint32_t height,
         auto *window =
             static_cast<Window *>(glfwGetWindowUserPointer(windowInstance));
         for (auto &[_, handler] : window->mResizeHandlers) {
-          handler(static_cast<uint32_t>(width), static_cast<uint32_t>(height));
+          handler(static_cast<u32>(width), static_cast<u32>(height));
         }
       });
 
@@ -81,15 +81,15 @@ Window::Window(StringView title, uint32_t width, uint32_t height,
     }
   });
 
-  glfwSetCursorPosCallback(mWindowInstance, [](::GLFWwindow *windowInstance,
-                                               double xpos, double ypos) {
-    auto *window =
-        static_cast<Window *>(glfwGetWindowUserPointer(windowInstance));
+  glfwSetCursorPosCallback(
+      mWindowInstance, [](::GLFWwindow *windowInstance, f64 xpos, f64 ypos) {
+        auto *window =
+            static_cast<Window *>(glfwGetWindowUserPointer(windowInstance));
 
-    window->mEventSystem.dispatch(
-        MouseCursorEvent::Moved,
-        {static_cast<float>(xpos), static_cast<float>(ypos)});
-  });
+        window->mEventSystem.dispatch(
+            MouseCursorEvent::Moved,
+            {static_cast<f32>(xpos), static_cast<f32>(ypos)});
+      });
 
   glfwSetMouseButtonCallback(mWindowInstance, [](::GLFWwindow *windowInstance,
                                                  int button, int action,
@@ -105,12 +105,12 @@ Window::Window(StringView title, uint32_t width, uint32_t height,
   });
 
   glfwSetScrollCallback(mWindowInstance, [](::GLFWwindow *windowInstance,
-                                            double xoffset, double yoffset) {
+                                            f64 xoffset, f64 yoffset) {
     auto *window =
         static_cast<Window *>(glfwGetWindowUserPointer(windowInstance));
     window->mEventSystem.dispatch(
         MouseScrollEvent::Scroll,
-        {static_cast<float>(xoffset), static_cast<float>(yoffset)});
+        {static_cast<f32>(xoffset), static_cast<f32>(yoffset)});
   });
 
   mDeviceManager.addDevice({.type = InputDeviceType::Keyboard,
@@ -140,7 +140,7 @@ Window::Window(StringView title, uint32_t width, uint32_t height,
       addGamepad(jid, window);
     } else if (event == GLFW_DISCONNECTED) {
       window->mDeviceManager.removeDevice(InputDeviceType::Gamepad,
-                                          static_cast<uint32_t>(jid));
+                                          static_cast<u32>(jid));
     }
   });
 }
@@ -159,8 +159,8 @@ glm::uvec2 Window::getFramebufferSize() {
   glfwGetFramebufferSize(mWindowInstance, &width, &height);
 
   return {
-      static_cast<uint32_t>(width),
-      static_cast<uint32_t>(height),
+      static_cast<u32>(width),
+      static_cast<u32>(height),
   };
 }
 
@@ -169,8 +169,8 @@ glm::uvec2 Window::getWindowSize() {
   glfwGetWindowSize(mWindowInstance, &width, &height);
 
   return {
-      static_cast<uint32_t>(width),
-      static_cast<uint32_t>(height),
+      static_cast<u32>(width),
+      static_cast<u32>(height),
   };
 }
 
@@ -178,28 +178,26 @@ bool Window::shouldClose() { return glfwWindowShouldClose(mWindowInstance); }
 
 void Window::pollEvents() { glfwPollEvents(); }
 
-uint32_t Window::addFramebufferResizeHandler(
-    const std::function<void(uint32_t, uint32_t)> &handler) {
-  uint32_t id = static_cast<uint32_t>(mResizeHandlers.size());
+u32 Window::addFramebufferResizeHandler(
+    const std::function<void(u32, u32)> &handler) {
+  u32 id = static_cast<u32>(mResizeHandlers.size());
 
   mResizeHandlers.insert(std::make_pair(id, handler));
   return id;
 }
 
-void Window::removeResizeHandler(uint32_t handle) {
+void Window::removeResizeHandler(u32 handle) {
   mResizeHandlers.erase(mResizeHandlers.find(handle));
 }
 
-uint32_t Window::addFocusHandler(const std::function<void(bool)> &handler) {
-  uint32_t id = static_cast<uint32_t>(mFocusHandlers.size());
+u32 Window::addFocusHandler(const std::function<void(bool)> &handler) {
+  u32 id = static_cast<u32>(mFocusHandlers.size());
   mFocusHandlers.insert(std::make_pair(id, handler));
 
   return id;
 }
 
-void Window::removeFocusHandler(uint32_t handle) {
-  mFocusHandlers.erase(handle);
-}
+void Window::removeFocusHandler(u32 handle) { mFocusHandlers.erase(handle); }
 
 glm::vec2 Window::getCurrentMousePosition() const {
   glm::dvec2 mousePos;
@@ -225,14 +223,13 @@ InputStateValue Window::getKeyboardState(int key) {
 
 InputStateValue Window::getMouseState(int key) {
   if (input::isMouseMove(key)) {
-    double xpos = 0.0, ypos = 0.0;
+    f64 xpos = 0.0, ypos = 0.0;
     glfwGetCursorPos(mWindowInstance, &xpos, &ypos);
 
     auto windowSize = getWindowSize();
 
-    return glm::vec2{
-        static_cast<float>(xpos) / static_cast<float>(windowSize.x),
-        static_cast<float>(ypos) / static_cast<float>(windowSize.y)};
+    return glm::vec2{static_cast<f32>(xpos) / static_cast<f32>(windowSize.x),
+                     static_cast<f32>(ypos) / static_cast<f32>(windowSize.y)};
   }
 
   return glfwGetMouseButton(mWindowInstance, input::getGlfwMouseButton(key)) ==
@@ -265,7 +262,7 @@ void Window::addGamepad(int jid, Window *window) {
 
   InputDevice device = {.type = InputDeviceType::Gamepad,
                         .name = name,
-                        .index = static_cast<uint32_t>(jid),
+                        .index = static_cast<u32>(jid),
                         .stateFn = std::bind(&Window::getGamepadState, window,
                                              jid, std::placeholders::_1)};
 

--- a/engine/src/quoll/window/Window.h
+++ b/engine/src/quoll/window/Window.h
@@ -24,7 +24,7 @@ public:
    * @param deviceManager Device manager
    * @param eventSystem Event system
    */
-  Window(StringView title, uint32_t width, uint32_t height,
+  Window(StringView title, u32 width, u32 height,
          InputDeviceManager &deviceManager, EventSystem &eventSystem);
 
   /**
@@ -89,15 +89,14 @@ public:
    * @param handler Framebuffer resize handler
    * @return Framebuffer resize handler ID
    */
-  uint32_t addFramebufferResizeHandler(
-      const std::function<void(uint32_t, uint32_t)> &handler);
+  u32 addFramebufferResizeHandler(const std::function<void(u32, u32)> &handler);
 
   /**
    * @brief Remove resize handler
    *
    * @param handle Handle
    */
-  void removeResizeHandler(uint32_t handle);
+  void removeResizeHandler(u32 handle);
 
   /**
    * @brief Add focus handler
@@ -105,14 +104,14 @@ public:
    * @param handler Focus handler
    * @return Focus handler ID
    */
-  uint32_t addFocusHandler(const std::function<void(bool)> &handler);
+  u32 addFocusHandler(const std::function<void(bool)> &handler);
 
   /**
    * @brief Remove focus handler
    *
    * @param handle Handle
    */
-  void removeFocusHandler(uint32_t handle);
+  void removeFocusHandler(u32 handle);
 
   /**
    * @brief Get current mouse position
@@ -157,9 +156,9 @@ private:
   ::GLFWwindow *mWindowInstance;
 
   template <class TFunctionType>
-  using HandlerMap = std::map<uint32_t, std::function<TFunctionType>>;
+  using HandlerMap = std::map<u32, std::function<TFunctionType>>;
 
-  HandlerMap<void(uint32_t, uint32_t)> mResizeHandlers;
+  HandlerMap<void(u32, u32)> mResizeHandlers;
   HandlerMap<void(bool)> mFocusHandlers;
 };
 

--- a/engine/src/quoll/yaml/Yaml.h
+++ b/engine/src/quoll/yaml/Yaml.h
@@ -34,8 +34,8 @@ template <> struct convert<glm::vec2> {
       return false;
     }
 
-    return convert<float>::decode(node[0], value.x) &&
-           convert<float>::decode(node[1], value.y);
+    return convert<f32>::decode(node[0], value.x) &&
+           convert<f32>::decode(node[1], value.y);
   }
 };
 
@@ -70,9 +70,9 @@ template <> struct convert<glm::vec3> {
       return false;
     }
 
-    return convert<float>::decode(node[0], value.x) &&
-           convert<float>::decode(node[1], value.y) &&
-           convert<float>::decode(node[2], value.z);
+    return convert<f32>::decode(node[0], value.x) &&
+           convert<f32>::decode(node[1], value.y) &&
+           convert<f32>::decode(node[2], value.z);
   }
 };
 
@@ -108,10 +108,10 @@ template <> struct convert<glm::vec4> {
       return false;
     }
 
-    return convert<float>::decode(node[0], value.x) &&
-           convert<float>::decode(node[1], value.y) &&
-           convert<float>::decode(node[2], value.z) &&
-           convert<float>::decode(node[3], value.w);
+    return convert<f32>::decode(node[0], value.x) &&
+           convert<f32>::decode(node[1], value.y) &&
+           convert<f32>::decode(node[2], value.z) &&
+           convert<f32>::decode(node[3], value.w);
   }
 };
 
@@ -147,10 +147,10 @@ template <> struct convert<glm::quat> {
       return false;
     }
 
-    return convert<float>::decode(node[0], value.x) &&
-           convert<float>::decode(node[1], value.y) &&
-           convert<float>::decode(node[2], value.z) &&
-           convert<float>::decode(node[3], value.w);
+    return convert<f32>::decode(node[0], value.x) &&
+           convert<f32>::decode(node[1], value.y) &&
+           convert<f32>::decode(node[2], value.z) &&
+           convert<f32>::decode(node[3], value.w);
   }
 };
 

--- a/engine/tests/quoll-tests/Testing.h
+++ b/engine/tests/quoll-tests/Testing.h
@@ -27,7 +27,7 @@ void PrintTo(const qua<T, Q> &value, std::ostream *out) {
 namespace quoll {
 
 static void PrintTo(Entity entity, std::ostream *out) {
-  *out << static_cast<uint32_t>(entity);
+  *out << static_cast<u32>(entity);
 }
 
 } // namespace quoll

--- a/engine/tests/quoll-tests/animation/AnimationSystem.test.cpp
+++ b/engine/tests/quoll-tests/animation/AnimationSystem.test.cpp
@@ -50,7 +50,7 @@ public:
   }
 
   quoll::AnimationAssetHandle
-  createAnimation(quoll::KeyframeSequenceAssetTarget target, float time) {
+  createAnimation(quoll::KeyframeSequenceAssetTarget target, f32 time) {
     quoll::AssetData<quoll::AnimationAsset> animation;
     animation.data.time = time;
 
@@ -68,8 +68,7 @@ public:
   }
 
   quoll::AnimationAssetHandle
-  createSkeletonAnimation(quoll::KeyframeSequenceAssetTarget target,
-                          float time) {
+  createSkeletonAnimation(quoll::KeyframeSequenceAssetTarget target, f32 time) {
     quoll::AssetData<quoll::AnimationAsset> animation;
     animation.data.time = time;
 

--- a/engine/tests/quoll-tests/animation/KeyframeInterpolator.test.cpp
+++ b/engine/tests/quoll-tests/animation/KeyframeInterpolator.test.cpp
@@ -11,8 +11,8 @@ using Interpolator = quoll::KeyframeInterpolator;
 class KeyframeInterpolatorTest : public ::testing::Test {
 public:
   glm::quat randomQuat(std::mt19937 mt) {
-    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
-    float x = 0.0f, y = 0.0f, z = 0.0f, u = 0.0f, v = 0.0f, w = 0.0f, s = 0.0f;
+    std::uniform_real_distribution<f32> dist(-1.0f, 1.0f);
+    f32 x = 0.0f, y = 0.0f, z = 0.0f, u = 0.0f, v = 0.0f, w = 0.0f, s = 0.0f;
     do {
       x = dist(mt);
       y = dist(mt);
@@ -66,12 +66,12 @@ TEST_F(KeyframeInterpolatorTest,
   sequence.keyframeTimes = {0.0f, 0.5f, 1.0f};
   sequence.keyframeValues = {glm::vec4(0.0f), glm::vec4(0.5f), glm::vec4(1.0f)};
 
-  for (float t = 0; t < 0.5f; t += 0.05f) {
+  for (f32 t = 0; t < 0.5f; t += 0.05f) {
     // 0 + (t - 0.0) * vec4(0.5 - 0.0) / (0.5 - 0.0) = t
     EXPECT_EQ(Interpolator::interpolateVec3(sequence, t), glm::vec3(t));
   }
 
-  for (float t = 0.5f; t <= 1.0f; t += 0.05f) {
+  for (f32 t = 0.5f; t <= 1.0f; t += 0.05f) {
     // 0.5 + (t - 0.5) * vec4(1.0 - 0.0) / (1.0 - 0.0) = 0.5 + (1 - 0.5)
     EXPECT_EQ(Interpolator::interpolateVec3(sequence, t),
               glm::vec3(0.5f + (t - 0.5f)));
@@ -106,15 +106,15 @@ TEST_F(KeyframeInterpolatorTest,
 
   sequence.keyframeValues = {quatToVec4(q1), quatToVec4(q2), quatToVec4(q3)};
 
-  for (float t = 0; t < 0.5f; t += 0.05f) {
-    float k = t / 0.5f;
+  for (f32 t = 0; t < 0.5f; t += 0.05f) {
+    f32 k = t / 0.5f;
 
     EXPECT_EQ(Interpolator::interpolateQuat(sequence, t),
               glm::normalize(glm::slerp(q1, q2, k)));
   }
 
-  for (float t = 0.5f; t <= 1.0f; t += 0.05f) {
-    float k = (t - 0.5f) / 0.5f;
+  for (f32 t = 0.5f; t <= 1.0f; t += 0.05f) {
+    f32 k = (t - 0.5f) / 0.5f;
 
     EXPECT_EQ(Interpolator::interpolateQuat(sequence, t),
               glm::normalize(glm::slerp(q2, q3, k)));

--- a/engine/tests/quoll-tests/asset/AssetCacheAnimation.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheAnimation.test.cpp
@@ -20,16 +20,16 @@ quoll::AssetData<quoll::AnimationAsset> createRandomizedAnimation() {
   {
     std::random_device device;
     std::mt19937 mt(device());
-    std::uniform_real_distribution<float> dist(-5.0f, 10.0f);
-    std::uniform_int_distribution<uint32_t> udist(0, 20);
-    std::uniform_int_distribution<uint32_t> targetDist(0, 2);
-    std::uniform_int_distribution<uint32_t> interpolationDist(0, 1);
+    std::uniform_real_distribution<f32> dist(-5.0f, 10.0f);
+    std::uniform_int_distribution<u32> udist(0, 20);
+    std::uniform_int_distribution<u32> targetDist(0, 2);
+    std::uniform_int_distribution<u32> interpolationDist(0, 1);
 
-    size_t countKeyframes = 5;
-    size_t countKeyframeValues = 10;
-    asset.data.time = static_cast<float>(countKeyframeValues) * 0.5f;
+    usize countKeyframes = 5;
+    usize countKeyframeValues = 10;
+    asset.data.time = static_cast<f32>(countKeyframeValues) * 0.5f;
 
-    for (size_t i = 0; i < countKeyframes; ++i) {
+    for (usize i = 0; i < countKeyframes; ++i) {
       quoll::KeyframeSequenceAsset keyframe;
       keyframe.interpolation =
           static_cast<quoll::KeyframeSequenceAssetInterpolation>(
@@ -41,8 +41,8 @@ quoll::AssetData<quoll::AnimationAsset> createRandomizedAnimation() {
       keyframe.keyframeTimes.resize(countKeyframeValues);
       keyframe.keyframeValues.resize(countKeyframeValues);
 
-      for (size_t j = 0; j < countKeyframeValues; ++j) {
-        keyframe.keyframeTimes.at(j) = 0.5f * static_cast<float>(j);
+      for (usize j = 0; j < countKeyframeValues; ++j) {
+        keyframe.keyframeTimes.at(j) = 0.5f * static_cast<f32>(j);
         keyframe.keyframeValues.at(j) =
             glm::vec4(dist(mt), dist(mt), dist(mt), dist(mt));
       }
@@ -66,8 +66,8 @@ TEST_F(AssetCacheAnimationTest, CreatesAnimationFile) {
   EXPECT_EQ(header.type, quoll::AssetType::Animation);
   EXPECT_EQ(header.name, asset.name);
 
-  float time = 0.0f;
-  uint32_t numKeyframes = 0;
+  f32 time = 0.0f;
+  u32 numKeyframes = 0;
 
   file.read(time);
   file.read(numKeyframes);
@@ -75,14 +75,14 @@ TEST_F(AssetCacheAnimationTest, CreatesAnimationFile) {
   EXPECT_EQ(time, 5.0f);
   EXPECT_EQ(numKeyframes, 5);
 
-  for (uint32_t i = 0; i < numKeyframes; ++i) {
+  for (u32 i = 0; i < numKeyframes; ++i) {
     auto &keyframe = asset.data.keyframes.at(i);
 
     quoll::KeyframeSequenceAssetTarget target{0};
     quoll::KeyframeSequenceAssetInterpolation interpolation{0};
     bool jointTarget = false;
     quoll::JointId joint = 0;
-    uint32_t numValues = 0;
+    u32 numValues = 0;
 
     file.read(target);
     file.read(interpolation);
@@ -94,14 +94,14 @@ TEST_F(AssetCacheAnimationTest, CreatesAnimationFile) {
     EXPECT_EQ(interpolation, keyframe.interpolation);
     EXPECT_EQ(jointTarget, keyframe.jointTarget);
     EXPECT_EQ(joint, keyframe.joint);
-    EXPECT_EQ(numValues, static_cast<uint32_t>(keyframe.keyframeValues.size()));
+    EXPECT_EQ(numValues, static_cast<u32>(keyframe.keyframeValues.size()));
 
-    std::vector<float> times(numValues);
+    std::vector<f32> times(numValues);
     std::vector<glm::vec4> values(numValues);
 
     file.read(times);
     file.read(values);
-    for (uint32_t i = 0; i < numValues; ++i) {
+    for (u32 i = 0; i < numValues; ++i) {
       EXPECT_EQ(times.at(i), keyframe.keyframeTimes.at(i));
       EXPECT_EQ(values.at(i), keyframe.keyframeValues.at(i));
     }
@@ -125,7 +125,7 @@ TEST_F(AssetCacheAnimationTest, LoadsAnimationAssetFromFile) {
 
   EXPECT_EQ(actual.data.time, asset.data.time);
   EXPECT_EQ(actual.data.keyframes.size(), asset.data.keyframes.size());
-  for (size_t i = 0; i < asset.data.keyframes.size(); ++i) {
+  for (usize i = 0; i < asset.data.keyframes.size(); ++i) {
     auto &expectedKf = asset.data.keyframes.at(i);
     auto &actualKf = actual.data.keyframes.at(i);
 
@@ -136,7 +136,7 @@ TEST_F(AssetCacheAnimationTest, LoadsAnimationAssetFromFile) {
     EXPECT_EQ(expectedKf.keyframeTimes.size(), actualKf.keyframeTimes.size());
     EXPECT_EQ(expectedKf.keyframeValues.size(), actualKf.keyframeValues.size());
 
-    for (size_t j = 0; j < expectedKf.keyframeTimes.size(); ++j) {
+    for (usize j = 0; j < expectedKf.keyframeTimes.size(); ++j) {
       EXPECT_EQ(expectedKf.keyframeTimes.at(j), actualKf.keyframeTimes.at(j));
       EXPECT_EQ(expectedKf.keyframeValues.at(j), actualKf.keyframeValues.at(j));
     }

--- a/engine/tests/quoll-tests/asset/AssetCacheAnimator.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheAnimator.test.cpp
@@ -249,7 +249,7 @@ TEST_F(AssetCacheAnimatorTest, LoadAnimatorIgnoresStatesThatHaveInvalidData) {
   YAML::Node node;
   node["version"] = "0.1";
   node["type"] = "animator";
-  for (size_t i = 0; i < invalidStateNames.size(); ++i) {
+  for (usize i = 0; i < invalidStateNames.size(); ++i) {
     node["states"][invalidStateNames[i]] = invalidNodes[i];
   }
   node["states"]["valid"] = YAML::Node(YAML::NodeType::Map);
@@ -292,7 +292,7 @@ TEST_F(AssetCacheAnimatorTest, LoadAnimatorAddsDummyStateIfNoValidState) {
   node["version"] = "0.1";
   node["type"] = "animator";
   node["initial"] = "invalid1";
-  for (size_t i = 0; i < invalidStateNames.size(); ++i) {
+  for (usize i = 0; i < invalidStateNames.size(); ++i) {
     node["states"][invalidStateNames[i]] = invalidNodes[i];
   }
 

--- a/engine/tests/quoll-tests/asset/AssetCacheMaterial.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheMaterial.test.cpp
@@ -99,7 +99,7 @@ TEST_F(AssetCacheMaterialTest, CreatesMaterialWithTexturesFromAsset) {
     // Base color
     quoll::String baseTexturePath;
     file.read(baseTexturePath);
-    int8_t baseTextureCoord = -1;
+    i8 baseTextureCoord = -1;
     file.read(baseTextureCoord);
     glm::vec4 baseColorFactor;
     file.read(baseColorFactor);
@@ -107,33 +107,33 @@ TEST_F(AssetCacheMaterialTest, CreatesMaterialWithTexturesFromAsset) {
     // Metallic roughness
     quoll::String metallicRoughnessTexturePath;
     file.read(metallicRoughnessTexturePath);
-    int8_t metallicRoughnessTextureCoord = -1;
+    i8 metallicRoughnessTextureCoord = -1;
     file.read(metallicRoughnessTextureCoord);
-    float metallicFactor = 0.0f;
+    f32 metallicFactor = 0.0f;
     file.read(metallicFactor);
-    float roughnessFactor = 0.0f;
+    f32 roughnessFactor = 0.0f;
     file.read(roughnessFactor);
 
     // Normal
     quoll::String normalTexturePath;
     file.read(normalTexturePath);
-    int8_t normalTextureCoord = -1;
+    i8 normalTextureCoord = -1;
     file.read(normalTextureCoord);
-    float normalScale = 0.0f;
+    f32 normalScale = 0.0f;
     file.read(normalScale);
 
     // Occlusion
     quoll::String occlusionTexturePath;
     file.read(occlusionTexturePath);
-    int8_t occlusionTextureCoord = -1;
+    i8 occlusionTextureCoord = -1;
     file.read(occlusionTextureCoord);
-    float occlusionStrength = 0.0f;
+    f32 occlusionStrength = 0.0f;
     file.read(occlusionStrength);
 
     // Emissive
     quoll::String emissiveTexturePath;
     file.read(emissiveTexturePath);
-    int8_t emissiveTextureCoord = -1;
+    i8 emissiveTextureCoord = -1;
     file.read(emissiveTextureCoord);
     glm::vec3 emissiveFactor;
     file.read(emissiveFactor);
@@ -176,7 +176,7 @@ TEST_F(AssetCacheMaterialTest,
     // Base color
     quoll::String baseTexturePath;
     file.read(baseTexturePath);
-    int8_t baseTextureCoord = -1;
+    i8 baseTextureCoord = -1;
     file.read(baseTextureCoord);
     glm::vec4 baseColorFactor;
     file.read(baseColorFactor);
@@ -184,33 +184,33 @@ TEST_F(AssetCacheMaterialTest,
     // Metallic roughness
     quoll::String metallicRoughnessTexturePath;
     file.read(metallicRoughnessTexturePath);
-    int8_t metallicRoughnessTextureCoord = -1;
+    i8 metallicRoughnessTextureCoord = -1;
     file.read(metallicRoughnessTextureCoord);
-    float metallicFactor = 0.0f;
+    f32 metallicFactor = 0.0f;
     file.read(metallicFactor);
-    float roughnessFactor = 0.0f;
+    f32 roughnessFactor = 0.0f;
     file.read(roughnessFactor);
 
     // Normal
     quoll::String normalTexturePath;
     file.read(normalTexturePath);
-    int8_t normalTextureCoord = -1;
+    i8 normalTextureCoord = -1;
     file.read(normalTextureCoord);
-    float normalScale = 0.0f;
+    f32 normalScale = 0.0f;
     file.read(normalScale);
 
     // Occlusion
     quoll::String occlusionTexturePath;
     file.read(occlusionTexturePath);
-    int8_t occlusionTextureCoord = -1;
+    i8 occlusionTextureCoord = -1;
     file.read(occlusionTextureCoord);
-    float occlusionStrength = 0.0f;
+    f32 occlusionStrength = 0.0f;
     file.read(occlusionStrength);
 
     // Emissive
     quoll::String emissiveTexturePath;
     file.read(emissiveTexturePath);
-    int8_t emissiveTextureCoord = -1;
+    i8 emissiveTextureCoord = -1;
     file.read(emissiveTextureCoord);
     glm::vec3 emissiveFactor;
     file.read(emissiveFactor);

--- a/engine/tests/quoll-tests/asset/AssetCacheMesh.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheMesh.test.cpp
@@ -20,15 +20,15 @@ public:
     {
       std::random_device device;
       std::mt19937 mt(device());
-      std::uniform_real_distribution<float> dist(-5.0f, 10.0f);
-      std::uniform_int_distribution<uint32_t> udist(0, 20);
-      size_t countGeometries = 2;
-      size_t countVertices = 10;
-      size_t countIndices = 20;
+      std::uniform_real_distribution<f32> dist(-5.0f, 10.0f);
+      std::uniform_int_distribution<u32> udist(0, 20);
+      usize countGeometries = 2;
+      usize countVertices = 10;
+      usize countIndices = 20;
 
-      for (size_t i = 0; i < countGeometries; ++i) {
+      for (usize i = 0; i < countGeometries; ++i) {
         quoll::BaseGeometryAsset geometry;
-        for (size_t i = 0; i < countVertices; ++i) {
+        for (usize i = 0; i < countVertices; ++i) {
           geometry.positions.push_back({dist(mt), dist(mt), dist(mt)});
           geometry.normals.push_back({dist(mt), dist(mt), dist(mt)});
           geometry.tangents.push_back({dist(mt), dist(mt), dist(mt), dist(mt)});
@@ -36,7 +36,7 @@ public:
           geometry.texCoords1.push_back({dist(mt), dist(mt)});
         }
 
-        for (size_t i = 0; i < countIndices; ++i) {
+        for (usize i = 0; i < countIndices; ++i) {
           geometry.indices.push_back(udist(mt));
         }
 
@@ -55,15 +55,15 @@ public:
 
     std::random_device device;
     std::mt19937 mt(device());
-    std::uniform_real_distribution<float> dist(-5.0f, 10.0f);
-    std::uniform_int_distribution<uint32_t> udist(0, 20);
-    size_t countGeometries = 2;
-    size_t countVertices = 10;
-    size_t countIndices = 20;
+    std::uniform_real_distribution<f32> dist(-5.0f, 10.0f);
+    std::uniform_int_distribution<u32> udist(0, 20);
+    usize countGeometries = 2;
+    usize countVertices = 10;
+    usize countIndices = 20;
 
-    for (size_t i = 0; i < countGeometries; ++i) {
+    for (usize i = 0; i < countGeometries; ++i) {
       quoll::BaseGeometryAsset geometry;
-      for (size_t i = 0; i < countVertices; ++i) {
+      for (usize i = 0; i < countVertices; ++i) {
         geometry.positions.push_back({dist(mt), dist(mt), dist(mt)});
         geometry.normals.push_back({dist(mt), dist(mt), dist(mt)});
         geometry.tangents.push_back({dist(mt), dist(mt), dist(mt), dist(mt)});
@@ -73,7 +73,7 @@ public:
         geometry.weights.push_back({dist(mt), dist(mt), dist(mt), dist(mt)});
       }
 
-      for (size_t i = 0; i < countIndices; ++i) {
+      for (usize i = 0; i < countIndices; ++i) {
         geometry.indices.push_back(udist(mt));
       }
 
@@ -101,16 +101,16 @@ TEST_F(AssetCacheMeshTest, CreatesMeshFileFromMeshAsset) {
   EXPECT_EQ(header.magic, header.MagicConstant);
   EXPECT_EQ(header.type, quoll::AssetType::Mesh);
 
-  uint32_t numGeometries = 0;
+  u32 numGeometries = 0;
   file.read(numGeometries);
 
   EXPECT_EQ(numGeometries, 2);
 
-  for (uint32_t i = 0; i < numGeometries; ++i) {
-    uint32_t numVertices = 0;
+  for (u32 i = 0; i < numGeometries; ++i) {
+    u32 numVertices = 0;
     file.read(numVertices);
     EXPECT_EQ(numVertices, 10);
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).positions.at(v);
       glm::vec3 valueActual;
       file.read(valueActual);
@@ -118,7 +118,7 @@ TEST_F(AssetCacheMeshTest, CreatesMeshFileFromMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).normals.at(v);
       glm::vec3 valueActual;
       file.read(valueActual);
@@ -126,7 +126,7 @@ TEST_F(AssetCacheMeshTest, CreatesMeshFileFromMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).tangents.at(v);
       glm::vec4 valueActual;
       file.read(valueActual);
@@ -134,7 +134,7 @@ TEST_F(AssetCacheMeshTest, CreatesMeshFileFromMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).texCoords0.at(v);
       glm::vec2 valueActual;
       file.read(valueActual);
@@ -142,7 +142,7 @@ TEST_F(AssetCacheMeshTest, CreatesMeshFileFromMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).texCoords1.at(v);
       glm::vec2 valueActual;
       file.read(valueActual);
@@ -150,13 +150,13 @@ TEST_F(AssetCacheMeshTest, CreatesMeshFileFromMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    uint32_t numIndices = 0;
+    u32 numIndices = 0;
     file.read(numIndices);
     EXPECT_EQ(numIndices, 20);
 
-    for (uint32_t idx = 0; idx < numIndices; ++idx) {
+    for (u32 idx = 0; idx < numIndices; ++idx) {
       const auto valueExpected = asset.data.geometries.at(i).indices.at(idx);
-      uint32_t valueActual = 100000;
+      u32 valueActual = 100000;
       file.read(valueActual);
       EXPECT_EQ(valueExpected, valueActual);
     }
@@ -198,13 +198,13 @@ TEST_F(AssetCacheMeshTest, LoadsMeshFromFile) {
   auto &mesh = cache.getRegistry().getMeshes().getAsset(handle);
   EXPECT_EQ(mesh.name, asset.name);
 
-  for (size_t g = 0; g < asset.data.geometries.size(); ++g) {
+  for (usize g = 0; g < asset.data.geometries.size(); ++g) {
     auto &expectedGeometry = asset.data.geometries.at(g);
     auto &actualGeometry = mesh.data.geometries.at(g);
 
     EXPECT_EQ(expectedGeometry.positions.size(),
               actualGeometry.positions.size());
-    for (size_t v = 0; v < expectedGeometry.positions.size(); ++v) {
+    for (usize v = 0; v < expectedGeometry.positions.size(); ++v) {
       auto &e = expectedGeometry;
       auto &a = actualGeometry;
 
@@ -215,7 +215,7 @@ TEST_F(AssetCacheMeshTest, LoadsMeshFromFile) {
       EXPECT_EQ(e.texCoords1.at(v), a.texCoords1.at(v));
     }
 
-    for (size_t i = 0; i < expectedGeometry.indices.size(); ++i) {
+    for (usize i = 0; i < expectedGeometry.indices.size(); ++i) {
       auto expected = expectedGeometry.indices.at(i);
       auto actual = actualGeometry.indices.at(i);
       EXPECT_EQ(expected, actual);
@@ -237,16 +237,16 @@ TEST_F(AssetCacheMeshTest, CreatesSkinnedMeshFileFromSkinnedMeshAsset) {
   EXPECT_EQ(header.name, "test-mesh0");
   EXPECT_EQ(header.type, quoll::AssetType::SkinnedMesh);
 
-  uint32_t numGeometries = 0;
+  u32 numGeometries = 0;
   file.read(numGeometries);
 
   EXPECT_EQ(numGeometries, 2);
 
-  for (uint32_t i = 0; i < numGeometries; ++i) {
-    uint32_t numVertices = 0;
+  for (u32 i = 0; i < numGeometries; ++i) {
+    u32 numVertices = 0;
     file.read(numVertices);
     EXPECT_EQ(numVertices, 10);
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &vertex = asset.data.geometries.at(i).positions.at(v);
       glm::vec3 valueExpected(vertex.x, vertex.y, vertex.z);
       glm::vec3 valueActual;
@@ -255,7 +255,7 @@ TEST_F(AssetCacheMeshTest, CreatesSkinnedMeshFileFromSkinnedMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).normals.at(v);
       glm::vec3 valueActual;
       file.read(valueActual);
@@ -263,7 +263,7 @@ TEST_F(AssetCacheMeshTest, CreatesSkinnedMeshFileFromSkinnedMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).tangents.at(v);
       glm::vec4 valueActual;
       file.read(valueActual);
@@ -271,7 +271,7 @@ TEST_F(AssetCacheMeshTest, CreatesSkinnedMeshFileFromSkinnedMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).texCoords0.at(v);
       glm::vec2 valueActual;
       file.read(valueActual);
@@ -279,7 +279,7 @@ TEST_F(AssetCacheMeshTest, CreatesSkinnedMeshFileFromSkinnedMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).texCoords1.at(v);
       glm::vec2 valueActual;
       file.read(valueActual);
@@ -287,7 +287,7 @@ TEST_F(AssetCacheMeshTest, CreatesSkinnedMeshFileFromSkinnedMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).joints.at(v);
       glm::uvec4 valueActual;
       file.read(valueActual);
@@ -295,7 +295,7 @@ TEST_F(AssetCacheMeshTest, CreatesSkinnedMeshFileFromSkinnedMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    for (uint32_t v = 0; v < numVertices; ++v) {
+    for (u32 v = 0; v < numVertices; ++v) {
       const auto &valueExpected = asset.data.geometries.at(i).weights.at(v);
       glm::vec4 valueActual;
       file.read(valueActual);
@@ -303,13 +303,13 @@ TEST_F(AssetCacheMeshTest, CreatesSkinnedMeshFileFromSkinnedMeshAsset) {
       EXPECT_EQ(valueExpected, valueActual);
     }
 
-    uint32_t numIndices = 0;
+    u32 numIndices = 0;
     file.read(numIndices);
     EXPECT_EQ(numIndices, 20);
 
-    for (uint32_t idx = 0; idx < numIndices; ++idx) {
+    for (u32 idx = 0; idx < numIndices; ++idx) {
       const auto valueExpected = asset.data.geometries.at(i).indices.at(idx);
-      uint32_t valueActual = 100000;
+      u32 valueActual = 100000;
       file.read(valueActual);
       EXPECT_EQ(valueExpected, valueActual);
     }
@@ -347,13 +347,13 @@ TEST_F(AssetCacheMeshTest, LoadsSkinnedMeshFromFile) {
   auto &mesh = cache.getRegistry().getMeshes().getAsset(handle.getData());
   EXPECT_EQ(mesh.name, asset.name);
 
-  for (size_t g = 0; g < asset.data.geometries.size(); ++g) {
+  for (usize g = 0; g < asset.data.geometries.size(); ++g) {
     auto &expectedGeometry = asset.data.geometries.at(g);
     auto &actualGeometry = mesh.data.geometries.at(g);
 
     EXPECT_EQ(expectedGeometry.positions.size(),
               actualGeometry.positions.size());
-    for (size_t v = 0; v < expectedGeometry.positions.size(); ++v) {
+    for (usize v = 0; v < expectedGeometry.positions.size(); ++v) {
       auto &e = expectedGeometry;
       auto &a = actualGeometry;
 
@@ -366,7 +366,7 @@ TEST_F(AssetCacheMeshTest, LoadsSkinnedMeshFromFile) {
       EXPECT_EQ(e.weights.at(v), a.weights.at(v));
     }
 
-    for (size_t i = 0; i < expectedGeometry.indices.size(); ++i) {
+    for (usize i = 0; i < expectedGeometry.indices.size(); ++i) {
       auto expected = expectedGeometry.indices.at(i);
       auto actual = actualGeometry.indices.at(i);
       EXPECT_EQ(expected, actual);

--- a/engine/tests/quoll-tests/asset/AssetCachePrefab.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCachePrefab.test.cpp
@@ -18,24 +18,24 @@ public:
 
     std::random_device device;
     std::mt19937 mt(device());
-    std::uniform_real_distribution<float> dist(-5.0f, 10.0f);
-    std::uniform_int_distribution<int32_t> idist(-1, 2);
-    std::uniform_real_distribution<float> distColor(0.0f, 1.0f);
-    std::uniform_real_distribution<float> distPositive(0.0f, 10.0f);
+    std::uniform_real_distribution<f32> dist(-5.0f, 10.0f);
+    std::uniform_int_distribution<i32> idist(-1, 2);
+    std::uniform_real_distribution<f32> distColor(0.0f, 1.0f);
+    std::uniform_real_distribution<f32> distPositive(0.0f, 10.0f);
 
-    uint32_t numMaterials = 5;
-    uint32_t numTransforms = 5;
-    uint32_t numMeshes = 5;
-    uint32_t numMeshRenderers = 4;
-    uint32_t numSkeletons = 3;
-    uint32_t numSkinnedMeshRenderers = 2;
-    uint32_t numAnimators = 4;
-    uint32_t numAnimations = 3;
-    uint32_t numDirectionalLights = 2;
-    uint32_t numPointLights = 4;
-    uint32_t numNames = 3;
+    u32 numMaterials = 5;
+    u32 numTransforms = 5;
+    u32 numMeshes = 5;
+    u32 numMeshRenderers = 4;
+    u32 numSkeletons = 3;
+    u32 numSkinnedMeshRenderers = 2;
+    u32 numAnimators = 4;
+    u32 numAnimations = 3;
+    u32 numDirectionalLights = 2;
+    u32 numPointLights = 4;
+    u32 numNames = 3;
 
-    for (uint32_t i = 0; i < numTransforms; ++i) {
+    for (u32 i = 0; i < numTransforms; ++i) {
       quoll::PrefabTransformData transform{};
       transform.position = {dist(mt), dist(mt), dist(mt)};
       transform.rotation = {dist(mt), dist(mt), dist(mt), dist(mt)};
@@ -45,13 +45,13 @@ public:
       asset.data.transforms.push_back({i, transform});
     }
 
-    for (uint32_t i = 0; i < numNames; ++i) {
+    for (u32 i = 0; i < numNames; ++i) {
       quoll::String name = "Test name " + std::to_string(i);
 
       asset.data.names.push_back({i, name});
     }
 
-    for (uint32_t i = 0; i < numDirectionalLights; ++i) {
+    for (u32 i = 0; i < numDirectionalLights; ++i) {
       quoll::DirectionalLight light{};
       light.color = {distColor(mt), distColor(mt), distColor(mt),
                      distColor(mt)};
@@ -60,7 +60,7 @@ public:
       asset.data.directionalLights.push_back({i, light});
     }
 
-    for (uint32_t i = 0; i < numPointLights; ++i) {
+    for (u32 i = 0; i < numPointLights; ++i) {
       quoll::PointLight light{};
       light.color = {distColor(mt), distColor(mt), distColor(mt),
                      distColor(mt)};
@@ -71,20 +71,20 @@ public:
     }
 
     std::vector<quoll::MaterialAssetHandle> materials(numMaterials);
-    for (uint32_t i = 0; i < numMaterials; ++i) {
+    for (u32 i = 0; i < numMaterials; ++i) {
       quoll::AssetData<quoll::MaterialAsset> material;
       material.uuid = quoll::Uuid("material-" + std::to_string(i));
       materials.at(i) = cache.getRegistry().getMaterials().addAsset(material);
     }
 
-    for (uint32_t i = 0; i < numMeshes; ++i) {
+    for (u32 i = 0; i < numMeshes; ++i) {
       quoll::AssetData<quoll::MeshAsset> mesh;
       mesh.uuid = quoll::Uuid("mesh-" + std::to_string(i));
       auto handle = cache.getRegistry().getMeshes().addAsset(mesh);
       asset.data.meshes.push_back({i, handle});
     }
 
-    for (uint32_t i = 0; i < numMeshRenderers; ++i) {
+    for (u32 i = 0; i < numMeshRenderers; ++i) {
       quoll::MeshRenderer renderer{};
       renderer.materials.push_back(materials.at(i % 3));
       renderer.materials.push_back(materials.at(1 + (i % 3)));
@@ -95,12 +95,12 @@ public:
     // Add two more entities that point to the same
     // meshes to test that existing meshes are always
     // referenced instead of added again
-    for (uint32_t i = 0; i < 2; ++i) {
-      auto handle = asset.data.meshes.at(static_cast<size_t>(i)).value;
+    for (u32 i = 0; i < 2; ++i) {
+      auto handle = asset.data.meshes.at(static_cast<usize>(i)).value;
       asset.data.meshes.push_back({numMeshes + i, handle});
     }
 
-    for (uint32_t i = 0; i < numSkinnedMeshRenderers; ++i) {
+    for (u32 i = 0; i < numSkinnedMeshRenderers; ++i) {
       quoll::SkinnedMeshRenderer renderer{};
       renderer.materials.push_back(materials.at((i % 2)));
       renderer.materials.push_back(materials.at(1 + (i % 2)));
@@ -109,7 +109,7 @@ public:
       asset.data.skinnedMeshRenderers.push_back({i, renderer});
     }
 
-    for (uint32_t i = 0; i < numSkeletons; ++i) {
+    for (u32 i = 0; i < numSkeletons; ++i) {
       quoll::AssetData<quoll::SkeletonAsset> skeleton;
       skeleton.uuid = quoll::Uuid("skel-" + std::to_string(i));
       auto handle = cache.getRegistry().getSkeletons().addAsset(skeleton);
@@ -119,12 +119,12 @@ public:
     // Add two more entities that point to the same
     // skeletons to test that existing skeletons are always
     // referenced instead of added again
-    for (uint32_t i = 0; i < 2; ++i) {
-      auto handle = asset.data.skeletons.at(static_cast<size_t>(i)).value;
+    for (u32 i = 0; i < 2; ++i) {
+      auto handle = asset.data.skeletons.at(static_cast<usize>(i)).value;
       asset.data.skeletons.push_back({numSkeletons + i, handle});
     }
 
-    for (uint32_t i = 0; i < numAnimations; ++i) {
+    for (u32 i = 0; i < numAnimations; ++i) {
       quoll::AssetData<quoll::AnimationAsset> animation;
       animation.uuid = quoll::Uuid("animation-" + std::to_string(i));
 
@@ -132,7 +132,7 @@ public:
       asset.data.animations.push_back(handle);
     }
 
-    for (uint32_t i = 0; i < numAnimators; ++i) {
+    for (u32 i = 0; i < numAnimators; ++i) {
       quoll::AssetData<quoll::AnimatorAsset> animator;
       animator.uuid = quoll::Uuid("animator-" + std::to_string(i));
       auto handle = cache.getRegistry().getAnimators().addAsset(animator);
@@ -142,7 +142,7 @@ public:
     // Add two more entities that point to same animations
     // to test that existing animations are always
     // referenced instead of added again
-    for (uint32_t i = 0; i < 2; ++i) {
+    for (u32 i = 0; i < 2; ++i) {
       auto handle = asset.data.animators.at(i).value;
       asset.data.animators.push_back({numAnimators + i, handle});
     }
@@ -177,13 +177,13 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   {
     auto &map = cache.getRegistry().getMaterials();
     auto &actual = actualMaterials;
-    uint32_t numAssets = 0;
+    u32 numAssets = 0;
     file.read(numAssets);
     EXPECT_EQ(numAssets, 4);
     actualMaterials.resize(4);
     file.read(actual);
 
-    for (uint32_t i = 0; i < numAssets; ++i) {
+    for (u32 i = 0; i < numAssets; ++i) {
       auto handle = map.findHandleByUuid(actual.at(i));
       EXPECT_NE(handle, quoll::MaterialAssetHandle::Null);
     }
@@ -193,13 +193,13 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   {
     auto &expected = asset.data.meshes;
     auto &map = cache.getRegistry().getMeshes();
-    uint32_t numAssets = 0;
+    u32 numAssets = 0;
     file.read(numAssets);
-    EXPECT_EQ(numAssets, static_cast<uint32_t>(expected.size() - 2));
+    EXPECT_EQ(numAssets, static_cast<u32>(expected.size() - 2));
     actualMeshes.resize(numAssets);
     file.read(actualMeshes);
 
-    for (uint32_t i = 0; i < numAssets; ++i) {
+    for (u32 i = 0; i < numAssets; ++i) {
       auto expectedString = map.getAsset(expected.at(i).value).uuid;
       EXPECT_EQ(expectedString, actualMeshes.at(i));
     }
@@ -209,13 +209,13 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   {
     auto &expected = asset.data.skeletons;
     auto &map = cache.getRegistry().getSkeletons();
-    uint32_t numAssets = 0;
+    u32 numAssets = 0;
     file.read(numAssets);
     EXPECT_EQ(numAssets, 3);
     actualSkeletons.resize(numAssets);
     file.read(actualSkeletons);
 
-    for (uint32_t i = 0; i < numAssets; ++i) {
+    for (u32 i = 0; i < numAssets; ++i) {
       auto expectedString = map.getAsset(expected.at(i).value).uuid;
       EXPECT_EQ(expectedString, actualSkeletons.at(i));
     }
@@ -226,13 +226,13 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
     auto &expected = asset.data.animations;
     auto &map = cache.getRegistry().getAnimations();
     auto &actual = actualAnimations;
-    uint32_t numAssets = 0;
+    u32 numAssets = 0;
     file.read(numAssets);
     EXPECT_EQ(numAssets, 3);
     actualAnimations.resize(numAssets);
     file.read(actual);
 
-    for (uint32_t i = 0; i < numAssets; ++i) {
+    for (u32 i = 0; i < numAssets; ++i) {
       auto expectedString = map.getAsset(expected.at(i)).uuid;
       EXPECT_EQ(expectedString, actual.at(i));
     }
@@ -243,31 +243,31 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
     auto &expected = asset.data.animators;
     auto &map = cache.getRegistry().getAnimators();
     auto &actual = actualAnimators;
-    uint32_t numAssets = 0;
+    u32 numAssets = 0;
     file.read(numAssets);
     EXPECT_EQ(numAssets, 4);
     actualAnimators.resize(numAssets);
     file.read(actual);
 
-    for (uint32_t i = 0; i < numAssets; ++i) {
+    for (u32 i = 0; i < numAssets; ++i) {
       auto expectedString = map.getAsset(expected.at(i).value).uuid;
       EXPECT_EQ(expectedString, actual.at(i));
     }
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     file.read(numComponents);
     EXPECT_EQ(numComponents, 5);
     std::vector<quoll::PrefabTransformData> transforms(numComponents);
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 0;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 0;
       file.read(entity);
 
       glm::vec3 position;
       glm::quat rotation;
       glm::vec3 scale;
-      int32_t parent = -1;
+      i32 parent = -1;
       file.read(position);
       file.read(rotation);
       file.read(scale);
@@ -282,12 +282,12 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     file.read(numComponents);
     EXPECT_EQ(numComponents, 3);
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 999;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 999;
       file.read(entity);
       EXPECT_EQ(entity, i);
 
@@ -299,16 +299,16 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     file.read(numComponents);
     EXPECT_EQ(numComponents, 7);
     auto &map = cache.getRegistry().getMeshes();
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 999;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 999;
       file.read(entity);
       EXPECT_EQ(entity, i);
 
-      uint32_t meshIndex = 999;
+      u32 meshIndex = 999;
       file.read(meshIndex);
       EXPECT_EQ(meshIndex, i % 5);
 
@@ -319,26 +319,26 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   }
 
   {
-    uint32_t numComponents = 999;
+    u32 numComponents = 999;
     file.read(numComponents);
     EXPECT_EQ(numComponents, 4);
     auto &map = cache.getRegistry().getMaterials();
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 999;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 999;
       file.read(entity);
       EXPECT_EQ(entity, i);
 
-      uint32_t numMaterials = 999;
+      u32 numMaterials = 999;
       file.read(numMaterials);
       EXPECT_EQ(numMaterials, 2);
 
-      std::vector<uint32_t> materialIndices(numMaterials);
+      std::vector<u32> materialIndices(numMaterials);
       file.read(materialIndices);
 
       auto &expected = asset.data.meshRenderers.at(i).value;
       EXPECT_EQ(materialIndices.size(), expected.materials.size());
 
-      for (size_t mi = 0; mi < materialIndices.size(); ++mi) {
+      for (usize mi = 0; mi < materialIndices.size(); ++mi) {
         auto materialIndex = materialIndices.at(mi);
         auto handle = expected.materials.at(mi);
 
@@ -349,26 +349,26 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   }
 
   {
-    uint32_t numComponents = 999;
+    u32 numComponents = 999;
     file.read(numComponents);
     EXPECT_EQ(numComponents, 2);
     auto &map = cache.getRegistry().getMaterials();
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 999;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 999;
       file.read(entity);
       EXPECT_EQ(entity, i);
 
-      uint32_t numMaterials = 999;
+      u32 numMaterials = 999;
       file.read(numMaterials);
       EXPECT_EQ(numMaterials, 3);
 
-      std::vector<uint32_t> materialIndices(numMaterials);
+      std::vector<u32> materialIndices(numMaterials);
       file.read(materialIndices);
 
       auto &expected = asset.data.skinnedMeshRenderers.at(i).value;
       EXPECT_EQ(materialIndices.size(), expected.materials.size());
 
-      for (size_t mi = 0; mi < materialIndices.size(); ++mi) {
+      for (usize mi = 0; mi < materialIndices.size(); ++mi) {
         auto materialIndex = materialIndices.at(mi);
         auto handle = expected.materials.at(mi);
 
@@ -379,16 +379,16 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     file.read(numComponents);
     EXPECT_EQ(numComponents, 5);
     auto &map = cache.getRegistry().getSkeletons();
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 999;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 999;
       file.read(entity);
       EXPECT_EQ(entity, i);
 
-      uint32_t skeletonIndex = 999;
+      u32 skeletonIndex = 999;
       file.read(skeletonIndex);
       EXPECT_EQ(skeletonIndex, i % 3);
 
@@ -399,13 +399,13 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     file.read(numComponents);
     EXPECT_EQ(numComponents, 3);
     auto &map = cache.getRegistry().getAnimations();
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t animatorIndex = 999;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 animatorIndex = 999;
       file.read(animatorIndex);
 
       auto &expected = map.getAsset(asset.data.animations.at(i));
@@ -415,17 +415,17 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     file.read(numComponents);
     EXPECT_EQ(numComponents, 6);
     auto &map = cache.getRegistry().getAnimators();
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 999;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 999;
       file.read(entity);
       EXPECT_EQ(entity, i);
 
-      uint32_t animatorIndex = 999;
+      u32 animatorIndex = 999;
       file.read(animatorIndex);
 
       auto &expected = map.getAsset(asset.data.animators.at(i).value);
@@ -435,17 +435,17 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     file.read(numComponents);
     EXPECT_EQ(numComponents, 2);
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 999;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 999;
       file.read(entity);
       EXPECT_EQ(entity, i);
 
       glm::vec4 color{999.0f};
-      float intensity = 0.0f;
+      f32 intensity = 0.0f;
       file.read(color);
       file.read(intensity);
 
@@ -455,18 +455,18 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   }
 
   {
-    uint32_t numComponents = 0;
+    u32 numComponents = 0;
     file.read(numComponents);
     EXPECT_EQ(numComponents, 4);
 
-    for (uint32_t i = 0; i < numComponents; ++i) {
-      uint32_t entity = 999;
+    for (u32 i = 0; i < numComponents; ++i) {
+      u32 entity = 999;
       file.read(entity);
       EXPECT_EQ(entity, i);
 
       glm::vec4 color{999.0f};
-      float intensity = 0.0f;
-      float range = 99.0f;
+      f32 intensity = 0.0f;
+      f32 range = 99.0f;
       file.read(color);
       file.read(intensity);
       file.read(range);
@@ -504,7 +504,7 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabFile) {
   EXPECT_EQ(prefab.name, asset.name);
 
   EXPECT_EQ(asset.data.transforms.size(), prefab.data.transforms.size());
-  for (size_t i = 0; i < prefab.data.transforms.size(); ++i) {
+  for (usize i = 0; i < prefab.data.transforms.size(); ++i) {
     auto &expected = asset.data.transforms.at(i);
     auto &actual = prefab.data.transforms.at(i);
     EXPECT_EQ(expected.entity, actual.entity);
@@ -515,7 +515,7 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabFile) {
   }
 
   EXPECT_EQ(asset.data.names.size(), prefab.data.names.size());
-  for (size_t i = 0; i < prefab.data.names.size(); ++i) {
+  for (usize i = 0; i < prefab.data.names.size(); ++i) {
     auto &expected = asset.data.names.at(i);
     auto &actual = prefab.data.names.at(i);
     EXPECT_EQ(expected.entity, actual.entity);
@@ -523,7 +523,7 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabFile) {
   }
 
   EXPECT_EQ(asset.data.meshes.size(), prefab.data.meshes.size());
-  for (size_t i = 0; i < prefab.data.meshes.size(); ++i) {
+  for (usize i = 0; i < prefab.data.meshes.size(); ++i) {
     auto &expected = asset.data.meshes.at(i);
     auto &actual = prefab.data.meshes.at(i);
     EXPECT_EQ(expected.entity, actual.entity);
@@ -531,30 +531,30 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabFile) {
   }
 
   EXPECT_EQ(asset.data.meshRenderers.size(), prefab.data.meshRenderers.size());
-  for (size_t i = 0; i < prefab.data.meshRenderers.size(); ++i) {
+  for (usize i = 0; i < prefab.data.meshRenderers.size(); ++i) {
     auto &expected = asset.data.meshRenderers.at(i);
     auto &actual = prefab.data.meshRenderers.at(i);
     EXPECT_EQ(expected.entity, actual.entity);
     EXPECT_EQ(expected.value.materials.size(), actual.value.materials.size());
-    for (size_t mi = 0; mi < expected.value.materials.size(); ++mi) {
+    for (usize mi = 0; mi < expected.value.materials.size(); ++mi) {
       EXPECT_EQ(expected.value.materials.at(mi), actual.value.materials.at(mi));
     }
   }
 
   EXPECT_EQ(asset.data.skinnedMeshRenderers.size(),
             prefab.data.skinnedMeshRenderers.size());
-  for (size_t i = 0; i < prefab.data.skinnedMeshRenderers.size(); ++i) {
+  for (usize i = 0; i < prefab.data.skinnedMeshRenderers.size(); ++i) {
     auto &expected = asset.data.skinnedMeshRenderers.at(i);
     auto &actual = prefab.data.skinnedMeshRenderers.at(i);
     EXPECT_EQ(expected.entity, actual.entity);
     EXPECT_EQ(expected.value.materials.size(), actual.value.materials.size());
-    for (size_t mi = 0; mi < expected.value.materials.size(); ++mi) {
+    for (usize mi = 0; mi < expected.value.materials.size(); ++mi) {
       EXPECT_EQ(expected.value.materials.at(mi), actual.value.materials.at(mi));
     }
   }
 
   EXPECT_EQ(asset.data.skeletons.size(), prefab.data.skeletons.size());
-  for (size_t i = 0; i < prefab.data.skeletons.size(); ++i) {
+  for (usize i = 0; i < prefab.data.skeletons.size(); ++i) {
     auto &expected = asset.data.skeletons.at(i);
     auto &actual = prefab.data.skeletons.at(i);
     EXPECT_EQ(expected.entity, actual.entity);
@@ -562,7 +562,7 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabFile) {
   }
 
   EXPECT_EQ(asset.data.animations.size(), prefab.data.animations.size());
-  for (size_t i = 0; i < prefab.data.animations.size(); ++i) {
+  for (usize i = 0; i < prefab.data.animations.size(); ++i) {
     auto &expected = asset.data.animations.at(i);
     auto &actual = prefab.data.animations.at(i);
 
@@ -570,7 +570,7 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabFile) {
   }
 
   EXPECT_EQ(asset.data.animators.size(), prefab.data.animators.size());
-  for (size_t i = 0; i < prefab.data.animators.size(); ++i) {
+  for (usize i = 0; i < prefab.data.animators.size(); ++i) {
     auto &expected = asset.data.animators.at(i);
     auto &actual = prefab.data.animators.at(i);
 
@@ -580,7 +580,7 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabFile) {
 
   EXPECT_EQ(asset.data.directionalLights.size(),
             prefab.data.directionalLights.size());
-  for (size_t i = 0; i < prefab.data.directionalLights.size(); ++i) {
+  for (usize i = 0; i < prefab.data.directionalLights.size(); ++i) {
     auto &expected = asset.data.directionalLights.at(i);
     auto &actual = prefab.data.directionalLights.at(i);
 
@@ -592,7 +592,7 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabFile) {
   }
 
   EXPECT_EQ(asset.data.pointLights.size(), prefab.data.pointLights.size());
-  for (size_t i = 0; i < prefab.data.pointLights.size(); ++i) {
+  for (usize i = 0; i < prefab.data.pointLights.size(); ++i) {
     auto &expected = asset.data.pointLights.at(i);
     auto &actual = prefab.data.pointLights.at(i);
 

--- a/engine/tests/quoll-tests/asset/AssetCacheSkeleton.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheSkeleton.test.cpp
@@ -21,11 +21,11 @@ TEST_F(AssetCacheSkeletonTest, CreatesSkeletonFileFromSkeletonAsset) {
   {
     std::random_device device;
     std::mt19937 mt(device());
-    std::uniform_real_distribution<float> dist(-5.0f, 10.0f);
-    std::uniform_int_distribution<uint32_t> udist(0, 20);
+    std::uniform_real_distribution<f32> dist(-5.0f, 10.0f);
+    std::uniform_int_distribution<u32> udist(0, 20);
 
-    size_t countJoints = 20;
-    for (size_t i = 0; i < countJoints; ++i) {
+    usize countJoints = 20;
+    for (usize i = 0; i < countJoints; ++i) {
       asset.data.jointLocalPositions.push_back(
           glm::vec3(dist(mt), dist(mt), dist(mt)));
       asset.data.jointLocalRotations.push_back(
@@ -72,7 +72,7 @@ TEST_F(AssetCacheSkeletonTest, CreatesSkeletonFileFromSkeletonAsset) {
   EXPECT_EQ(header.magic, header.MagicConstant);
   EXPECT_EQ(header.type, quoll::AssetType::Skeleton);
 
-  uint32_t numJoints = 0;
+  u32 numJoints = 0;
   file.read(numJoints);
   EXPECT_EQ(numJoints, 20);
 
@@ -89,7 +89,7 @@ TEST_F(AssetCacheSkeletonTest, CreatesSkeletonFileFromSkeletonAsset) {
   file.read(actualInverseBindMatrices);
   file.read(actualNames);
 
-  for (uint32_t i = 0; i < numJoints; ++i) {
+  for (u32 i = 0; i < numJoints; ++i) {
     EXPECT_EQ(actualPositions.at(i), asset.data.jointLocalPositions.at(i));
     EXPECT_EQ(actualRotations.at(i), asset.data.jointLocalRotations.at(i));
     EXPECT_EQ(actualScales.at(i), asset.data.jointLocalScales.at(i));
@@ -111,11 +111,11 @@ TEST_F(AssetCacheSkeletonTest, LoadsSkeletonAssetFromFile) {
   {
     std::random_device device;
     std::mt19937 mt(device());
-    std::uniform_real_distribution<float> dist(-5.0f, 10.0f);
-    std::uniform_int_distribution<uint32_t> udist(0, 20);
+    std::uniform_real_distribution<f32> dist(-5.0f, 10.0f);
+    std::uniform_int_distribution<u32> udist(0, 20);
 
-    size_t countJoints = 20;
-    for (size_t i = 0; i < countJoints; ++i) {
+    usize countJoints = 20;
+    for (usize i = 0; i < countJoints; ++i) {
       asset.data.jointLocalPositions.push_back(
           glm::vec3(dist(mt), dist(mt), dist(mt)));
       asset.data.jointLocalRotations.push_back(
@@ -161,7 +161,7 @@ TEST_F(AssetCacheSkeletonTest, LoadsSkeletonAssetFromFile) {
 
   EXPECT_EQ(actual.name, asset.name);
 
-  for (size_t i = 0; i < actual.data.jointLocalPositions.size(); ++i) {
+  for (usize i = 0; i < actual.data.jointLocalPositions.size(); ++i) {
     EXPECT_EQ(actual.data.jointLocalPositions.at(i),
               asset.data.jointLocalPositions.at(i));
     EXPECT_EQ(actual.data.jointLocalRotations.at(i),

--- a/engine/tests/quoll-tests/asset/FileTracker.test.cpp
+++ b/engine/tests/quoll-tests/asset/FileTracker.test.cpp
@@ -15,8 +15,8 @@ class FileTrackerTest : public ::testing::Test {
 public:
   FileTrackerTest() : fileTracker(fileTrackerPath) {}
 
-  void createFixtures(size_t count) {
-    for (size_t i = 0; i < count; ++i) {
+  void createFixtures(usize count) {
+    for (usize i = 0; i < count; ++i) {
       {
         fs::path path(fileTrackerPath / ("file-" + std::to_string(i)));
         std::ofstream stream(path);

--- a/engine/tests/quoll-tests/core/EntityDeleter.test.cpp
+++ b/engine/tests/quoll-tests/core/EntityDeleter.test.cpp
@@ -10,10 +10,10 @@ public:
 };
 
 TEST_F(EntityDeleterTest, DeleteEntitiesThatHaveDeleteComponents) {
-  static constexpr size_t NumEntities = 20;
+  static constexpr usize NumEntities = 20;
 
   std::vector<quoll::Entity> entities(NumEntities, quoll::Entity::Null);
-  for (size_t i = 0; i < entities.size(); ++i) {
+  for (usize i = 0; i < entities.size(); ++i) {
     auto entity = scene.entityDatabase.create();
     entities.at(i) = entity;
 
@@ -28,18 +28,18 @@ TEST_F(EntityDeleterTest, DeleteEntitiesThatHaveDeleteComponents) {
 
   entityDeleter.update(scene);
 
-  for (size_t i = 0; i < entities.size(); ++i) {
+  for (usize i = 0; i < entities.size(); ++i) {
     auto entity = entities.at(i);
     EXPECT_NE(scene.entityDatabase.exists(entity), (i % 2) == 0);
   }
 }
 
 TEST_F(EntityDeleterTest, DeletesAllChildrenOfEntitiesWithDeleteComponents) {
-  static constexpr size_t NumEntities = 20;
+  static constexpr usize NumEntities = 20;
 
   std::vector<quoll::Entity> entities(NumEntities, quoll::Entity::Null);
 
-  for (size_t i = 0; i < entities.size(); ++i) {
+  for (usize i = 0; i < entities.size(); ++i) {
     auto entity = scene.entityDatabase.create();
     entities.at(i) = entity;
 
@@ -58,7 +58,7 @@ TEST_F(EntityDeleterTest, DeletesAllChildrenOfEntitiesWithDeleteComponents) {
 
   entityDeleter.update(scene);
 
-  for (size_t i = 0; i < entities.size(); ++i) {
+  for (usize i = 0; i < entities.size(); ++i) {
     auto entity = entities.at(i);
 
     // Even numbers are removed
@@ -71,11 +71,11 @@ TEST_F(EntityDeleterTest, DeletesAllChildrenOfEntitiesWithDeleteComponents) {
 }
 
 TEST_F(EntityDeleterTest, RemoveDeletedEntityFromChildrenOfAParent) {
-  static constexpr size_t NumEntities = 20;
+  static constexpr usize NumEntities = 20;
 
   std::vector<quoll::Entity> entities(NumEntities, quoll::Entity::Null);
 
-  for (size_t i = 0; i < entities.size(); ++i) {
+  for (usize i = 0; i < entities.size(); ++i) {
     auto entity = scene.entityDatabase.create();
     entities.at(i) = entity;
 
@@ -98,7 +98,7 @@ TEST_F(EntityDeleterTest, RemoveDeletedEntityFromChildrenOfAParent) {
 
   entityDeleter.update(scene);
 
-  for (size_t i = 0; i < entities.size(); ++i) {
+  for (usize i = 0; i < entities.size(); ++i) {
     if (!scene.entityDatabase.has<quoll::Children>(entities.at(i))) {
       continue;
     }

--- a/engine/tests/quoll-tests/core/Errorable.test.cpp
+++ b/engine/tests/quoll-tests/core/Errorable.test.cpp
@@ -4,7 +4,7 @@
 #include "quoll-tests/Testing.h"
 
 struct Data {
-  uint32_t value = 25;
+  u32 value = 25;
 };
 
 enum class Error { None = 0, InvalidNumber = 1, MaximumReached = 2 };

--- a/engine/tests/quoll-tests/core/Property.test.cpp
+++ b/engine/tests/quoll-tests/core/Property.test.cpp
@@ -7,8 +7,8 @@ TEST(PropertyTest, SetsInt32Value) {
   quoll::Property property(-232);
 
   EXPECT_EQ(property.getType(), quoll::Property::INT32);
-  EXPECT_EQ(property.getSize(), sizeof(int32_t));
-  EXPECT_EQ(property.getValue<int32_t>(), -232);
+  EXPECT_EQ(property.getSize(), sizeof(i32));
+  EXPECT_EQ(property.getValue<i32>(), -232);
   EXPECT_EQ(property.toString(), "-232");
 }
 
@@ -16,18 +16,18 @@ TEST(PropertyTest, SetsUint32Value) {
   quoll::Property property(232u);
 
   EXPECT_EQ(property.getType(), quoll::Property::UINT32);
-  EXPECT_EQ(property.getSize(), sizeof(uint32_t));
-  EXPECT_EQ(property.getValue<uint32_t>(), 232);
+  EXPECT_EQ(property.getSize(), sizeof(u32));
+  EXPECT_EQ(property.getValue<u32>(), 232);
   EXPECT_EQ(property.toString(), "232");
 }
 
 TEST(PropertyTest, SetsUint64Value) {
-  uint64_t value = 232;
+  u64 value = 232;
   quoll::Property property(value);
 
   EXPECT_EQ(property.getType(), quoll::Property::UINT64);
-  EXPECT_EQ(property.getSize(), sizeof(uint64_t));
-  EXPECT_EQ(property.getValue<uint64_t>(), 232);
+  EXPECT_EQ(property.getSize(), sizeof(u64));
+  EXPECT_EQ(property.getValue<u64>(), 232);
   EXPECT_EQ(property.toString(), "232");
 }
 
@@ -35,8 +35,8 @@ TEST(PropertyTest, SetsRealValue) {
   quoll::Property property(12.0f);
 
   EXPECT_EQ(property.getType(), quoll::Property::REAL);
-  EXPECT_EQ(property.getSize(), sizeof(float));
-  EXPECT_EQ(property.getValue<float>(), 12.0f);
+  EXPECT_EQ(property.getSize(), sizeof(f32));
+  EXPECT_EQ(property.getValue<f32>(), 12.0f);
   EXPECT_EQ(property.toString(), "12.00");
 }
 
@@ -94,14 +94,14 @@ TEST(PropertyDeathTest, UndefinedTypeThrowsError) {
 TEST(PropertyDeathTest, CastingToWrongTypeThrowsError) {
   quoll::Property p1(12.0f);
 
-  EXPECT_DEATH(p1.getValue<int32_t>(), ".*");
-  EXPECT_DEATH(p1.getValue<uint32_t>(), ".*");
-  EXPECT_DEATH(p1.getValue<uint64_t>(), ".*");
+  EXPECT_DEATH(p1.getValue<i32>(), ".*");
+  EXPECT_DEATH(p1.getValue<u32>(), ".*");
+  EXPECT_DEATH(p1.getValue<u64>(), ".*");
   EXPECT_DEATH(p1.getValue<glm::vec2>(), ".*");
   EXPECT_DEATH(p1.getValue<glm::vec3>(), ".*");
   EXPECT_DEATH(p1.getValue<glm::vec4>(), ".*");
   EXPECT_DEATH(p1.getValue<glm::mat4>(), ".*");
 
   quoll::Property p2(glm::vec2{1.0f, 1.0f});
-  EXPECT_DEATH(p2.getValue<float>(), ".*");
+  EXPECT_DEATH(p2.getValue<f32>(), ".*");
 }

--- a/engine/tests/quoll-tests/core/SparseSet.test.cpp
+++ b/engine/tests/quoll-tests/core/SparseSet.test.cpp
@@ -5,9 +5,9 @@
 
 class SparseSetTest : public ::testing::Test {
 public:
-  quoll::SparseSet<uint32_t> sparseSet;
+  quoll::SparseSet<u32> sparseSet;
 
-  static constexpr size_t NumItems = 20;
+  static constexpr usize NumItems = 20;
 };
 
 using SparseSetDeathTest = SparseSetTest;
@@ -15,19 +15,19 @@ using SparseSetDeathTest = SparseSetTest;
 using SparseSetIteratorTest = SparseSetTest;
 
 TEST_F(SparseSetTest, PushesItemToTheEndOfTheListIfNoHoles) {
-  for (size_t i = 0; i < NumItems; ++i) {
-    size_t index = sparseSet.insert(static_cast<uint32_t>(i) * 2);
+  for (usize i = 0; i < NumItems; ++i) {
+    usize index = sparseSet.insert(static_cast<u32>(i) * 2);
     EXPECT_EQ(index, (sparseSet.size() - 1));
   }
 
-  for (size_t i = 0; i < NumItems; ++i) {
-    EXPECT_EQ(sparseSet.at(i), static_cast<uint32_t>(i) * 2);
+  for (usize i = 0; i < NumItems; ++i) {
+    EXPECT_EQ(sparseSet.at(i), static_cast<u32>(i) * 2);
   }
 }
 
 TEST_F(SparseSetTest, ErasesItemAtIndex) {
-  for (uint32_t i = 0; i < NumItems; ++i) {
-    size_t index = sparseSet.insert(i * 2);
+  for (u32 i = 0; i < NumItems; ++i) {
+    usize index = sparseSet.insert(i * 2);
     EXPECT_EQ(index, sparseSet.size() - 1);
   }
 
@@ -35,51 +35,51 @@ TEST_F(SparseSetTest, ErasesItemAtIndex) {
   sparseSet.erase(9);
   sparseSet.erase(17);
 
-  for (size_t i = 0; i < 5; ++i) {
+  for (usize i = 0; i < 5; ++i) {
     EXPECT_TRUE(sparseSet.contains(i));
     EXPECT_EQ(sparseSet.at(i), i * 2);
   }
 
   EXPECT_FALSE(sparseSet.contains(5));
 
-  for (size_t i = 6; i < 9; ++i) {
+  for (usize i = 6; i < 9; ++i) {
     EXPECT_TRUE(sparseSet.contains(i));
     EXPECT_EQ(sparseSet.at(i), i * 2);
   }
 
   EXPECT_FALSE(sparseSet.contains(9));
 
-  for (size_t i = 10; i < 17; ++i) {
+  for (usize i = 10; i < 17; ++i) {
     EXPECT_TRUE(sparseSet.contains(i));
     EXPECT_EQ(sparseSet.at(i), i * 2);
   }
 
   EXPECT_FALSE(sparseSet.contains(17));
 
-  for (size_t i = 18; i < NumItems; ++i) {
+  for (usize i = 18; i < NumItems; ++i) {
     EXPECT_TRUE(sparseSet.contains(i));
     EXPECT_EQ(sparseSet.at(i), i * 2);
   }
 }
 
 TEST_F(SparseSetTest, OutOfOrderAddAndEraseDoesNotCauseInvalidState) {
-  for (uint32_t i = 0; i < NumItems; ++i) {
-    size_t index0 = sparseSet.insert(i);
-    size_t index1 = sparseSet.insert(NumItems + i);
+  for (u32 i = 0; i < NumItems; ++i) {
+    usize index0 = sparseSet.insert(i);
+    usize index1 = sparseSet.insert(NumItems + i);
 
     sparseSet.erase(index0);
     sparseSet.erase(index1);
   }
 
-  for (uint32_t i = 0; i < NumItems; ++i) {
+  for (u32 i = 0; i < NumItems; ++i) {
     EXPECT_FALSE(sparseSet.contains(i));
     EXPECT_FALSE(sparseSet.contains(NumItems + i));
   }
 }
 
 TEST_F(SparseSetTest, FillsEmptyHolesOnInsertIfThereAreAny) {
-  for (size_t i = 0; i < NumItems; ++i) {
-    size_t index = sparseSet.insert(static_cast<uint32_t>(i) * 2);
+  for (usize i = 0; i < NumItems; ++i) {
+    usize index = sparseSet.insert(static_cast<u32>(i) * 2);
     EXPECT_EQ(index, sparseSet.size() - 1);
   }
 
@@ -102,8 +102,8 @@ TEST_F(SparseSetTest, FillsEmptyHolesOnInsertIfThereAreAny) {
 }
 
 TEST_F(SparseSetTest, GetsSize) {
-  for (uint32_t i = 0; i < NumItems; ++i) {
-    size_t index = sparseSet.insert(i * 2);
+  for (u32 i = 0; i < NumItems; ++i) {
+    usize index = sparseSet.insert(i * 2);
     EXPECT_EQ(index, sparseSet.size() - 1);
   }
 
@@ -115,11 +115,11 @@ TEST_F(SparseSetTest, GetsSize) {
 }
 
 TEST_F(SparseSetTest, EmptyReturnsTrueIfSetIsEmpty) {
-  for (uint32_t i = 0; i < NumItems; ++i) {
+  for (u32 i = 0; i < NumItems; ++i) {
     sparseSet.insert(i * 2);
   }
 
-  for (uint32_t i = 0; i < NumItems; ++i) {
+  for (u32 i = 0; i < NumItems; ++i) {
     sparseSet.erase(i);
   }
 
@@ -127,8 +127,8 @@ TEST_F(SparseSetTest, EmptyReturnsTrueIfSetIsEmpty) {
 }
 
 TEST_F(SparseSetTest, EmptyReturnsFalseIfSetIsNotEmpty) {
-  for (uint32_t i = 0; i < NumItems; ++i) {
-    size_t index = sparseSet.insert(i * 2);
+  for (u32 i = 0; i < NumItems; ++i) {
+    usize index = sparseSet.insert(i * 2);
   }
 
   EXPECT_FALSE(sparseSet.empty());
@@ -139,7 +139,7 @@ TEST_F(SparseSetDeathTest, FailsGettingItemIfIndexOutOfBounds) {
 }
 
 TEST_F(SparseSetDeathTest, FailsGettingItemIfNoItemAtIndex) {
-  for (uint32_t i = 0; i < NumItems; ++i) {
+  for (u32 i = 0; i < NumItems; ++i) {
     sparseSet.insert(i * 2);
   }
 
@@ -149,11 +149,11 @@ TEST_F(SparseSetDeathTest, FailsGettingItemIfNoItemAtIndex) {
 }
 
 TEST_F(SparseSetTest, FailsGettingItemIfNoItemAtIndex) {
-  for (uint32_t i = 0; i < NumItems; ++i) {
+  for (u32 i = 0; i < NumItems; ++i) {
     sparseSet.insert(i * 2);
   }
 
-  size_t i = 0;
+  usize i = 0;
   for (auto value : sparseSet) {
     EXPECT_EQ(value, i * 2);
     i++;

--- a/engine/tests/quoll-tests/core/SwappableVector.test.cpp
+++ b/engine/tests/quoll-tests/core/SwappableVector.test.cpp
@@ -59,7 +59,7 @@ TEST_F(SwappableVectorTest, RangeForLoopWorks) {
   buffer.push_back({7});
   buffer.push_back({8});
 
-  size_t i = 0;
+  usize i = 0;
   for (auto &x : buffer) {
     EXPECT_EQ(x.val, buffer.at(i).val);
     i++;

--- a/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
@@ -56,9 +56,9 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Create 2 transforms that point to previous entity
-  for (int32_t i = 1; i < 3; ++i) {
-    glm::vec3 position(static_cast<float>(i));
-    glm::quat rotation(static_cast<float>(i) / 5.0f, 0.0f, 0.0f, 1.0f);
+  for (i32 i = 1; i < 3; ++i) {
+    glm::vec3 position(static_cast<f32>(i));
+    glm::quat rotation(static_cast<f32>(i) / 5.0f, 0.0f, 0.0f, 1.0f);
     glm::vec3 scale = position;
 
     quoll::PrefabComponent<quoll::PrefabTransformData> transform{};
@@ -71,9 +71,9 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Create transforms that point to previous parent
-  for (int32_t i = 3; i < 5; ++i) {
-    glm::vec3 position(static_cast<float>(i));
-    glm::quat rotation(static_cast<float>(i) / 5.0f, 0.0f, 0.0f, 1.0f);
+  for (i32 i = 3; i < 5; ++i) {
+    glm::vec3 position(static_cast<f32>(i));
+    glm::quat rotation(static_cast<f32>(i) / 5.0f, 0.0f, 0.0f, 1.0f);
     glm::vec3 scale = position;
 
     quoll::PrefabComponent<quoll::PrefabTransformData> transform{};
@@ -86,7 +86,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Create two meshes
-  for (uint32_t i = 0; i < 2; ++i) {
+  for (u32 i = 0; i < 2; ++i) {
     quoll::AssetData<quoll::MeshAsset> meshAsset{};
     meshAsset.type = quoll::AssetType::Mesh;
 
@@ -97,7 +97,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Create two mesh renderers with 3 materials each
-  for (uint32_t i = 0; i < 2; ++i) {
+  for (u32 i = 0; i < 2; ++i) {
     quoll::PrefabComponent<quoll::MeshRenderer> renderer{};
     renderer.entity = i;
     renderer.value.materials.push_back(quoll::MaterialAssetHandle{1});
@@ -107,7 +107,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Create three skinned mesh renderers with 2 materials each
-  for (uint32_t i = 0; i < 3; ++i) {
+  for (u32 i = 0; i < 3; ++i) {
     quoll::PrefabComponent<quoll::SkinnedMeshRenderer> renderer{};
     renderer.entity = i;
     renderer.value.materials.push_back(quoll::MaterialAssetHandle{1});
@@ -116,7 +116,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Create names
-  for (uint32_t i = 3; i < 5; ++i) {
+  for (u32 i = 3; i < 5; ++i) {
     quoll::PrefabComponent<quoll::String> name{};
     name.entity = i;
     name.value = "Test name " + std::to_string(i);
@@ -124,7 +124,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Create three skinned meshes
-  for (uint32_t i = 2; i < 5; ++i) {
+  for (u32 i = 2; i < 5; ++i) {
     quoll::AssetData<quoll::MeshAsset> meshAsset{};
     meshAsset.type = quoll::AssetType::SkinnedMesh;
 
@@ -135,21 +135,21 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // create skeletons for skinned meshes
-  for (uint32_t i = 2; i < 5; ++i) {
+  for (u32 i = 2; i < 5; ++i) {
     quoll::PrefabComponent<quoll::SkeletonAssetHandle> skeleton{};
     skeleton.entity = i;
     skeleton.value = assetRegistry.getSkeletons().addAsset({});
     asset.data.skeletons.push_back(skeleton);
   }
 
-  for (uint32_t i = 2; i < 5; ++i) {
+  for (u32 i = 2; i < 5; ++i) {
     quoll::AnimationAssetHandle animation{i};
     asset.data.animations.push_back(animation);
   }
 
   // create animators for skinned meshes
   // also create one additional animator
-  for (uint32_t i = 2; i < 5; ++i) {
+  for (u32 i = 2; i < 5; ++i) {
     quoll::AssetData<quoll::AnimatorAsset> animatorAsset{};
     animatorAsset.data.initialState = i;
     auto handle = assetRegistry.getAnimators().addAsset(animatorAsset);
@@ -161,7 +161,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Create two directional lights
-  for (uint32_t i = 1; i < 3; ++i) {
+  for (u32 i = 1; i < 3; ++i) {
     quoll::PrefabComponent<quoll::DirectionalLight> light{};
     light.entity = i;
     light.value.intensity = 25.0f;
@@ -169,7 +169,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Create two point lights
-  for (uint32_t i = 3; i < 5; ++i) {
+  for (u32 i = 3; i < 5; ++i) {
     quoll::PrefabComponent<quoll::PointLight> light{};
     light.entity = i;
     light.value.range = 25.0f;
@@ -193,13 +193,13 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   EXPECT_EQ(db.get<quoll::Children>(res.at(0)).children.at(1), res.at(2));
 
   // Second and third items have first entity as parent
-  for (uint32_t i = 1; i < 3; ++i) {
+  for (u32 i = 1; i < 3; ++i) {
     auto current = res.at(i);
     EXPECT_TRUE(db.has<quoll::Parent>(current));
     EXPECT_EQ(db.get<quoll::Parent>(current).parent, res.at(0));
   }
 
-  for (uint32_t i = 3; i < 5; ++i) {
+  for (u32 i = 3; i < 5; ++i) {
     auto current = res.at(i);
     auto parent = res.at(i - 1);
     // All transform items have parent that is the previous item
@@ -217,7 +217,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
             transform.localPosition);
   EXPECT_TRUE(db.has<quoll::WorldTransform>(res.at(0)));
 
-  for (uint32_t i = 1; i < 5; ++i) {
+  for (u32 i = 1; i < 5; ++i) {
     auto entity = res.at(i);
 
     const auto &transform = db.get<quoll::LocalTransform>(entity);
@@ -231,14 +231,14 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   // Test names
 
   // First three items have names with Untitled
-  for (uint32_t i = 0; i < 3; ++i) {
+  for (u32 i = 0; i < 3; ++i) {
     auto entity = res.at(i);
     const auto &name = db.get<quoll::Name>(entity);
 
     EXPECT_EQ(name.name, "New entity");
   }
 
-  for (uint32_t i = 3; i < 5; ++i) {
+  for (u32 i = 3; i < 5; ++i) {
     auto entity = res.at(i);
     const auto &name = db.get<quoll::Name>(entity);
 
@@ -246,7 +246,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Test meshes
-  for (uint32_t i = 0; i < 2; ++i) {
+  for (u32 i = 0; i < 2; ++i) {
     auto entity = res.at(i);
 
     const auto &mesh = db.get<quoll::Mesh>(entity);
@@ -254,7 +254,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Test skinned meshes
-  for (uint32_t i = 2; i < 5; ++i) {
+  for (u32 i = 2; i < 5; ++i) {
     auto entity = res.at(i);
 
     const auto &mesh = db.get<quoll::SkinnedMesh>(entity);
@@ -262,29 +262,29 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Test mesh renderers
-  for (uint32_t i = 0; i < 2; ++i) {
+  for (u32 i = 0; i < 2; ++i) {
     auto entity = res.at(i);
     const auto &renderer = db.get<quoll::MeshRenderer>(entity);
 
-    for (size_t mi = 0; mi < renderer.materials.size(); ++mi) {
+    for (usize mi = 0; mi < renderer.materials.size(); ++mi) {
       EXPECT_EQ(renderer.materials.at(mi),
                 static_cast<quoll::MaterialAssetHandle>(mi + 1));
     }
   }
 
   // Test skinned mesh renderer
-  for (uint32_t i = 0; i < 3; ++i) {
+  for (u32 i = 0; i < 3; ++i) {
     auto entity = res.at(i);
     const auto &renderer = db.get<quoll::SkinnedMeshRenderer>(entity);
 
-    for (size_t mi = 0; mi < renderer.materials.size(); ++mi) {
+    for (usize mi = 0; mi < renderer.materials.size(); ++mi) {
       EXPECT_EQ(renderer.materials.at(mi),
                 static_cast<quoll::MaterialAssetHandle>(mi + 1));
     }
   }
 
   // Test skeletons
-  for (uint32_t i = 2; i < 5; ++i) {
+  for (u32 i = 2; i < 5; ++i) {
     auto entity = res.at(i);
 
     const auto &skeleton = db.get<quoll::Skeleton>(entity);
@@ -294,7 +294,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   }
 
   // Test animators
-  for (uint32_t i = 2; i < 5; ++i) {
+  for (u32 i = 2; i < 5; ++i) {
     auto entity = res.at(i);
     const auto &animator = db.get<quoll::Animator>(entity);
     EXPECT_NE(animator.asset, quoll::AnimatorAssetHandle::Null);
@@ -305,13 +305,13 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
     EXPECT_EQ(animator.normalizedTime, 0.0f);
   }
 
-  for (uint32_t i = 1; i < 3; ++i) {
+  for (u32 i = 1; i < 3; ++i) {
     auto entity = res.at(i);
     const auto &light = db.get<quoll::DirectionalLight>(entity);
     EXPECT_EQ(light.intensity, 25.0f);
   }
 
-  for (uint32_t i = 3; i < 5; ++i) {
+  for (u32 i = 3; i < 5; ++i) {
     auto entity = res.at(i);
     const auto &light = db.get<quoll::PointLight>(entity);
     EXPECT_EQ(light.range, 25.0f);
@@ -383,7 +383,7 @@ TEST_F(
 
   auto children = db.get<quoll::Children>(root).children;
   EXPECT_EQ(children.size(), 2);
-  for (size_t i = 0; i < children.size(); ++i) {
+  for (usize i = 0; i < children.size(); ++i) {
     auto entity = res.at(i);
     EXPECT_EQ(children.at(i), entity);
     EXPECT_EQ(db.get<quoll::Parent>(entity).parent, root);
@@ -393,9 +393,9 @@ TEST_F(
 TEST_F(EntitySpawnerTest,
        SpawnPrefabCreatesSingleEntityIfPrefabHasOneRootEntity) {
   quoll::AssetData<quoll::PrefabAsset> asset{};
-  for (int32_t i = 0; i < 2; ++i) {
-    glm::vec3 position(static_cast<float>(i));
-    glm::quat rotation(static_cast<float>(i) / 5.0f, 0.0f, 0.0f, 1.0f);
+  for (i32 i = 0; i < 2; ++i) {
+    glm::vec3 position(static_cast<f32>(i));
+    glm::quat rotation(static_cast<f32>(i) / 5.0f, 0.0f, 0.0f, 1.0f);
     glm::vec3 scale = position;
 
     quoll::PrefabComponent<quoll::PrefabTransformData> transform{};

--- a/engine/tests/quoll-tests/entity/EntityStorageSparseSet.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntityStorageSparseSet.test.cpp
@@ -6,7 +6,7 @@
 
 struct Component1 {
   int intValue;
-  float realValue;
+  f32 realValue;
 };
 
 struct Component2 {
@@ -19,7 +19,7 @@ struct IntComponent {
 };
 
 struct FloatComponent {
-  float value;
+  f32 value;
 };
 
 struct StringComponent {
@@ -512,7 +512,7 @@ TEST(EntityStorageSparseSetTest,
       Pair{e1, 10, "e1"}, {e3, 30, "e3"}, {e2, 20, "e2"}, {e4, 40, "e4"}};
 
   {
-    size_t index = 0;
+    usize index = 0;
     EXPECT_EQ(observer1.size(), 4);
     for (auto [entity, component] : observer1) {
       EXPECT_EQ(entity, orderedExpectation.at(index).entity);
@@ -523,7 +523,7 @@ TEST(EntityStorageSparseSetTest,
   }
 
   {
-    size_t index = 0;
+    usize index = 0;
     EXPECT_EQ(observer2.size(), 1);
     for (auto [entity, component] : observer2) {
       EXPECT_EQ(entity, orderedExpectation.at(index).entity);
@@ -535,7 +535,7 @@ TEST(EntityStorageSparseSetTest,
   }
 
   {
-    size_t index = 2;
+    usize index = 2;
     EXPECT_EQ(observer3.size(), 2);
     for (auto [entity, component] : observer3) {
       EXPECT_EQ(entity, orderedExpectation.at(index).entity);
@@ -590,7 +590,7 @@ TEST(EntityStorageSparseSetTest, DeletingEntitiesTriggersRemoveObservers) {
   storage.deleteEntity(e3);
 
   {
-    size_t index = 0;
+    usize index = 0;
     EXPECT_EQ(observer1.size(), 4);
     for (auto [entity, component] : observer1) {
       EXPECT_EQ(entity, orderedExpectation.at(index).entity);
@@ -602,7 +602,7 @@ TEST(EntityStorageSparseSetTest, DeletingEntitiesTriggersRemoveObservers) {
   }
 
   {
-    size_t index = 0;
+    usize index = 0;
     EXPECT_EQ(observer2.size(), 4);
     for (auto [entity, component] : observer2) {
       EXPECT_EQ(entity, orderedExpectation.at(index).entity);
@@ -614,7 +614,7 @@ TEST(EntityStorageSparseSetTest, DeletingEntitiesTriggersRemoveObservers) {
   }
 
   {
-    size_t index = 2;
+    usize index = 2;
     EXPECT_EQ(observer3.size(), 2);
     for (auto [entity, component] : observer3) {
       EXPECT_EQ(entity, orderedExpectation.at(index).entity);
@@ -655,7 +655,7 @@ TEST(EntityStorageSparseSetTest, ClearingObserverClearsAllExistingData) {
 
   {
     EXPECT_EQ(observer1.size(), 2);
-    size_t index = 0;
+    usize index = 0;
     for (auto [entity, component] : observer1) {
       EXPECT_EQ(entity, orderedExpectation.at(index).entity);
       EXPECT_EQ(component.value, orderedExpectation.at(index).value);
@@ -672,7 +672,7 @@ TEST(EntityStorageSparseSetTest, ClearingObserverClearsAllExistingData) {
 
   {
     EXPECT_EQ(observer1.size(), 2);
-    size_t index = 2;
+    usize index = 2;
     for (auto [entity, component] : observer1) {
       EXPECT_EQ(entity, orderedExpectation.at(index).entity);
       EXPECT_EQ(component.value, orderedExpectation.at(index).value);

--- a/engine/tests/quoll-tests/input/InputMapLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/input/InputMapLuaTable.test.cpp
@@ -6,7 +6,7 @@
 class InputMapLuaTableTest : public LuaScriptingInterfaceTestBase {
 public:
   quoll::Entity createEntityWithInputMap(bool value = false,
-                                         size_t defaultScheme = 0) {
+                                         usize defaultScheme = 0) {
     auto entity = entityDatabase.create();
 
     quoll::InputMap map{};
@@ -44,7 +44,7 @@ TEST_F(InputMapLuaTableTest, GetCommandReturnsCommandIndex) {
   auto state = call(entity, "input_get_command");
 
   EXPECT_FALSE(state["input_command"].is<sol::nil_t>());
-  EXPECT_EQ(state["input_command"].get<uint32_t>(), 1);
+  EXPECT_EQ(state["input_command"].get<u32>(), 1);
 }
 
 TEST_F(InputMapLuaTableTest, GetCommandReturnsNilIfEntityHasNoInputMap) {
@@ -117,8 +117,8 @@ TEST_F(InputMapLuaTableTest, GetCommandValueAxis2dReturnsVec2Value) {
   EXPECT_FALSE(state["input_command_value_x"].is<sol::nil_t>());
   EXPECT_FALSE(state["input_command_value_y"].is<sol::nil_t>());
 
-  EXPECT_EQ(state["input_command_value_x"].get<float>(), 0.2f);
-  EXPECT_EQ(state["input_command_value_y"].get<float>(), -0.3f);
+  EXPECT_EQ(state["input_command_value_x"].get<f32>(), 0.2f);
+  EXPECT_EQ(state["input_command_value_y"].get<f32>(), -0.3f);
 }
 
 TEST_F(InputMapLuaTableTest,
@@ -129,8 +129,8 @@ TEST_F(InputMapLuaTableTest,
   EXPECT_FALSE(state["input_command_value_x"].is<sol::nil_t>());
   EXPECT_FALSE(state["input_command_value_y"].is<sol::nil_t>());
 
-  EXPECT_EQ(state["input_command_value_x"].get<float>(), 0.0f);
-  EXPECT_EQ(state["input_command_value_y"].get<float>(), 0.0f);
+  EXPECT_EQ(state["input_command_value_x"].get<f32>(), 0.0f);
+  EXPECT_EQ(state["input_command_value_y"].get<f32>(), 0.0f);
 }
 
 TEST_F(InputMapLuaTableTest,
@@ -141,8 +141,8 @@ TEST_F(InputMapLuaTableTest,
   EXPECT_FALSE(state["input_command_value_x"].is<sol::nil_t>());
   EXPECT_FALSE(state["input_command_value_y"].is<sol::nil_t>());
 
-  EXPECT_EQ(state["input_command_value_x"].get<float>(), 1.0f);
-  EXPECT_EQ(state["input_command_value_y"].get<float>(), 1.0f);
+  EXPECT_EQ(state["input_command_value_x"].get<f32>(), 1.0f);
+  EXPECT_EQ(state["input_command_value_y"].get<f32>(), 1.0f);
 }
 
 TEST_F(InputMapLuaTableTest,

--- a/engine/tests/quoll-tests/input/InputMapSystem.test.cpp
+++ b/engine/tests/quoll-tests/input/InputMapSystem.test.cpp
@@ -24,7 +24,7 @@ public:
     inputStates.insert_or_assign(key, value);
   }
 
-  void setInputState(int key, float value) {
+  void setInputState(int key, f32 value) {
     inputStates.insert_or_assign(key, value);
   }
 

--- a/engine/tests/quoll-tests/physics/CollidableLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/physics/CollidableLuaTable.test.cpp
@@ -50,7 +50,7 @@ TEST_F(CollidableLuaTableTest,
   entityDatabase.set(entity, collidable);
 
   auto state = call(entity, "collidable_get_static_friction");
-  EXPECT_EQ(state["static_friction"].get<float>(), 2.5f);
+  EXPECT_EQ(state["static_friction"].get<f32>(), 2.5f);
 }
 
 // Set static friction
@@ -101,7 +101,7 @@ TEST_F(CollidableLuaTableTest,
   entityDatabase.set(entity, collidable);
 
   auto state = call(entity, "collidable_get_dynamic_friction");
-  EXPECT_EQ(state["dynamic_friction"].get<float>(), 2.5f);
+  EXPECT_EQ(state["dynamic_friction"].get<f32>(), 2.5f);
 }
 
 // Set dynamic friction
@@ -151,7 +151,7 @@ TEST_F(CollidableLuaTableTest, GetRestitutionReturnsCollidableRestitution) {
   entityDatabase.set(entity, collidable);
 
   auto state = call(entity, "collidable_get_restitution");
-  EXPECT_EQ(state["restitution"].get<float>(), 2.5f);
+  EXPECT_EQ(state["restitution"].get<f32>(), 2.5f);
 }
 
 // Set restitution

--- a/engine/tests/quoll-tests/physics/RigidBodyLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/physics/RigidBodyLuaTable.test.cpp
@@ -28,7 +28,7 @@ TEST_F(RigidBodyLuaTableTest, GetMassReturnsRigidBodyMass) {
   entityDatabase.set(entity, rigidBody);
 
   auto state = call(entity, "rigid_body_get_mass");
-  EXPECT_EQ(state["mass"].get<float>(), 2.5f);
+  EXPECT_EQ(state["mass"].get<f32>(), 2.5f);
 }
 
 TEST_F(RigidBodyLuaTableTest, SetMassCreatesRigidBodyIfItDoesNotExist) {
@@ -71,9 +71,9 @@ TEST_F(RigidBodyLuaTableTest, GetInertiaReturnsRigidBodyInertia) {
   entityDatabase.set(entity, rigidBody);
 
   auto state = call(entity, "rigid_body_get_inertia");
-  EXPECT_EQ(state["inertia_x"].get<float>(), 2.5f);
-  EXPECT_EQ(state["inertia_y"].get<float>(), 2.5f);
-  EXPECT_EQ(state["inertia_z"].get<float>(), 2.5f);
+  EXPECT_EQ(state["inertia_x"].get<f32>(), 2.5f);
+  EXPECT_EQ(state["inertia_y"].get<f32>(), 2.5f);
+  EXPECT_EQ(state["inertia_z"].get<f32>(), 2.5f);
 }
 
 TEST_F(RigidBodyLuaTableTest, SetInertiaCreatesRigidBodyIfItDoesNotExist) {

--- a/engine/tests/quoll-tests/renderer/Material.test.cpp
+++ b/engine/tests/quoll-tests/renderer/Material.test.cpp
@@ -59,7 +59,7 @@ TEST_F(MaterialTest, DoesNotSetTexturesIfNoTexture) {
 
 TEST_F(MaterialTest, DoesNotUpdatePropertyIfPropertyDoesNotExist) {
   glm::vec3 testVec3{1.0f, 0.2f, 3.6f};
-  float testReal = 45.0f;
+  f32 testReal = 45.0f;
 
   quoll::Material material("test", {},
                            {
@@ -72,14 +72,14 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfPropertyDoesNotExist) {
   {
     EXPECT_EQ(properties.size(), 2);
     EXPECT_TRUE(properties.at(0).getValue<glm::vec3>() == testVec3);
-    EXPECT_TRUE(properties.at(1).getValue<float>() == testReal);
+    EXPECT_TRUE(properties.at(1).getValue<f32>() == testReal);
 
     auto *buffer = device.getBuffer(material.getBuffer());
     const char *data = static_cast<const char *>(buffer->map());
 
     EXPECT_EQ(buffer->getDescription().size, sizeof(glm::vec3) * 2);
     EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == testVec3);
-    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const f32 *>(data + sizeof(glm::vec3)) ==
                 testReal);
   }
 
@@ -88,21 +88,21 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfPropertyDoesNotExist) {
   {
     EXPECT_EQ(properties.size(), 2);
     EXPECT_TRUE(properties.at(0).getValue<glm::vec3>() == testVec3);
-    EXPECT_TRUE(properties.at(1).getValue<float>() == testReal);
+    EXPECT_TRUE(properties.at(1).getValue<f32>() == testReal);
 
     auto *buffer = device.getBuffer(material.getBuffer());
     const char *data = static_cast<const char *>(buffer->map());
 
     EXPECT_EQ(buffer->getDescription().size, sizeof(glm::vec3) * 2);
     EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == testVec3);
-    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const f32 *>(data + sizeof(glm::vec3)) ==
                 testReal);
   }
 }
 
 TEST_F(MaterialTest, DoesNotUpdatePropertyIfNewPropertyTypeIsDifferent) {
   glm::vec3 testVec3{1.0f, 0.2f, 3.6f};
-  float testReal = 45.0f;
+  f32 testReal = 45.0f;
 
   quoll::Material material("test", {},
                            {
@@ -115,14 +115,14 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfNewPropertyTypeIsDifferent) {
   {
     EXPECT_EQ(properties.size(), 2);
     EXPECT_TRUE(properties.at(0).getValue<glm::vec3>() == testVec3);
-    EXPECT_TRUE(properties.at(1).getValue<float>() == testReal);
+    EXPECT_TRUE(properties.at(1).getValue<f32>() == testReal);
 
     auto *buffer = device.getBuffer(material.getBuffer());
     const char *data = static_cast<const char *>(buffer->map());
 
     EXPECT_EQ(buffer->getDescription().size, sizeof(glm::vec3) * 2);
     EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == testVec3);
-    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const f32 *>(data + sizeof(glm::vec3)) ==
                 testReal);
   }
 
@@ -131,21 +131,21 @@ TEST_F(MaterialTest, DoesNotUpdatePropertyIfNewPropertyTypeIsDifferent) {
   {
     EXPECT_EQ(properties.size(), 2);
     EXPECT_TRUE(properties.at(0).getValue<glm::vec3>() == testVec3);
-    EXPECT_TRUE(properties.at(1).getValue<float>() == testReal);
+    EXPECT_TRUE(properties.at(1).getValue<f32>() == testReal);
 
     auto *buffer = device.getBuffer(material.getBuffer());
     const char *data = static_cast<const char *>(buffer->map());
 
     EXPECT_EQ(buffer->getDescription().size, sizeof(glm::vec3) * 2);
     EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == testVec3);
-    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const f32 *>(data + sizeof(glm::vec3)) ==
                 testReal);
   }
 }
 
 TEST_F(MaterialTest, UpdatesPropertyIfNameAndTypeMatch) {
   glm::vec3 testVec3{1.0f, 0.2f, 3.6f};
-  float testReal = 45.0f;
+  f32 testReal = 45.0f;
 
   quoll::Material material("test", {},
                            {
@@ -158,33 +158,33 @@ TEST_F(MaterialTest, UpdatesPropertyIfNameAndTypeMatch) {
   {
     EXPECT_EQ(properties.size(), 2);
     EXPECT_TRUE(properties.at(0).getValue<glm::vec3>() == testVec3);
-    EXPECT_TRUE(properties.at(1).getValue<float>() == testReal);
+    EXPECT_TRUE(properties.at(1).getValue<f32>() == testReal);
 
     auto *buffer = device.getBuffer(material.getBuffer());
     const char *data = static_cast<const char *>(buffer->map());
 
     EXPECT_EQ(buffer->getDescription().size, sizeof(glm::vec3) * 2);
     EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == testVec3);
-    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const f32 *>(data + sizeof(glm::vec3)) ==
                 testReal);
   }
 
   glm::vec3 newTestVec3{2.6, 0.1, 5.3};
-  float newTestReal = 78.2f;
+  f32 newTestReal = 78.2f;
   material.updateProperty("specular", quoll::Property(newTestVec3));
   material.updateProperty("diffuse", quoll::Property(newTestReal));
 
   {
     EXPECT_EQ(properties.size(), 2);
     EXPECT_TRUE(properties.at(0).getValue<glm::vec3>() == newTestVec3);
-    EXPECT_TRUE(properties.at(1).getValue<float>() == newTestReal);
+    EXPECT_TRUE(properties.at(1).getValue<f32>() == newTestReal);
 
     auto *buffer = device.getBuffer(material.getBuffer());
     const char *data = static_cast<const char *>(buffer->map());
 
     EXPECT_EQ(buffer->getDescription().size, sizeof(glm::vec3) * 2);
     EXPECT_TRUE(*reinterpret_cast<const glm::vec3 *>(data) == newTestVec3);
-    EXPECT_TRUE(*reinterpret_cast<const float *>(data + sizeof(glm::vec3)) ==
+    EXPECT_TRUE(*reinterpret_cast<const f32 *>(data + sizeof(glm::vec3)) ==
                 newTestReal);
   }
 }

--- a/engine/tests/quoll-tests/renderer/MaterialPBR.test.cpp
+++ b/engine/tests/quoll-tests/renderer/MaterialPBR.test.cpp
@@ -69,52 +69,52 @@ TEST_F(MaterialPBRTest, GetsProperties) {
   EXPECT_EQ(properties.getProperties()[idx].first, key);                       \
   EXPECT_TRUE(properties.getProperties()[idx].second.getValue<type>() == value);
 
-  EXPECT_PROP_EQ(0, "baseColorTexture", uint32_t, 0);
+  EXPECT_PROP_EQ(0, "baseColorTexture", u32, 0);
   EXPECT_PROP_EQ(1, "baseColorTextureCoord", int, 0);
   EXPECT_PROP_EQ(2, "baseColorFactor", glm::vec4,
                  glm::vec4(1.0, 0.2, 0.3, 0.4));
 
-  EXPECT_PROP_EQ(3, "metallicRoughnessTexture", uint32_t, 0);
+  EXPECT_PROP_EQ(3, "metallicRoughnessTexture", u32, 0);
   EXPECT_PROP_EQ(4, "metallicRoughnessTextureCoord", int, 0);
-  EXPECT_PROP_EQ(5, "metallicFactor", float, 0.2f);
-  EXPECT_PROP_EQ(6, "roughnessFactor", float, 0.6f);
+  EXPECT_PROP_EQ(5, "metallicFactor", f32, 0.2f);
+  EXPECT_PROP_EQ(6, "roughnessFactor", f32, 0.6f);
 
-  EXPECT_PROP_EQ(7, "normalTexture", uint32_t, 0);
+  EXPECT_PROP_EQ(7, "normalTexture", u32, 0);
   EXPECT_PROP_EQ(8, "normalTextureCoord", int, 1);
-  EXPECT_PROP_EQ(9, "normalScale", float, 0.7f);
+  EXPECT_PROP_EQ(9, "normalScale", f32, 0.7f);
 
-  EXPECT_PROP_EQ(10, "occlusionTexture", uint32_t, 0);
+  EXPECT_PROP_EQ(10, "occlusionTexture", u32, 0);
   EXPECT_PROP_EQ(11, "occlusionTextureCoord", int, 0);
-  EXPECT_PROP_EQ(12, "occlusionStrength", float, 0.3f);
+  EXPECT_PROP_EQ(12, "occlusionStrength", f32, 0.3f);
 
-  EXPECT_PROP_EQ(13, "emissiveTexture", uint32_t, 0);
+  EXPECT_PROP_EQ(13, "emissiveTexture", u32, 0);
   EXPECT_PROP_EQ(14, "emissiveTextureCoord", int, 0);
   EXPECT_PROP_EQ(15, "emissiveFactor", glm::vec3, glm::vec3(1.0, 0.2, 0.4));
 
   properties.baseColorTexture = quoll::rhi::TextureHandle(1);
-  EXPECT_PROP_EQ(0, "baseColorTexture", uint32_t, 1);
+  EXPECT_PROP_EQ(0, "baseColorTexture", u32, 1);
 
   properties.normalTexture = quoll::rhi::TextureHandle(2);
-  EXPECT_PROP_EQ(0, "baseColorTexture", uint32_t, 1);
-  EXPECT_PROP_EQ(7, "normalTexture", uint32_t, 2);
+  EXPECT_PROP_EQ(0, "baseColorTexture", u32, 1);
+  EXPECT_PROP_EQ(7, "normalTexture", u32, 2);
 
   properties.occlusionTexture = quoll::rhi::TextureHandle(3);
-  EXPECT_PROP_EQ(0, "baseColorTexture", uint32_t, 1);
-  EXPECT_PROP_EQ(7, "normalTexture", uint32_t, 2);
-  EXPECT_PROP_EQ(10, "occlusionTexture", uint32_t, 3);
+  EXPECT_PROP_EQ(0, "baseColorTexture", u32, 1);
+  EXPECT_PROP_EQ(7, "normalTexture", u32, 2);
+  EXPECT_PROP_EQ(10, "occlusionTexture", u32, 3);
 
   properties.metallicRoughnessTexture = quoll::rhi::TextureHandle(4);
-  EXPECT_PROP_EQ(0, "baseColorTexture", uint32_t, 1);
-  EXPECT_PROP_EQ(3, "metallicRoughnessTexture", uint32_t, 4);
-  EXPECT_PROP_EQ(7, "normalTexture", uint32_t, 2);
-  EXPECT_PROP_EQ(10, "occlusionTexture", uint32_t, 3);
+  EXPECT_PROP_EQ(0, "baseColorTexture", u32, 1);
+  EXPECT_PROP_EQ(3, "metallicRoughnessTexture", u32, 4);
+  EXPECT_PROP_EQ(7, "normalTexture", u32, 2);
+  EXPECT_PROP_EQ(10, "occlusionTexture", u32, 3);
 
   properties.emissiveTexture = quoll::rhi::TextureHandle(5);
-  EXPECT_PROP_EQ(0, "baseColorTexture", uint32_t, 1);
-  EXPECT_PROP_EQ(3, "metallicRoughnessTexture", uint32_t, 4);
-  EXPECT_PROP_EQ(7, "normalTexture", uint32_t, 2);
-  EXPECT_PROP_EQ(10, "occlusionTexture", uint32_t, 3);
-  EXPECT_PROP_EQ(13, "emissiveTexture", uint32_t, 5);
+  EXPECT_PROP_EQ(0, "baseColorTexture", u32, 1);
+  EXPECT_PROP_EQ(3, "metallicRoughnessTexture", u32, 4);
+  EXPECT_PROP_EQ(7, "normalTexture", u32, 2);
+  EXPECT_PROP_EQ(10, "occlusionTexture", u32, 3);
+  EXPECT_PROP_EQ(13, "emissiveTexture", u32, 5);
 
 #undef EXPECT_PROP_EQ
 }

--- a/engine/tests/quoll-tests/scene/PerpesctiveLensLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/scene/PerpesctiveLensLuaTable.test.cpp
@@ -34,15 +34,15 @@ TEST_F(PerspectiveLensLuaTableTest, GetReturnsComponentValues) {
 
   auto state = call(entity, "perspective_lens_get");
 
-  EXPECT_EQ(state["pr_near"].get<float>(), lens.near);
-  EXPECT_EQ(state["pr_far"].get<float>(), lens.far);
-  EXPECT_EQ(state["pr_sensor_width"].get<float>(), lens.sensorSize.x);
-  EXPECT_EQ(state["pr_sensor_height"].get<float>(), lens.sensorSize.y);
-  EXPECT_EQ(state["pr_focal_length"].get<float>(), lens.focalLength);
-  EXPECT_EQ(state["pr_aperture"].get<float>(), lens.aperture);
-  EXPECT_FLOAT_EQ(state["pr_shutter_speed"].get<float>(),
+  EXPECT_EQ(state["pr_near"].get<f32>(), lens.near);
+  EXPECT_EQ(state["pr_far"].get<f32>(), lens.far);
+  EXPECT_EQ(state["pr_sensor_width"].get<f32>(), lens.sensorSize.x);
+  EXPECT_EQ(state["pr_sensor_height"].get<f32>(), lens.sensorSize.y);
+  EXPECT_EQ(state["pr_focal_length"].get<f32>(), lens.focalLength);
+  EXPECT_EQ(state["pr_aperture"].get<f32>(), lens.aperture);
+  EXPECT_FLOAT_EQ(state["pr_shutter_speed"].get<f32>(),
                   1.0f / lens.shutterSpeed);
-  EXPECT_EQ(state["pr_sensitivity"].get<float>(), lens.sensitivity);
+  EXPECT_EQ(state["pr_sensitivity"].get<f32>(), lens.sensitivity);
 }
 
 TEST_F(PerspectiveLensLuaTableTest, SetCreatesComponentIfItDoesNotExist) {

--- a/engine/tests/quoll-tests/scene/SceneIO.test.cpp
+++ b/engine/tests/quoll-tests/scene/SceneIO.test.cpp
@@ -141,11 +141,11 @@ TEST_F(SceneIOTest, DoesNotCreateEntityFromNodeIfIdAlreadyExists) {
 }
 
 TEST_F(SceneIOTest, LoadsSceneFileWithManyEntities) {
-  static constexpr uint64_t NumEntities = 9;
+  static constexpr u64 NumEntities = 9;
 
   std::vector<YAML::Node> nodes(NumEntities);
 
-  for (uint64_t i = 1; i < NumEntities + 1; ++i) {
+  for (u64 i = 1; i < NumEntities + 1; ++i) {
     YAML::Node node;
     node["id"] = i;
     nodes.push_back(node);
@@ -162,11 +162,11 @@ TEST_F(SceneIOTest, LoadsSceneFileWithManyEntities) {
 }
 
 TEST_F(SceneIOTest, LoadingSetsParentsProperly) {
-  static constexpr uint64_t NumEntities = 9;
+  static constexpr u64 NumEntities = 9;
 
   std::vector<YAML::Node> nodes(NumEntities);
 
-  for (uint64_t i = 1; i < NumEntities + 1; ++i) {
+  for (u64 i = 1; i < NumEntities + 1; ++i) {
     // set parent to next entity
     // to make sure that parent entities
     // are loaded after child ones

--- a/engine/tests/quoll-tests/scene/SceneUpdater.test.cpp
+++ b/engine/tests/quoll-tests/scene/SceneUpdater.test.cpp
@@ -225,7 +225,7 @@ TEST_F(SceneUpdaterTest, UpdatesCameraBasedOnTransformAndPerspectiveLens) {
   auto &lens = entityDatabase.get<quoll::PerspectiveLens>(entity);
   auto &camera = entityDatabase.get<quoll::Camera>(entity);
 
-  float fovY = 2.0f * atanf(lens.sensorSize.y / (2.0f * lens.focalLength));
+  f32 fovY = 2.0f * atanf(lens.sensorSize.y / (2.0f * lens.focalLength));
 
   auto expectedPerspective =
       glm::perspective(fovY, lens.aspectRatio, lens.near, lens.far);

--- a/engine/tests/quoll-tests/scene/SkeletonUpdater.test.cpp
+++ b/engine/tests/quoll-tests/scene/SkeletonUpdater.test.cpp
@@ -9,7 +9,7 @@ struct SkeletonUpdaterTest : public ::testing::Test {
   quoll::SkeletonUpdater skeletonUpdater;
 
   std::tuple<quoll::Skeleton &, quoll::SkeletonDebug &, quoll::Entity>
-  createSkeleton(uint32_t numJoints) {
+  createSkeleton(u32 numJoints) {
     auto entity = entityDatabase.create();
 
     quoll::Skeleton skeleton;
@@ -18,8 +18,8 @@ struct SkeletonUpdaterTest : public ::testing::Test {
     skeleton.jointFinalTransforms.resize(numJoints, glm::mat4{1.0f});
     skeleton.numJoints = numJoints;
 
-    for (uint32_t i = 0; i < numJoints; ++i) {
-      float value = static_cast<float>(i) + 1.2f;
+    for (u32 i = 0; i < numJoints; ++i) {
+      f32 value = static_cast<f32>(i) + 1.2f;
       skeleton.jointLocalPositions.push_back(glm::vec3(value));
       skeleton.jointLocalRotations.push_back(
           glm::quat(value, value, value, value));
@@ -35,7 +35,7 @@ struct SkeletonUpdaterTest : public ::testing::Test {
     auto numBones = skeleton.numJoints * 2;
     skeletonDebug.bones.reserve(numBones);
 
-    for (uint32_t joint = 0; joint < skeleton.numJoints; ++joint) {
+    for (u32 joint = 0; joint < skeleton.numJoints; ++joint) {
       skeletonDebug.bones.push_back(skeleton.jointParents.at(joint));
       skeletonDebug.bones.push_back(joint);
     }
@@ -55,14 +55,14 @@ struct SkeletonUpdaterTest : public ::testing::Test {
     return entityDatabase.get<quoll::SkeletonDebug>(entity);
   }
 
-  glm::mat4 getLocalTransform(quoll::Skeleton &skeleton, uint32_t i) {
+  glm::mat4 getLocalTransform(quoll::Skeleton &skeleton, u32 i) {
     glm::mat4 identity{1.0f};
     return glm::translate(identity, skeleton.jointLocalPositions.at(i)) *
            glm::toMat4(skeleton.jointLocalRotations.at(i)) *
            glm::scale(identity, skeleton.jointLocalScales.at(i));
   };
 
-  template <class T> std::vector<T> createItems(uint32_t numJoints) {
+  template <class T> std::vector<T> createItems(u32 numJoints) {
     return std::vector<T>(numJoints);
   }
 };
@@ -117,7 +117,7 @@ TEST_F(SkeletonUpdaterTest, UpdatesDebugBonesOnUpdate) {
 
   skeletonUpdater.update(entityDatabase);
 
-  for (size_t i = 0; i < skeletonDebug.bones.size(); ++i) {
+  for (usize i = 0; i < skeletonDebug.bones.size(); ++i) {
     EXPECT_EQ(skeletonDebug.boneTransforms.at(i),
               skeleton.jointWorldTransforms.at(skeletonDebug.bones.at(i)));
   }

--- a/engine/tests/quoll-tests/scene/TransformLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/scene/TransformLuaTable.test.cpp
@@ -19,9 +19,9 @@ TEST_F(TransformLuaTableTest, GetsPositionValue) {
 
   auto state = call(entity, "local_transform_position_get");
 
-  EXPECT_EQ(state["local_position_x"].get<float>(), 2.5f);
-  EXPECT_EQ(state["local_position_y"].get<float>(), 0.2f);
-  EXPECT_EQ(state["local_position_z"].get<float>(), 0.5f);
+  EXPECT_EQ(state["local_position_x"].get<f32>(), 2.5f);
+  EXPECT_EQ(state["local_position_y"].get<f32>(), 0.2f);
+  EXPECT_EQ(state["local_position_z"].get<f32>(), 0.5f);
 }
 
 TEST_F(TransformLuaTableDeathTest, SetPositionFailsIfComponentDoesNotExist) {
@@ -52,9 +52,9 @@ TEST_F(TransformLuaTableTest, GetsScaleValue) {
 
   auto state = call(entity, "local_transform_scale_get");
 
-  EXPECT_EQ(state["local_scale_x"].get<float>(), 2.5f);
-  EXPECT_EQ(state["local_scale_y"].get<float>(), 0.2f);
-  EXPECT_EQ(state["local_scale_z"].get<float>(), 0.5f);
+  EXPECT_EQ(state["local_scale_x"].get<f32>(), 2.5f);
+  EXPECT_EQ(state["local_scale_y"].get<f32>(), 0.2f);
+  EXPECT_EQ(state["local_scale_z"].get<f32>(), 0.5f);
 }
 
 TEST_F(TransformLuaTableDeathTest, SetScaleFailsIfComponentDoesNotExist) {
@@ -88,9 +88,9 @@ TEST_F(TransformLuaTableTest, GetRotationReturnsRotationInDegrees) {
 
   auto state = call(entity, "local_transform_rotation_get");
 
-  auto actual = glm::vec3{state["local_rotation_x"].get<float>(),
-                          state["local_rotation_y"].get<float>(),
-                          state["local_rotation_z"].get<float>()};
+  auto actual = glm::vec3{state["local_rotation_x"].get<f32>(),
+                          state["local_rotation_y"].get<f32>(),
+                          state["local_rotation_z"].get<f32>()};
   auto expected = TestEulerDegrees;
 
   EXPECT_NEAR(actual.x, expected.x, 0.0001f);

--- a/engine/tests/quoll-tests/scene/private/EntitySerializer.test.cpp
+++ b/engine/tests/quoll-tests/scene/private/EntitySerializer.test.cpp
@@ -394,7 +394,7 @@ TEST_F(EntitySerializerTest, CreatesJointAttachmentFieldWithJointId) {
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_TRUE(node["jointAttachment"]);
-  EXPECT_EQ(node["jointAttachment"]["joint"].as<uint32_t>(0), 10);
+  EXPECT_EQ(node["jointAttachment"]["joint"].as<u32>(0), 10);
 }
 
 // Animator
@@ -449,8 +449,8 @@ TEST_F(EntitySerializerTest,
 
   EXPECT_TRUE(node["light"]);
   EXPECT_TRUE(node["light"].IsMap());
-  EXPECT_EQ(node["light"]["type"].as<uint32_t>(1000), 0);
-  EXPECT_EQ(node["light"]["intensity"].as<float>(-1.0f), light.intensity);
+  EXPECT_EQ(node["light"]["type"].as<u32>(1000), 0);
+  EXPECT_EQ(node["light"]["intensity"].as<f32>(-1.0f), light.intensity);
   EXPECT_EQ(node["light"]["color"].as<glm::vec4>(glm::vec4{-1.0f}),
             light.color);
   EXPECT_FALSE(node["light"]["direction"]);
@@ -495,9 +495,9 @@ TEST_F(
   EXPECT_TRUE(node["light"]["shadow"].IsMap());
   EXPECT_EQ(node["light"]["shadow"]["softShadows"].as<bool>(true),
             shadow.softShadows);
-  EXPECT_EQ(node["light"]["shadow"]["splitLambda"].as<float>(1.0f),
+  EXPECT_EQ(node["light"]["shadow"]["splitLambda"].as<f32>(1.0f),
             shadow.splitLambda);
-  EXPECT_EQ(node["light"]["shadow"]["numCascades"].as<uint32_t>(0),
+  EXPECT_EQ(node["light"]["shadow"]["numCascades"].as<u32>(0),
             shadow.numCascades);
 }
 
@@ -521,11 +521,11 @@ TEST_F(EntitySerializerTest, CreatesLightFieldIfPointLightComponentExists) {
 
   EXPECT_TRUE(node["light"]);
   EXPECT_TRUE(node["light"].IsMap());
-  EXPECT_EQ(node["light"]["type"].as<uint32_t>(1000), 1);
-  EXPECT_EQ(node["light"]["intensity"].as<float>(-1.0f), light.intensity);
+  EXPECT_EQ(node["light"]["type"].as<u32>(1000), 1);
+  EXPECT_EQ(node["light"]["intensity"].as<f32>(-1.0f), light.intensity);
   EXPECT_EQ(node["light"]["color"].as<glm::vec4>(glm::vec4{-1.0f}),
             light.color);
-  EXPECT_EQ(node["light"]["range"].as<float>(-1.0f), light.range);
+  EXPECT_EQ(node["light"]["range"].as<f32>(-1.0f), light.range);
 }
 
 // Camera
@@ -554,16 +554,16 @@ TEST_F(EntitySerializerTest, CreatesCameraFieldIfLensComponentExists) {
 
   EXPECT_TRUE(node["camera"]);
   EXPECT_TRUE(node["camera"].IsMap());
-  EXPECT_EQ(node["camera"]["type"].as<uint32_t>(1000), 0);
-  EXPECT_EQ(node["camera"]["near"].as<float>(-1.0f), lens.near);
-  EXPECT_EQ(node["camera"]["far"].as<float>(-1.0f), lens.far);
-  EXPECT_EQ(node["camera"]["aspectRatio"].as<float>(-1.0f), lens.aspectRatio);
+  EXPECT_EQ(node["camera"]["type"].as<u32>(1000), 0);
+  EXPECT_EQ(node["camera"]["near"].as<f32>(-1.0f), lens.near);
+  EXPECT_EQ(node["camera"]["far"].as<f32>(-1.0f), lens.far);
+  EXPECT_EQ(node["camera"]["aspectRatio"].as<f32>(-1.0f), lens.aspectRatio);
   EXPECT_EQ(node["camera"]["sensorSize"].as<glm::vec2>(glm::vec2{-1.0f, -1.0f}),
             lens.sensorSize);
-  EXPECT_EQ(node["camera"]["focalLength"].as<float>(-1.0f), lens.focalLength);
-  EXPECT_EQ(node["camera"]["aperture"].as<float>(-1.0f), lens.aperture);
-  EXPECT_EQ(node["camera"]["shutterSpeed"].as<float>(-1.0f), lens.shutterSpeed);
-  EXPECT_EQ(node["camera"]["sensitivity"].as<float>(-1.0f), lens.sensitivity);
+  EXPECT_EQ(node["camera"]["focalLength"].as<f32>(-1.0f), lens.focalLength);
+  EXPECT_EQ(node["camera"]["aperture"].as<f32>(-1.0f), lens.aperture);
+  EXPECT_EQ(node["camera"]["shutterSpeed"].as<f32>(-1.0f), lens.shutterSpeed);
+  EXPECT_EQ(node["camera"]["sensitivity"].as<f32>(-1.0f), lens.sensitivity);
 }
 
 TEST_F(EntitySerializerTest,
@@ -747,7 +747,7 @@ TEST_F(EntitySerializerTest,
   EXPECT_TRUE(node["text"]);
   EXPECT_TRUE(node["text"].IsMap());
   EXPECT_EQ(node["text"]["content"].as<quoll::String>(""), "Hello world");
-  EXPECT_EQ(node["text"]["lineHeight"].as<float>(-1.0f), component.lineHeight);
+  EXPECT_EQ(node["text"]["lineHeight"].as<f32>(-1.0f), component.lineHeight);
   EXPECT_EQ(node["text"]["font"].as<quoll::String>(""), "Roboto.ttf");
 }
 
@@ -776,7 +776,7 @@ TEST_F(EntitySerializerTest, CreatesRigidBodyFieldIfRigidBodyComponentExists) {
             rigidBodyDesc.applyGravity);
   EXPECT_EQ(node["rigidBody"]["inertia"].as<glm::vec3>(),
             rigidBodyDesc.inertia);
-  EXPECT_EQ(node["rigidBody"]["mass"].as<float>(), rigidBodyDesc.mass);
+  EXPECT_EQ(node["rigidBody"]["mass"].as<f32>(), rigidBodyDesc.mass);
 }
 
 // Collidable
@@ -829,7 +829,7 @@ TEST_F(EntitySerializerTest, CreatesCollidableFieldForSphereGeometry) {
   EXPECT_EQ(node["collidable"]["shape"].as<quoll::String>(""), "sphere");
   EXPECT_EQ(node["collidable"]["center"].as<glm::vec3>(glm::vec3(0.0f)),
             geometryDesc.center);
-  EXPECT_EQ(node["collidable"]["radius"].as<float>(0.0f), sphereParams.radius);
+  EXPECT_EQ(node["collidable"]["radius"].as<f32>(0.0f), sphereParams.radius);
   EXPECT_EQ(node["collidable"]["useInSimulation"].as<bool>(false), true);
   EXPECT_EQ(node["collidable"]["useInQueries"].as<bool>(false), true);
 }
@@ -852,8 +852,8 @@ TEST_F(EntitySerializerTest, CreatesCollidableFieldForCapsuleGeometry) {
   EXPECT_EQ(node["collidable"]["shape"].as<quoll::String>(""), "capsule");
   EXPECT_EQ(node["collidable"]["center"].as<glm::vec3>(glm::vec3(0.0f)),
             geometryDesc.center);
-  EXPECT_EQ(node["collidable"]["radius"].as<float>(0.0f), capsuleParams.radius);
-  EXPECT_EQ(node["collidable"]["halfHeight"].as<float>(0.0f),
+  EXPECT_EQ(node["collidable"]["radius"].as<f32>(0.0f), capsuleParams.radius);
+  EXPECT_EQ(node["collidable"]["halfHeight"].as<f32>(0.0f),
             capsuleParams.halfHeight);
   EXPECT_EQ(node["collidable"]["useInSimulation"].as<bool>(false), true);
   EXPECT_EQ(node["collidable"]["useInQueries"].as<bool>(false), true);
@@ -891,11 +891,11 @@ TEST_F(EntitySerializerTest, CreatesCollidableFieldMaterialData) {
   auto node = entitySerializer.createComponentsNode(entity);
 
   EXPECT_TRUE(node["collidable"]);
-  EXPECT_EQ(node["collidable"]["dynamicFriction"].as<float>(0.0f),
+  EXPECT_EQ(node["collidable"]["dynamicFriction"].as<f32>(0.0f),
             materialDesc.dynamicFriction);
-  EXPECT_EQ(node["collidable"]["restitution"].as<float>(0.0f),
+  EXPECT_EQ(node["collidable"]["restitution"].as<f32>(0.0f),
             materialDesc.restitution);
-  EXPECT_EQ(node["collidable"]["staticFriction"].as<float>(0.0f),
+  EXPECT_EQ(node["collidable"]["staticFriction"].as<f32>(0.0f),
             materialDesc.staticFriction);
   EXPECT_EQ(node["collidable"]["useInSimulation"].as<bool>(false), true);
   EXPECT_EQ(node["collidable"]["useInQueries"].as<bool>(false), true);
@@ -956,7 +956,7 @@ TEST_F(EntitySerializerTest,
 }
 
 TEST_F(EntitySerializerTest, CreatesEntityComponentIfParentIdExists) {
-  static constexpr uint64_t ParentId{50};
+  static constexpr u64 ParentId{50};
 
   auto parent = entityDatabase.create();
   entityDatabase.set<quoll::Id>(parent, {ParentId});
@@ -965,7 +965,7 @@ TEST_F(EntitySerializerTest, CreatesEntityComponentIfParentIdExists) {
   entityDatabase.set<quoll::Parent>(entity, {parent});
 
   auto node = entitySerializer.createComponentsNode(entity);
-  EXPECT_EQ(node["transform"]["parent"].as<uint64_t>(0), ParentId);
+  EXPECT_EQ(node["transform"]["parent"].as<u64>(0), ParentId);
 }
 
 // Skybox
@@ -1077,7 +1077,7 @@ TEST_F(EntitySerializerTest,
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_TRUE(node["inputMap"]);
   EXPECT_EQ(node["inputMap"]["asset"].as<quoll::String>(""), "inputMap.asset");
-  EXPECT_EQ(node["inputMap"]["defaultScheme"].as<uint32_t>(999), 0);
+  EXPECT_EQ(node["inputMap"]["defaultScheme"].as<u32>(999), 0);
 }
 
 // UI Canvas

--- a/engine/tests/quoll-tests/scene/private/SceneLoader.test.cpp
+++ b/engine/tests/quoll-tests/scene/private/SceneLoader.test.cpp
@@ -36,7 +36,7 @@ public:
   quoll::detail::SceneLoader sceneLoader;
 
 private:
-  uint32_t lastId = 1;
+  u32 lastId = 1;
 };
 
 using SceneLoaderNameTest = SceneLoaderTest;
@@ -539,10 +539,10 @@ TEST_F(SceneLoaderSkeletonTest,
        CreatesSkeletonComponentWithFileDataIfValidField) {
   quoll::AssetData<quoll::SkeletonAsset> data{};
 
-  static constexpr uint32_t NumJoints = 5;
+  static constexpr u32 NumJoints = 5;
 
-  for (uint32_t i = 0; i < NumJoints; ++i) {
-    float fi = static_cast<float>(i);
+  for (u32 i = 0; i < NumJoints; ++i) {
+    f32 fi = static_cast<f32>(i);
 
     data.data.jointLocalPositions.push_back(glm::vec3(fi));
     data.data.jointLocalRotations.push_back(glm::quat(fi, fi, fi, fi));
@@ -565,8 +565,8 @@ TEST_F(SceneLoaderSkeletonTest,
   EXPECT_EQ(skeleton.assetHandle, handle);
 
   EXPECT_EQ(skeleton.numJoints, NumJoints);
-  for (uint32_t i = 0; i < NumJoints; ++i) {
-    float fi = static_cast<float>(i);
+  for (u32 i = 0; i < NumJoints; ++i) {
+    f32 fi = static_cast<f32>(i);
 
     EXPECT_EQ(skeleton.jointLocalPositions.at(i),
               data.data.jointLocalPositions.at(i));
@@ -629,7 +629,7 @@ TEST_F(SceneLoaderJointAttachmentTest,
 TEST_F(SceneLoaderJointAttachmentTest,
        DoesNotCreateJointAttachmentIfJointFieldIsLargerThanMaximumJointSize) {
   auto [node, entity] = createNode();
-  node["jointAttachment"]["joint"] = std::numeric_limits<uint8_t>::max();
+  node["jointAttachment"]["joint"] = std::numeric_limits<u8>::max();
   sceneLoader.loadComponents(node, entity, entityIdCache).getData();
 
   EXPECT_FALSE(entityDatabase.has<quoll::JointAttachment>(entity));
@@ -699,7 +699,7 @@ TEST_F(SceneLoaderAnimatorTest, CreatesAnimatorComponentIfAllFieldsAreValid) {
 
   const auto &animator = entityDatabase.get<quoll::Animator>(entity);
   EXPECT_EQ(animator.asset, handle);
-  EXPECT_EQ(animator.currentState, std::numeric_limits<size_t>::max());
+  EXPECT_EQ(animator.currentState, std::numeric_limits<usize>::max());
   EXPECT_EQ(animator.normalizedTime, 0.0f);
 }
 
@@ -744,12 +744,12 @@ TEST_F(SceneLoaderLightTest,
 
 TEST_F(SceneLoaderLightTest,
        DoesNotCreateAnyLightComponentIfLightTypeIsUndefined) {
-  static constexpr uint32_t InvalidStart = 1;
+  static constexpr u32 InvalidStart = 1;
 
   // Check for 10 items
-  static constexpr uint32_t Size = 10;
+  static constexpr u32 Size = 10;
 
-  for (uint32_t i = InvalidStart; i < InvalidStart + Size; ++i) {
+  for (u32 i = InvalidStart; i < InvalidStart + Size; ++i) {
     auto [node, entity] = createNode();
     node["light"]["type"] = i;
     sceneLoader.loadComponents(node, entity, entityIdCache).getData();
@@ -776,7 +776,7 @@ TEST_F(SceneLoaderLightTest,
   quoll::DirectionalLight defaults{};
 
   glm::vec4 validColor{0.5f};
-  float validIntensity = 3.5f;
+  f32 validIntensity = 3.5f;
 
   for (const auto &invalidNode : invalidNodes) {
     auto [node, entity] = createNode();
@@ -1050,8 +1050,8 @@ TEST_F(
   quoll::PointLight defaults{};
 
   glm::vec4 validColor{0.5f};
-  float validIntensity = 3.5f;
-  float validRange = 25.0f;
+  f32 validIntensity = 3.5f;
+  f32 validRange = 25.0f;
 
   for (const auto &invalidNode : invalidNodes) {
     auto [node, entity] = createNode();
@@ -1166,14 +1166,14 @@ TEST_F(SceneLoaderCameraTest,
 
   quoll::PerspectiveLens defaults{};
 
-  float validNear = 0.5f;
-  float validFar = 1000.0f;
-  float validAspectRatio = 2.0f;
+  f32 validNear = 0.5f;
+  f32 validFar = 1000.0f;
+  f32 validAspectRatio = 2.0f;
   glm::vec2 validSensorSize{50.0f, 45.0f};
-  float validFocalLength = 100.0f;
-  float validAperture = 2.5f;
-  float validShutterSpeed = 0.125f;
-  uint32_t validSensitivity = 2500;
+  f32 validFocalLength = 100.0f;
+  f32 validAperture = 2.5f;
+  f32 validShutterSpeed = 0.125f;
+  u32 validSensitivity = 2500;
 
   // Near
   for (const auto &invalidNode : invalidNodes) {
@@ -1467,14 +1467,14 @@ TEST_F(SceneLoaderCameraTest,
 }
 
 TEST_F(SceneLoaderCameraTest, CreatesCameraComponentWithFileDataIfValidField) {
-  float validNear = 0.5f;
-  float validFar = 1000.0f;
-  float validAspectRatio = 2.0f;
+  f32 validNear = 0.5f;
+  f32 validFar = 1000.0f;
+  f32 validAspectRatio = 2.0f;
   glm::vec2 validSensorSize{50.0f, 45.0f};
-  float validFocalLength = 100.0f;
-  float validAperture = 2.5f;
-  float validShutterSpeed = 0.125f;
-  uint32_t validSensitivity = 2500;
+  f32 validFocalLength = 100.0f;
+  f32 validAperture = 2.5f;
+  f32 validShutterSpeed = 0.125f;
+  u32 validSensitivity = 2500;
 
   auto [node, entity] = createNode();
   node["camera"]["near"] = validNear;
@@ -2318,7 +2318,7 @@ TEST_F(SceneLoaderParentTest,
 
 TEST_F(SceneLoaderParentTest,
        DoesNotCreateParentComponentIfParentDoesNotExist) {
-  static constexpr uint64_t NonExistentId = 255;
+  static constexpr u64 NonExistentId = 255;
   auto [parentNode, parentEntity] = createNode();
 
   auto [node, entity] = createNode();
@@ -2331,7 +2331,7 @@ TEST_F(SceneLoaderParentTest,
 
 TEST_F(SceneLoaderParentTest,
        DoesNotCreateParentComponentIfParentIsNotCreatedWithSceneLoader) {
-  static constexpr uint64_t ParentId = 255;
+  static constexpr u64 ParentId = 255;
 
   auto parentEntity = entityDatabase.create();
   entityDatabase.set<quoll::Id>(parentEntity, {ParentId});

--- a/engine/tests/quoll-tests/scripting/ScriptingSystem.test.cpp
+++ b/engine/tests/quoll-tests/scripting/ScriptingSystem.test.cpp
@@ -28,7 +28,7 @@ public:
 
 using ScriptingSystemDeathTest = ScriptingSystemTest;
 
-static constexpr float TimeDelta = 0.2f;
+static constexpr f32 TimeDelta = 0.2f;
 
 TEST_F(ScriptingSystemTest, CallsScriptingUpdateFunctionOnUpdate) {
   auto handle = loadLuaScript();
@@ -45,17 +45,17 @@ TEST_F(ScriptingSystemTest, CallsScriptingUpdateFunctionOnUpdate) {
   scriptingSystem.update(TimeDelta, entityDatabase);
 
   sol::state_view state(component.state);
-  EXPECT_EQ(state["value"].get<int32_t>(), 0);
-  EXPECT_EQ(state["global_dt"].get<float>(), TimeDelta);
+  EXPECT_EQ(state["value"].get<i32>(), 0);
+  EXPECT_EQ(state["global_dt"].get<f32>(), TimeDelta);
 }
 
 TEST_F(ScriptingSystemTest, DeletesScriptDataWhenComponentIsDeleted) {
   auto handle = loadLuaScript();
 
-  static constexpr size_t NumEntities = 20;
+  static constexpr usize NumEntities = 20;
 
   std::vector<quoll::Entity> entities(NumEntities, quoll::Entity::Null);
-  for (size_t i = 0; i < entities.size(); ++i) {
+  for (usize i = 0; i < entities.size(); ++i) {
     auto entity = entityDatabase.create();
     entities.at(i) = entity;
 
@@ -65,7 +65,7 @@ TEST_F(ScriptingSystemTest, DeletesScriptDataWhenComponentIsDeleted) {
   scriptingSystem.start(entityDatabase, physicsSystem);
 
   std::vector<quoll::Script> scripts(entities.size());
-  for (size_t i = 0; i < entities.size(); ++i) {
+  for (usize i = 0; i < entities.size(); ++i) {
     auto entity = entities.at(i);
     scripts.at(i) = entityDatabase.get<quoll::Script>(entity);
     ASSERT_TRUE(eventSystem.hasObserver(quoll::CollisionEvent::CollisionEnded,
@@ -77,7 +77,7 @@ TEST_F(ScriptingSystemTest, DeletesScriptDataWhenComponentIsDeleted) {
   }
 
   scriptingSystem.update(TimeDelta, entityDatabase);
-  for (size_t i = 0; i < entities.size(); ++i) {
+  for (usize i = 0; i < entities.size(); ++i) {
     auto entity = entities.at(i);
     bool deleted = (i % 2) == 0;
     EXPECT_NE(entityDatabase.has<quoll::Script>(entity), deleted);
@@ -101,12 +101,12 @@ TEST_F(ScriptingSystemTest, CallsScriptingUpdateFunctionOnEveryUpdate) {
   scriptingSystem.start(entityDatabase, physicsSystem);
   EXPECT_NE(component.state, nullptr);
 
-  for (size_t i = 0; i < 10; ++i) {
+  for (usize i = 0; i < 10; ++i) {
     scriptingSystem.update(TimeDelta, entityDatabase);
   }
 
   sol::state_view state(component.state);
-  EXPECT_EQ(state["value"].get<int32_t>(), 9);
+  EXPECT_EQ(state["value"].get<i32>(), 9);
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptStartFunctionOnStart) {
@@ -122,7 +122,7 @@ TEST_F(ScriptingSystemTest, CallsScriptStartFunctionOnStart) {
   EXPECT_NE(component.state, nullptr);
 
   sol::state_view state(component.state);
-  EXPECT_EQ(state["value"].get<int32_t>(), -1);
+  EXPECT_EQ(state["value"].get<i32>(), -1);
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptingStartFunctionOnlyOnceOnStart) {
@@ -135,13 +135,13 @@ TEST_F(ScriptingSystemTest, CallsScriptingStartFunctionOnlyOnceOnStart) {
   EXPECT_EQ(component.state, nullptr);
 
   // Call 10 times
-  for (size_t i = 0; i < 10; ++i) {
+  for (usize i = 0; i < 10; ++i) {
     scriptingSystem.start(entityDatabase, physicsSystem);
   }
   EXPECT_NE(component.state, nullptr);
 
   auto state = sol::state_view(component.state);
-  EXPECT_EQ(state["value"].get<int32_t>(), -1);
+  EXPECT_EQ(state["value"].get<i32>(), -1);
 }
 
 TEST_F(ScriptingSystemTest, RemovesScriptComponentIfInputVarsAreNotSet) {
@@ -196,8 +196,8 @@ TEST_F(ScriptingSystemTest, SetsVariablesToInputVarsOnStart) {
   auto state = sol::state_view(component.state);
 
   EXPECT_EQ(state["var_string"].get<quoll::String>(), "Hello world");
-  EXPECT_EQ(state["var_prefab"].get<uint32_t>(), 15);
-  EXPECT_EQ(state["var_texture"].get<uint32_t>(), 25);
+  EXPECT_EQ(state["var_prefab"].get<u32>(), 15);
+  EXPECT_EQ(state["var_texture"].get<u32>(), 25);
 }
 
 TEST_F(ScriptingSystemTest, RemovesVariableSetterAfterInputVariablesAreSet) {
@@ -219,8 +219,8 @@ TEST_F(ScriptingSystemTest, RemovesVariableSetterAfterInputVariablesAreSet) {
   auto state = sol::state_view(component.state);
 
   EXPECT_EQ(state["var_string"].get<quoll::String>(), "Hello world");
-  EXPECT_EQ(state["var_prefab"].get<uint32_t>(), 15);
-  EXPECT_EQ(state["var_texture"].get<uint32_t>(), 25);
+  EXPECT_EQ(state["var_prefab"].get<u32>(), 15);
+  EXPECT_EQ(state["var_texture"].get<u32>(), 25);
 
   EXPECT_TRUE(state["global_vars"].get_type() == sol::type::table);
   EXPECT_TRUE(state["entity"].is<quoll::EntityTable>());
@@ -263,7 +263,7 @@ TEST_F(ScriptingSystemTest,
                        {quoll::Entity{5}, quoll::Entity{6}});
   eventSystem.poll();
 
-  EXPECT_EQ(state["event"].get<int32_t>(), 0);
+  EXPECT_EQ(state["event"].get<i32>(), 0);
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptCollisionStartEventIfEntityCollided) {
@@ -281,8 +281,8 @@ TEST_F(ScriptingSystemTest, CallsScriptCollisionStartEventIfEntityCollided) {
                        {entity, quoll::Entity{6}});
   eventSystem.poll();
 
-  EXPECT_EQ(state["event"].get<int32_t>(), 1);
-  EXPECT_EQ(state["target"].get<int32_t>(), 6);
+  EXPECT_EQ(state["event"].get<i32>(), 1);
+  EXPECT_EQ(state["target"].get<i32>(), 6);
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptCollisionEndEventIfEntityCollided) {
@@ -300,8 +300,8 @@ TEST_F(ScriptingSystemTest, CallsScriptCollisionEndEventIfEntityCollided) {
                        {quoll::Entity{5}, entity});
   eventSystem.poll();
 
-  EXPECT_EQ(state["event"].get<int32_t>(), 2);
-  EXPECT_EQ(state["target"].get<int32_t>(), 5);
+  EXPECT_EQ(state["event"].get<i32>(), 2);
+  EXPECT_EQ(state["target"].get<i32>(), 5);
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptKeyPressEventIfKeyIsPressed) {
@@ -318,9 +318,9 @@ TEST_F(ScriptingSystemTest, CallsScriptKeyPressEventIfKeyIsPressed) {
   eventSystem.dispatch(quoll::KeyboardEvent::Pressed, {15, -1, 3});
   eventSystem.poll();
 
-  EXPECT_EQ(state["event"].get<int32_t>(), 3);
-  EXPECT_EQ(state["key_value"].get<int32_t>(), 15);
-  EXPECT_EQ(state["key_mods"].get<int32_t>(), 3);
+  EXPECT_EQ(state["event"].get<i32>(), 3);
+  EXPECT_EQ(state["key_value"].get<i32>(), 15);
+  EXPECT_EQ(state["key_mods"].get<i32>(), 3);
 }
 
 TEST_F(ScriptingSystemTest, CallsScriptKeyReleaseEventIfKeyIsReleased) {
@@ -337,7 +337,7 @@ TEST_F(ScriptingSystemTest, CallsScriptKeyReleaseEventIfKeyIsReleased) {
   eventSystem.dispatch(quoll::KeyboardEvent::Released, {35, -1, 3});
   eventSystem.poll();
 
-  EXPECT_EQ(state["event"].get<int32_t>(), 4);
-  EXPECT_EQ(state["key_value"].get<int32_t>(), 35);
-  EXPECT_EQ(state["key_mods"].get<int32_t>(), 3);
+  EXPECT_EQ(state["event"].get<i32>(), 4);
+  EXPECT_EQ(state["key_value"].get<i32>(), 35);
+  EXPECT_EQ(state["key_mods"].get<i32>(), 3);
 }

--- a/engine/tests/quoll-tests/test-utils/TestPhysicsBackend.cpp
+++ b/engine/tests/quoll-tests/test-utils/TestPhysicsBackend.cpp
@@ -1,8 +1,8 @@
 #include "quoll/core/Base.h"
 #include "TestPhysicsBackend.h"
 
-void TestPhysicsBackend::update(float dt,
-                                quoll::EntityDatabase &entityDatabase) {}
+void TestPhysicsBackend::update(f32 dt, quoll::EntityDatabase &entityDatabase) {
+}
 
 void TestPhysicsBackend::cleanup(quoll::EntityDatabase &entityDatabase) {}
 
@@ -11,7 +11,7 @@ void TestPhysicsBackend::observeChanges(quoll::EntityDatabase &entityDatabase) {
 
 bool TestPhysicsBackend::sweep(quoll::EntityDatabase &entityDatabase,
                                quoll::Entity entity, const glm::vec3 &direction,
-                               float distance, quoll::CollisionHit &hit) {
+                               f32 distance, quoll::CollisionHit &hit) {
   if (mSweepValue) {
     hit.normal = mHit.normal;
   }

--- a/engine/tests/quoll-tests/test-utils/TestPhysicsBackend.h
+++ b/engine/tests/quoll-tests/test-utils/TestPhysicsBackend.h
@@ -4,14 +4,14 @@
 
 class TestPhysicsBackend : public quoll::PhysicsBackend {
 public:
-  void update(float dt, quoll::EntityDatabase &entityDatabase) override;
+  void update(f32 dt, quoll::EntityDatabase &entityDatabase) override;
 
   void cleanup(quoll::EntityDatabase &entityDatabase) override;
 
   void observeChanges(quoll::EntityDatabase &entityDatabase) override;
 
   bool sweep(quoll::EntityDatabase &entityDatabase, quoll::Entity entity,
-             const glm::vec3 &direction, float distance,
+             const glm::vec3 &direction, f32 distance,
              quoll::CollisionHit &hit) override;
 
   void setSweepValue(bool value);

--- a/engine/tests/quoll-tests/text/TextLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/text/TextLuaTable.test.cpp
@@ -57,7 +57,7 @@ TEST_F(TextLuaTableTest, GetLineHeightReturnsLineHeightIfComponentExists) {
 
   auto state = call(entity, "text_get_line_height");
 
-  auto name = state["text_line_height"].get<float>();
+  auto name = state["text_line_height"].get<f32>();
   EXPECT_EQ(name, 25.0f);
 }
 

--- a/platform/win32/src/Win32FileDialog.cpp
+++ b/platform/win32/src/Win32FileDialog.cpp
@@ -66,8 +66,7 @@ FileDialog::getFilePathFromDialog(const std::vector<FileTypeEntry> &fileTypes) {
     filters.push_back(filter);
   }
 
-  pFileOpen->SetFileTypes(static_cast<uint32_t>(filters.size()),
-                          filters.data());
+  pFileOpen->SetFileTypes(static_cast<u32>(filters.size()), filters.data());
 
   if (!SUCCEEDED(pFileOpen->Show(NULL))) {
     return "";
@@ -140,8 +139,7 @@ quoll::Path FileDialog::getFilePathFromCreateDialog(
     filters.push_back(filter);
   }
 
-  pFileOpen->SetFileTypes(static_cast<uint32_t>(filters.size()),
-                          filters.data());
+  pFileOpen->SetFileTypes(static_cast<u32>(filters.size()), filters.data());
 
   if (!SUCCEEDED(pFileOpen->Show(NULL))) {
     return "";

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -35,8 +35,8 @@ namespace quoll::runtime {
 Runtime::Runtime(const LaunchConfig &config) : mConfig(config) {}
 
 void Runtime::start() {
-  static constexpr uint32_t Width = 800;
-  static constexpr uint32_t Height = 600;
+  static constexpr u32 Width = 800;
+  static constexpr u32 Height = 600;
 
   Scene scene;
   EventSystem eventSystem;
@@ -54,7 +54,7 @@ void Runtime::start() {
   ImguiRenderer imguiRenderer(window, renderStorage);
 
   {
-    static constexpr float FontSize = 18.0f;
+    static constexpr f32 FontSize = 18.0f;
     auto &io = ImGui::GetIO();
 
     Path defaultFontPath = Engine::getFontsPath() / "Roboto-Regular.ttf";
@@ -92,9 +92,9 @@ void Runtime::start() {
   UICanvasUpdater uiCanvasUpdater;
 
   cameraAspectRatioUpdater.setViewportSize(window.getFramebufferSize());
-  uiCanvasUpdater.setViewport(
-      0.0f, 0.0f, static_cast<float>(window.getFramebufferSize().x),
-      static_cast<float>(window.getFramebufferSize().y));
+  uiCanvasUpdater.setViewport(0.0f, 0.0f,
+                              static_cast<f32>(window.getFramebufferSize().x),
+                              static_cast<f32>(window.getFramebufferSize().y));
 
   audioSystem.observeChanges(scene.entityDatabase);
   scriptingSystem.observeChanges(scene.entityDatabase);
@@ -104,8 +104,8 @@ void Runtime::start() {
     renderer.setFramebufferSize({width, height});
     presenter.enqueueFramebufferUpdate();
     cameraAspectRatioUpdater.setViewportSize({width, height});
-    uiCanvasUpdater.setViewport(0.0f, 0.0f, static_cast<float>(width),
-                                static_cast<float>(height));
+    uiCanvasUpdater.setViewport(0.0f, 0.0f, static_cast<f32>(width),
+                                static_cast<f32>(height));
   });
 
   auto handle = assetCache.getRegistry().getScenes().findHandleByUuid(
@@ -121,7 +121,7 @@ void Runtime::start() {
 
   presenter.updateFramebuffers(device->getSwapchain());
 
-  mainLoop.setUpdateFn([&](float dt) mutable {
+  mainLoop.setUpdateFn([&](f32 dt) mutable {
     auto &entityDatabase = scene.entityDatabase;
     entityDeleter.update(scene);
 
@@ -161,7 +161,7 @@ void Runtime::start() {
     auto size = window.getFramebufferSize();
     ImGui::SetNextWindowPos({0.0f, 0.0f});
     ImGui::SetNextWindowSize(
-        {static_cast<float>(size.x), static_cast<float>(size.y)});
+        {static_cast<f32>(size.x), static_cast<f32>(size.y)});
 
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
 
@@ -178,7 +178,7 @@ void Runtime::start() {
 
     const auto &renderFrame = device->beginFrame();
 
-    if (renderFrame.frameIndex < std::numeric_limits<uint32_t>::max()) {
+    if (renderFrame.frameIndex < std::numeric_limits<u32>::max()) {
       sceneRenderer.updateFrameData(scene.entityDatabase, scene.activeCamera,
                                     renderFrame.frameIndex);
       imguiRenderer.updateFrameData(renderFrame.frameIndex);


### PR DESCRIPTION
- Rename uintX_t to uX
- Rename float to f32
- Rename double to f64
- Rename size_t to usize
- Rename intptr_t to iptr
- Rename uintptr_t to uptr