### PR TITLE
Add kinematic rigid body type

### DIFF
--- a/editor/src/quoll/editor/scene/core/SceneSimulator.cpp
+++ b/editor/src/quoll/editor/scene/core/SceneSimulator.cpp
@@ -47,7 +47,6 @@ void SceneSimulator::updateSimulation(f32 dt, WorkspaceState &state) {
   mInputMapSystem.update(entityDatabase);
 
   mCameraAspectRatioUpdater.update(entityDatabase);
-  mPhysicsSystem.update(dt, entityDatabase);
 
   mScriptingSystem.start(entityDatabase, mPhysicsSystem, mWindow.getSignals());
   mScriptingSystem.update(dt, entityDatabase);
@@ -55,6 +54,7 @@ void SceneSimulator::updateSimulation(f32 dt, WorkspaceState &state) {
 
   mSkeletonUpdater.update(entityDatabase);
   mSceneUpdater.update(entityDatabase);
+  mPhysicsSystem.update(dt, entityDatabase);
 
   mAudioSystem.output(entityDatabase);
 }

--- a/editor/src/quoll/editor/scene/ui/EntityPanel.cpp
+++ b/editor/src/quoll/editor/scene/ui/EntityPanel.cpp
@@ -1219,36 +1219,57 @@ void EntityPanel::renderRigidBody(Scene &scene,
   if (auto _ = widgets::Section(SectionName.c_str())) {
     auto &rigidBody = scene.entityDatabase.get<RigidBody>(mSelectedEntity);
 
-    bool sendAction = false;
-    f32 mass = rigidBody.dynamicDesc.mass;
-    if (widgets::Input("Mass", mass, false)) {
-      if (!mRigidBodyAction) {
+    if (ImGui::BeginCombo("###RigidBodyType",
+                          rigidBody.type == RigidBodyType::Kinematic
+                              ? "Kinematic"
+                              : "Dynamic",
+                          0)) {
+      if (ImGui::Selectable("Dynamic")) {
         mRigidBodyAction = std::make_unique<EntityUpdateComponent<RigidBody>>(
             mSelectedEntity, rigidBody);
+        rigidBody.type = RigidBodyType::Dynamic;
       }
 
-      rigidBody.dynamicDesc.mass = mass;
+      if (ImGui::Selectable("Kinematic")) {
+        mRigidBodyAction = std::make_unique<EntityUpdateComponent<RigidBody>>(
+            mSelectedEntity, rigidBody);
+        rigidBody.type = RigidBodyType::Kinematic;
+      }
+
+      ImGui::EndCombo();
     }
 
-    glm::vec3 inertia = rigidBody.dynamicDesc.inertia;
-    if (widgets::Input("Inertia", inertia, false)) {
-      if (!mRigidBodyAction) {
-        mRigidBodyAction = std::make_unique<EntityUpdateComponent<RigidBody>>(
-            mSelectedEntity, rigidBody);
+    if (rigidBody.type == RigidBodyType::Dynamic) {
+      f32 mass = rigidBody.dynamicDesc.mass;
+      if (widgets::Input("Mass", mass, false)) {
+        if (!mRigidBodyAction) {
+          mRigidBodyAction = std::make_unique<EntityUpdateComponent<RigidBody>>(
+              mSelectedEntity, rigidBody);
+        }
+
+        rigidBody.dynamicDesc.mass = mass;
       }
 
-      rigidBody.dynamicDesc.inertia = inertia;
-    }
+      glm::vec3 inertia = rigidBody.dynamicDesc.inertia;
+      if (widgets::Input("Inertia", inertia, false)) {
+        if (!mRigidBodyAction) {
+          mRigidBodyAction = std::make_unique<EntityUpdateComponent<RigidBody>>(
+              mSelectedEntity, rigidBody);
+        }
 
-    ImGui::Text("Apply gravity");
-    bool applyGravity = rigidBody.dynamicDesc.applyGravity;
-    if (ImGui::Checkbox("Apply gravity###ApplyGravity", &applyGravity)) {
-      if (!mRigidBodyAction) {
-        mRigidBodyAction = std::make_unique<EntityUpdateComponent<RigidBody>>(
-            mSelectedEntity, rigidBody);
+        rigidBody.dynamicDesc.inertia = inertia;
       }
 
-      rigidBody.dynamicDesc.applyGravity = applyGravity;
+      ImGui::Text("Apply gravity");
+      bool applyGravity = rigidBody.dynamicDesc.applyGravity;
+      if (ImGui::Checkbox("Apply gravity###ApplyGravity", &applyGravity)) {
+        if (!mRigidBodyAction) {
+          mRigidBodyAction = std::make_unique<EntityUpdateComponent<RigidBody>>(
+              mSelectedEntity, rigidBody);
+        }
+
+        rigidBody.dynamicDesc.applyGravity = applyGravity;
+      }
     }
 
     if (mRigidBodyAction) {

--- a/engine/src/quoll/animation/AnimatorLuaTable.cpp
+++ b/engine/src/quoll/animation/AnimatorLuaTable.cpp
@@ -21,7 +21,8 @@ void AnimatorLuaTable::deleteThis() {
   }
 }
 
-void AnimatorLuaTable::create(sol::usertype<AnimatorLuaTable> usertype) {
+void AnimatorLuaTable::create(sol::usertype<AnimatorLuaTable> usertype,
+                              sol::state_view state) {
   usertype["trigger"] = &AnimatorLuaTable::trigger;
   usertype["delete"] = &AnimatorLuaTable::deleteThis;
 }

--- a/engine/src/quoll/animation/AnimatorLuaTable.h
+++ b/engine/src/quoll/animation/AnimatorLuaTable.h
@@ -40,8 +40,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<AnimatorLuaTable> usertype);
+  static void create(sol::usertype<AnimatorLuaTable> usertype,
+                     sol::state_view state);
 
 private:
   Entity mEntity;

--- a/engine/src/quoll/audio/AudioLuaTable.cpp
+++ b/engine/src/quoll/audio/AudioLuaTable.cpp
@@ -29,7 +29,8 @@ void AudioLuaTable::deleteThis() {
   }
 }
 
-void AudioLuaTable::create(sol::usertype<AudioLuaTable> usertype) {
+void AudioLuaTable::create(sol::usertype<AudioLuaTable> usertype,
+                           sol::state_view state) {
   usertype["play"] = &AudioLuaTable::play;
   usertype["isPlaying"] = sol::property(&AudioLuaTable::isPlaying);
   usertype["delete"] = &AudioLuaTable::deleteThis;

--- a/engine/src/quoll/audio/AudioLuaTable.h
+++ b/engine/src/quoll/audio/AudioLuaTable.h
@@ -46,8 +46,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<AudioLuaTable> usertype);
+  static void create(sol::usertype<AudioLuaTable> usertype,
+                     sol::state_view state);
 
 private:
   Entity mEntity;

--- a/engine/src/quoll/core/NameLuaTable.cpp
+++ b/engine/src/quoll/core/NameLuaTable.cpp
@@ -29,7 +29,8 @@ void NameLuaTable::deleteThis() {
   }
 }
 
-void NameLuaTable::create(sol::usertype<NameLuaTable> usertype) {
+void NameLuaTable::create(sol::usertype<NameLuaTable> usertype,
+                          sol::state_view state) {
   usertype["value"] = sol::property(&NameLuaTable::get, &NameLuaTable::set);
   usertype["delete"] = &NameLuaTable::deleteThis;
 }

--- a/engine/src/quoll/core/NameLuaTable.h
+++ b/engine/src/quoll/core/NameLuaTable.h
@@ -40,8 +40,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<NameLuaTable> usertype);
+  static void create(sol::usertype<NameLuaTable> usertype,
+                     sol::state_view state);
 
   /**
    * @brief Get component name in scripts

--- a/engine/src/quoll/entity/EntityLuaTable.cpp
+++ b/engine/src/quoll/entity/EntityLuaTable.cpp
@@ -9,7 +9,7 @@ void setToStruct(sol::state_view state,
                  TFieldType TFieldName::*field) {
   auto usertype = state.new_usertype<TFieldType>(
       "Entity_" + TFieldType::getName(), sol::no_constructor);
-  TFieldType::create(usertype);
+  TFieldType::create(usertype, state);
 
   entityTable[TFieldType::getName()] = field;
 }

--- a/engine/src/quoll/input/InputMapLuaTable.cpp
+++ b/engine/src/quoll/input/InputMapLuaTable.cpp
@@ -99,7 +99,8 @@ void InputMapLuaTable::setScheme(String name) {
   inputMap.activeScheme = inputMap.schemeNameMap.at(name);
 }
 
-void InputMapLuaTable::create(sol::usertype<InputMapLuaTable> usertype) {
+void InputMapLuaTable::create(sol::usertype<InputMapLuaTable> usertype,
+                              sol::state_view state) {
   usertype["getCommand"] = &InputMapLuaTable::getCommand;
   usertype["getValueBoolean"] = &InputMapLuaTable::getCommandValueBoolean;
   usertype["isPressed"] = &InputMapLuaTable::getCommandValueBoolean;

--- a/engine/src/quoll/input/InputMapLuaTable.h
+++ b/engine/src/quoll/input/InputMapLuaTable.h
@@ -60,8 +60,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<InputMapLuaTable> usertype);
+  static void create(sol::usertype<InputMapLuaTable> usertype,
+                     sol::state_view state);
 
 private:
   Entity mEntity;

--- a/engine/src/quoll/lua-scripting/ScriptLuaTable.cpp
+++ b/engine/src/quoll/lua-scripting/ScriptLuaTable.cpp
@@ -38,7 +38,8 @@ void ScriptLuaTable::set(const String &name, sol::object value) {
   }
 }
 
-void ScriptLuaTable::create(sol::usertype<ScriptLuaTable> usertype) {
+void ScriptLuaTable::create(sol::usertype<ScriptLuaTable> usertype,
+                            sol::state_view state) {
   usertype["get"] = &ScriptLuaTable::get;
   usertype["set"] = &ScriptLuaTable::set;
 }

--- a/engine/src/quoll/lua-scripting/ScriptLuaTable.h
+++ b/engine/src/quoll/lua-scripting/ScriptLuaTable.h
@@ -44,8 +44,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<ScriptLuaTable> usertype);
+  static void create(sol::usertype<ScriptLuaTable> usertype,
+                     sol::state_view state);
 
 private:
   Entity mEntity;

--- a/engine/src/quoll/lua-scripting/ScriptSignal.h
+++ b/engine/src/quoll/lua-scripting/ScriptSignal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "quoll/core/SparseSet.h"
+#include "quoll/core/Engine.h"
 #include "LuaHeaders.h"
 #include "LuaScript.h"
 #include "ScriptSignalSlot.h"
@@ -11,7 +12,7 @@ namespace quoll::lua {
  * @brief Script signal
  */
 class ScriptSignal {
-  using Handler = sol::function;
+  using Handler = sol::protected_function;
 
 public:
   /**
@@ -35,7 +36,11 @@ public:
    */
   template <class... TArgs> void notify(TArgs... args) {
     for (auto handler : mHandlers) {
-      handler(args...);
+      auto res = handler(args...);
+      if (!res.valid()) {
+        sol::error error = res;
+        Engine::getUserLogger().error() << error.what();
+      }
     }
   }
 

--- a/engine/src/quoll/physics/CollidableLuaTable.cpp
+++ b/engine/src/quoll/physics/CollidableLuaTable.cpp
@@ -166,7 +166,8 @@ void CollidableLuaTable::deleteThis() {
   }
 }
 
-void CollidableLuaTable::create(sol::usertype<CollidableLuaTable> usertype) {
+void CollidableLuaTable::create(sol::usertype<CollidableLuaTable> usertype,
+                                sol::state_view state) {
   usertype["setDefaultMaterial"] = &CollidableLuaTable::setDefaultMaterial;
   usertype["staticFriction"] =
       sol::property(&CollidableLuaTable::getStaticFriction,

--- a/engine/src/quoll/physics/CollidableLuaTable.h
+++ b/engine/src/quoll/physics/CollidableLuaTable.h
@@ -115,8 +115,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<CollidableLuaTable> usertype);
+  static void create(sol::usertype<CollidableLuaTable> usertype,
+                     sol::state_view state);
 
   /**
    * @brief Get component name in scripts

--- a/engine/src/quoll/physics/RigidBody.h
+++ b/engine/src/quoll/physics/RigidBody.h
@@ -4,10 +4,17 @@
 
 namespace quoll {
 
+enum class RigidBodyType { Dynamic, Kinematic };
+
 /**
  * @brief Rigid body component
  */
 struct RigidBody {
+  /**
+   * Rigid body type
+   */
+  RigidBodyType type{RigidBodyType::Dynamic};
+
   /**
    * Dynamic rigid body description
    */

--- a/engine/src/quoll/physics/RigidBodyLuaTable.cpp
+++ b/engine/src/quoll/physics/RigidBodyLuaTable.cpp
@@ -20,6 +20,17 @@ void RigidBodyLuaTable::setDefaultParams() {
   mScriptGlobals.entityDatabase.set<RigidBody>(mEntity, {});
 }
 
+sol_maybe<u32> RigidBodyLuaTable::getType() {
+  if (!mScriptGlobals.entityDatabase.has<RigidBody>(mEntity)) {
+    Engine::getUserLogger().error()
+        << lua::Messages::componentDoesNotExist(getName(), mEntity);
+    return sol::nil;
+  }
+
+  return static_cast<u32>(
+      mScriptGlobals.entityDatabase.get<RigidBody>(mEntity).type);
+}
+
 sol_maybe<f32> RigidBodyLuaTable::getMass() {
   if (!mScriptGlobals.entityDatabase.has<RigidBody>(mEntity)) {
     Engine::getUserLogger().error()
@@ -115,8 +126,13 @@ void RigidBodyLuaTable::deleteThis() {
   }
 }
 
-void RigidBodyLuaTable::create(sol::usertype<RigidBodyLuaTable> usertype) {
+void RigidBodyLuaTable::create(sol::usertype<RigidBodyLuaTable> usertype,
+                               sol::state_view state) {
+  state["RigidBodyType"] = state.create_table_with(
+      "Dynamic", RigidBodyType::Dynamic, "Kinematic", RigidBodyType::Kinematic);
+
   usertype["setDefaultParams"] = &RigidBodyLuaTable::setDefaultParams;
+  usertype["type"] = sol::property(&RigidBodyLuaTable::getType);
   usertype["mass"] =
       sol::property(&RigidBodyLuaTable::getMass, &RigidBodyLuaTable::setMass);
   usertype["getInertia"] = &RigidBodyLuaTable::getInertia;

--- a/engine/src/quoll/physics/RigidBodyLuaTable.h
+++ b/engine/src/quoll/physics/RigidBodyLuaTable.h
@@ -23,6 +23,13 @@ public:
   void setDefaultParams();
 
   /**
+   * @brief Get rigid body type
+   *
+   * @return Rigid body type
+   */
+  sol_maybe<u32> getType();
+
+  /**
    * @brief Get mass
    *
    * @return Mass
@@ -108,8 +115,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<RigidBodyLuaTable> usertype);
+  static void create(sol::usertype<RigidBodyLuaTable> usertype,
+                     sol::state_view state);
 
   /**
    * @brief Get component name in scripts

--- a/engine/src/quoll/scene/PerspectiveLensLuaTable.cpp
+++ b/engine/src/quoll/scene/PerspectiveLensLuaTable.cpp
@@ -196,7 +196,7 @@ void PerspectiveLensLuaTable::deleteThis() {
 }
 
 void PerspectiveLensLuaTable ::create(
-    sol::usertype<PerspectiveLensLuaTable> usertype) {
+    sol::usertype<PerspectiveLensLuaTable> usertype, sol::state_view state) {
   usertype["near"] = sol::property(&PerspectiveLensLuaTable::getNear,
                                    &PerspectiveLensLuaTable::setNear);
   usertype["far"] = sol::property(&PerspectiveLensLuaTable::getFar,

--- a/engine/src/quoll/scene/PerspectiveLensLuaTable.h
+++ b/engine/src/quoll/scene/PerspectiveLensLuaTable.h
@@ -125,8 +125,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<PerspectiveLensLuaTable> usertype);
+  static void create(sol::usertype<PerspectiveLensLuaTable> usertype,
+                     sol::state_view state);
 
   /**
    * @brief Get component name in scripts

--- a/engine/src/quoll/scene/TransformLuaTable.cpp
+++ b/engine/src/quoll/scene/TransformLuaTable.cpp
@@ -63,7 +63,8 @@ void TransformLuaTable::deleteThis() {
   }
 }
 
-void TransformLuaTable::create(sol::usertype<TransformLuaTable> usertype) {
+void TransformLuaTable::create(sol::usertype<TransformLuaTable> usertype,
+                               sol::state_view state) {
   usertype["getPosition"] = &TransformLuaTable::getPosition;
   usertype["setPosition"] = &TransformLuaTable::setPosition;
   usertype["getRotation"] = &TransformLuaTable::getRotation;

--- a/engine/src/quoll/scene/TransformLuaTable.h
+++ b/engine/src/quoll/scene/TransformLuaTable.h
@@ -74,8 +74,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<TransformLuaTable> usertype);
+  static void create(sol::usertype<TransformLuaTable> usertype,
+                     sol::state_view state);
 
   /**
    * @brief Get component name in scripts

--- a/engine/src/quoll/scene/private/EntitySerializer.cpp
+++ b/engine/src/quoll/scene/private/EntitySerializer.cpp
@@ -147,12 +147,17 @@ YAML::Node EntitySerializer::createComponentsNode(Entity entity) {
   }
 
   if (mEntityDatabase.has<RigidBody>(entity)) {
-    const auto &rigidBodyDesc =
-        mEntityDatabase.get<RigidBody>(entity).dynamicDesc;
+    const auto &rigidBody = mEntityDatabase.get<RigidBody>(entity);
 
-    components["rigidBody"]["applyGravity"] = rigidBodyDesc.applyGravity;
-    components["rigidBody"]["inertia"] = rigidBodyDesc.inertia;
-    components["rigidBody"]["mass"] = rigidBodyDesc.mass;
+    if (rigidBody.type == RigidBodyType::Dynamic) {
+      components["rigidBody"]["type"] = "dynamic";
+      components["rigidBody"]["applyGravity"] =
+          rigidBody.dynamicDesc.applyGravity;
+      components["rigidBody"]["inertia"] = rigidBody.dynamicDesc.inertia;
+      components["rigidBody"]["mass"] = rigidBody.dynamicDesc.mass;
+    } else if (rigidBody.type == RigidBodyType::Kinematic) {
+      components["rigidBody"]["type"] = "kinematic";
+    }
   }
 
   if (mEntityDatabase.has<Collidable>(entity)) {

--- a/engine/src/quoll/scene/private/SceneLoader.cpp
+++ b/engine/src/quoll/scene/private/SceneLoader.cpp
@@ -103,13 +103,21 @@ Result<bool> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
 
   if (node["rigidBody"] && node["rigidBody"].IsMap()) {
     RigidBody rigidBody{};
-    rigidBody.dynamicDesc.mass =
-        node["rigidBody"]["mass"].as<f32>(rigidBody.dynamicDesc.mass);
-    rigidBody.dynamicDesc.inertia = node["rigidBody"]["inertia"].as<glm::vec3>(
-        rigidBody.dynamicDesc.inertia);
-    rigidBody.dynamicDesc.applyGravity =
-        node["rigidBody"]["applyGravity"].as<bool>(
-            rigidBody.dynamicDesc.applyGravity);
+
+    auto type = node["rigidBody"]["type"].as<quoll::String>("dynamic");
+    if (type == "kinematic") {
+      rigidBody.type = RigidBodyType::Kinematic;
+    } else {
+      rigidBody.type = RigidBodyType::Dynamic;
+      rigidBody.dynamicDesc.mass =
+          node["rigidBody"]["mass"].as<f32>(rigidBody.dynamicDesc.mass);
+      rigidBody.dynamicDesc.inertia =
+          node["rigidBody"]["inertia"].as<glm::vec3>(
+              rigidBody.dynamicDesc.inertia);
+      rigidBody.dynamicDesc.applyGravity =
+          node["rigidBody"]["applyGravity"].as<bool>(
+              rigidBody.dynamicDesc.applyGravity);
+    }
 
     mEntityDatabase.set(entity, rigidBody);
   }

--- a/engine/src/quoll/text/TextLuaTable.cpp
+++ b/engine/src/quoll/text/TextLuaTable.cpp
@@ -51,7 +51,8 @@ void TextLuaTable::deleteThis() {
   }
 }
 
-void TextLuaTable::create(sol::usertype<TextLuaTable> usertype) {
+void TextLuaTable::create(sol::usertype<TextLuaTable> usertype,
+                          sol::state_view state) {
   usertype["content"] =
       sol::property(&TextLuaTable::getText, &TextLuaTable::setText);
   usertype["lineHeight"] =

--- a/engine/src/quoll/text/TextLuaTable.h
+++ b/engine/src/quoll/text/TextLuaTable.h
@@ -61,8 +61,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<TextLuaTable> usertype);
+  static void create(sol::usertype<TextLuaTable> usertype,
+                     sol::state_view state);
 
 private:
   Entity mEntity;

--- a/engine/src/quoll/ui/UICanvasLuaTable.cpp
+++ b/engine/src/quoll/ui/UICanvasLuaTable.cpp
@@ -14,7 +14,8 @@ void UICanvasLuaTable::render(UIView view) {
   }
 }
 
-void UICanvasLuaTable::create(sol::usertype<UICanvasLuaTable> usertype) {
+void UICanvasLuaTable::create(sol::usertype<UICanvasLuaTable> usertype,
+                              sol::state_view state) {
   usertype["render"] = &UICanvasLuaTable::render;
 }
 

--- a/engine/src/quoll/ui/UICanvasLuaTable.h
+++ b/engine/src/quoll/ui/UICanvasLuaTable.h
@@ -29,8 +29,10 @@ public:
    * @brief Create user type
    *
    * @param usertype User type
+   * @param state Sol state
    */
-  static void create(sol::usertype<UICanvasLuaTable> usertype);
+  static void create(sol::usertype<UICanvasLuaTable> usertype,
+                     sol::state_view state);
 
   /**
    * @brief Get component name in scripts

--- a/engine/tests/fixtures/scripting-system-component-tester.lua
+++ b/engine/tests/fixtures/scripting-system-component-tester.lua
@@ -92,8 +92,18 @@ function localTransformDelete()
 end
 
 -- Rigid body
+function rigidBodyCheckTypeEnumValues()
+    expectEq(RigidBodyType.Dynamic, 0)
+    expectEq(RigidBodyType.Kinematic, 1)
+end
+
 function rigidBodySetDefaultParams()
     entity.rigidBody:setDefaultParams();
+end
+
+rbType = nil
+function rigidBodyGetType()
+  rbType = entity.rigidBody.type
 end
 
 mass = 0

--- a/engine/tests/quoll-tests/physics/RigidBodyLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/physics/RigidBodyLuaTable.test.cpp
@@ -19,6 +19,41 @@ TEST_F(RigidBodyLuaTableTest, SetDefaultParamsSetsNewRigidBody) {
             quoll::RigidBody{}.dynamicDesc.mass);
 }
 
+TEST_F(RigidBodyLuaTableTest,
+       GetRigidBodyTypeReturnsNilIfRigidBodyDoesNotExist) {
+  auto entity = entityDatabase.create();
+
+  auto state = call(entity, "rigidBodyGetType");
+  EXPECT_TRUE(state["rbType"].is<sol::nil_t>());
+}
+
+TEST_F(RigidBodyLuaTableTest, GetRigidBodyTypeReturnsRigidBodyType) {
+  auto entity = entityDatabase.create();
+  quoll::RigidBody rigidBody{};
+
+  {
+    rigidBody.type = quoll::RigidBodyType::Dynamic;
+    entityDatabase.set(entity, rigidBody);
+    auto state = call(entity, "rigidBodyGetType");
+    EXPECT_EQ(state["rbType"].get<u32>(),
+              static_cast<u32>(quoll::RigidBodyType::Dynamic));
+  }
+
+  {
+    rigidBody.type = quoll::RigidBodyType::Kinematic;
+    entityDatabase.set(entity, rigidBody);
+
+    auto state = call(entity, "rigidBodyGetType");
+    EXPECT_EQ(state["rbType"].get<u32>(),
+              static_cast<u32>(quoll::RigidBodyType::Kinematic));
+  }
+}
+
+TEST_F(RigidBodyLuaTableTest, GetRigidBodyTypeEnumValues) {
+  auto entity = entityDatabase.create();
+  call(entity, "rigidBodyCheckTypeEnumValues");
+}
+
 TEST_F(RigidBodyLuaTableTest, GetMassReturnsNullIfRigidBodyDoesNotExist) {
   auto entity = entityDatabase.create();
 

--- a/engine/tests/quoll-tests/scene/private/EntitySerializer.test.cpp
+++ b/engine/tests/quoll-tests/scene/private/EntitySerializer.test.cpp
@@ -796,7 +796,8 @@ TEST_F(EntitySerializerTest,
   EXPECT_FALSE(node["rigidBody"]);
 }
 
-TEST_F(EntitySerializerTest, CreatesRigidBodyFieldIfRigidBodyComponentExists) {
+TEST_F(EntitySerializerTest,
+       CreatesDynamicRigidBodyFieldIfRigidBodyComponentWithDynamicTypeExists) {
   auto entity = entityDatabase.create();
 
   quoll::PhysicsDynamicRigidBodyDesc rigidBodyDesc{};
@@ -804,16 +805,40 @@ TEST_F(EntitySerializerTest, CreatesRigidBodyFieldIfRigidBodyComponentExists) {
   rigidBodyDesc.inertia = glm::vec3(2.5f, 2.5f, 2.5f);
   rigidBodyDesc.mass = 4.5f;
 
-  entityDatabase.set<quoll::RigidBody>(entity, {rigidBodyDesc});
+  entityDatabase.set<quoll::RigidBody>(
+      entity, {quoll::RigidBodyType::Dynamic, rigidBodyDesc});
 
   auto node = entitySerializer.createComponentsNode(entity);
 
   EXPECT_TRUE(node["rigidBody"]);
+  EXPECT_EQ(node["rigidBody"]["type"].as<quoll::String>(""), "dynamic");
   EXPECT_EQ(node["rigidBody"]["applyGravity"].as<bool>(),
             rigidBodyDesc.applyGravity);
   EXPECT_EQ(node["rigidBody"]["inertia"].as<glm::vec3>(),
             rigidBodyDesc.inertia);
   EXPECT_EQ(node["rigidBody"]["mass"].as<f32>(), rigidBodyDesc.mass);
+}
+
+TEST_F(
+    EntitySerializerTest,
+    CreatesKinematicRigidBodyFieldIfRigidBodyComponentWithKinematicTypeExists) {
+  auto entity = entityDatabase.create();
+
+  quoll::PhysicsDynamicRigidBodyDesc rigidBodyDesc{};
+  rigidBodyDesc.applyGravity = true;
+  rigidBodyDesc.inertia = glm::vec3(2.5f, 2.5f, 2.5f);
+  rigidBodyDesc.mass = 4.5f;
+
+  entityDatabase.set<quoll::RigidBody>(
+      entity, {quoll::RigidBodyType::Kinematic, rigidBodyDesc});
+
+  auto node = entitySerializer.createComponentsNode(entity);
+
+  EXPECT_TRUE(node["rigidBody"]);
+  EXPECT_EQ(node["rigidBody"]["type"].as<quoll::String>(""), "kinematic");
+  EXPECT_FALSE(node["rigidBody"]["applyGravity"]);
+  EXPECT_FALSE(node["rigidBody"]["inertia"]);
+  EXPECT_FALSE(node["rigidBody"]["mass"]);
 }
 
 // Collidable

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -129,12 +129,12 @@ void Runtime::start() {
 
     inputMapSystem.update(entityDatabase);
     cameraAspectRatioUpdater.update(entityDatabase);
-    physicsSystem.update(dt, entityDatabase);
     scriptingSystem.start(entityDatabase, physicsSystem, window.getSignals());
     scriptingSystem.update(dt, entityDatabase);
     animationSystem.update(dt, entityDatabase);
     skeletonUpdater.update(entityDatabase);
     sceneUpdater.update(entityDatabase);
+    physicsSystem.update(dt, entityDatabase);
     audioSystem.output(entityDatabase);
 
     return true;


### PR DESCRIPTION
- Set rigid body type value in physx backend
- Save and load rigid body type from scene loader
- Read rigid body type value from Lua script
- Add enum for rigid body type values
- Set rigid body type in entity panel
- Enable kinematic-kinematic and kinematic-static rigid body detection
- Provide error messages if lua signals fail
- Move physics updates after scene updates