### PR TITLE
Collect timings for each GPU pass

### DIFF
--- a/.premake/core/dependencies.lua
+++ b/.premake/core/dependencies.lua
@@ -42,7 +42,7 @@ function linkDependenciesWith(...)
     }
 
     linkSuffixed {
-        "yaml-cpp", "imgui", "freetype", "bz2"
+        "yaml-cpp", "imgui", "implot", "freetype", "bz2"
     }
 
     links {

--- a/editor/src/quoll/editor/asset/HDRIImporter.cpp
+++ b/editor/src/quoll/editor/asset/HDRIImporter.cpp
@@ -1,5 +1,5 @@
 #include "quoll/core/Base.h"
-#include "quoll/renderer/RenderGraph.h"
+#include "quoll/renderer/RenderStorage.h"
 #include "quoll/renderer/TextureUtils.h"
 #include "HDRIImporter.h"
 #include <stb_image.h>

--- a/editor/src/quoll/editor/asset/ImageLoader.cpp
+++ b/editor/src/quoll/editor/asset/ImageLoader.cpp
@@ -1,5 +1,6 @@
 #include "quoll/core/Base.h"
 #include "quoll/asset/AssetCache.h"
+#include "quoll/renderer/RenderStorage.h"
 #include "quoll/renderer/TextureUtils.h"
 #include "ImageLoader.h"
 #include <stb_image.h>

--- a/editor/src/quoll/editor/scene/core/EditorCamera.h
+++ b/editor/src/quoll/editor/scene/core/EditorCamera.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "quoll/entity/EntityDatabase.h"
-#include "quoll/renderer/Renderer.h"
 #include "quoll/window/Window.h"
 #include "quoll/editor/core/CameraLookAt.h"
 #include "quoll/editor/workspace/WorkspaceState.h"

--- a/editor/src/quoll/editor/scene/renderer/MousePickingGraph.cpp
+++ b/editor/src/quoll/editor/scene/renderer/MousePickingGraph.cpp
@@ -1,6 +1,7 @@
 #include "quoll/core/Base.h"
 #include "quoll/renderer/MeshRenderUtils.h"
 #include "quoll/renderer/MeshVertexLayout.h"
+#include "quoll/renderer/RenderStorage.h"
 #include "MousePickingGraph.h"
 
 namespace quoll::editor {
@@ -126,16 +127,7 @@ void MousePickingGraph::execute(rhi::RenderCommandList &commandList,
 
   mMousePos = mousePos;
 
-  if (mResized) {
-    mRenderGraph.destroy(mRenderStorage);
-    mRenderGraph = RenderGraph("Mouse picking");
-
-    createRenderGraph();
-
-    mRenderGraph.build(mRenderStorage);
-
-    mResized = false;
-  }
+  recreateIfResized();
 
   mRenderGraph.execute(commandList, frameIndex);
 }
@@ -158,6 +150,20 @@ Entity MousePickingGraph::getSelectedEntity() {
 void MousePickingGraph::setFramebufferSize(glm::uvec2 size) {
   mFramebufferSize = size;
   mResized = true;
+}
+
+void MousePickingGraph::recreateIfResized() {
+  if (!mResized)
+    return;
+
+  mRenderGraph.destroy(mRenderStorage);
+  mRenderGraph = RenderGraph("Mouse picking");
+
+  createRenderGraph();
+
+  mRenderGraph.build(mRenderStorage);
+
+  mResized = false;
 }
 
 void MousePickingGraph::createRenderGraph() {

--- a/editor/src/quoll/editor/scene/renderer/MousePickingGraph.h
+++ b/editor/src/quoll/editor/scene/renderer/MousePickingGraph.h
@@ -27,6 +27,8 @@ public:
     return frameIndex == mFrameIndex;
   }
 
+  void recreateIfResized();
+
 private:
   void createRenderGraph();
 

--- a/editor/tests/quoll/editor-tests/asset/AssetManager.test.cpp
+++ b/editor/tests/quoll/editor-tests/asset/AssetManager.test.cpp
@@ -1,5 +1,7 @@
 #include "quoll/core/Base.h"
 #include "quoll/core/Engine.h"
+#include "quoll/profiler/MetricsCollector.h"
+#include "quoll/renderer/RenderStorage.h"
 #include "quoll/rhi-mock/MockRenderDevice.h"
 #include "quoll/yaml/Yaml.h"
 #include "quoll/editor/asset/AssetManager.h"
@@ -19,7 +21,7 @@ static const quoll::Path InnerPathInAssets = AssetsPath / "inner-1" / "inner-2";
 class AssetManagerTest : public ::testing::Test {
 public:
   AssetManagerTest()
-      : renderStorage(&device),
+      : renderStorage(&device, metricsCollector),
         manager(AssetsPath, CachePath, renderStorage, false, false) {}
 
   void SetUp() override {
@@ -41,6 +43,7 @@ public:
 
 public:
   quoll::rhi::MockRenderDevice device;
+  quoll::MetricsCollector metricsCollector;
   quoll::RenderStorage renderStorage;
   quoll::editor::AssetManager manager;
 };
@@ -122,9 +125,6 @@ TEST_F(AssetManagerTest, ReloadingAssetIfChangedDoesNotCreateFileWithNewUUID) {
 TEST_F(
     AssetManagerTest,
     ValidateAndPreloadDoesNotCreateFileWithNewUUIDIfFileContentsHaveChanged) {
-  quoll::rhi::MockRenderDevice device;
-  quoll::RenderStorage renderStorage(&device);
-
   fs::create_directories(InnerPathInAssets);
 
   auto animatorPath = InnerPathInAssets / "test.animator";
@@ -148,9 +148,6 @@ TEST_F(
 TEST_F(AssetManagerTest,
        ValidateAndPreloadDeletesCacheFileIfAssetFileDoesNotExist) {
   auto texturePath = CachePath / "test.asset";
-
-  quoll::rhi::MockRenderDevice device;
-  quoll::RenderStorage renderStorage(&device);
 
   createEmptyFile(texturePath);
 

--- a/editor/tests/quoll/editor-tests/asset/gltf/GLTFImporterTestBase.h
+++ b/editor/tests/quoll/editor-tests/asset/gltf/GLTFImporterTestBase.h
@@ -2,6 +2,8 @@
 
 #include "quoll/asset/AssetCache.h"
 #include "quoll/asset/DefaultObjects.h"
+#include "quoll/profiler/MetricsCollector.h"
+#include "quoll/renderer/RenderStorage.h"
 #include "quoll/rhi-mock/MockRenderDevice.h"
 
 #define TINYGLTF_NO_INCLUDE_STB_IMAGE
@@ -314,7 +316,7 @@ static quoll::Path saveSceneGLTF(GLTFTestScene &scene) {
 class GLTFImporterTestBase : public ::testing::Test {
 public:
   GLTFImporterTestBase()
-      : renderStorage(&device), assetCache(CachePath, false),
+      : renderStorage(&device, metricsCollector), assetCache(CachePath, false),
         imageLoader(assetCache, renderStorage),
         importer(assetCache, imageLoader, false) {}
 
@@ -329,6 +331,7 @@ public:
   }
 
   quoll::rhi::MockRenderDevice device;
+  quoll::MetricsCollector metricsCollector;
   quoll::RenderStorage renderStorage;
   quoll::AssetCache assetCache;
   quoll::editor::ImageLoader imageLoader;

--- a/engine/src/quoll/asset/AssetRegistry.cpp
+++ b/engine/src/quoll/asset/AssetRegistry.cpp
@@ -1,6 +1,7 @@
 #include "quoll/core/Base.h"
 #include "quoll/core/Profiler.h"
 #include "quoll/renderer/MaterialPBR.h"
+#include "quoll/renderer/RenderStorage.h"
 #include "quoll/renderer/TextureUtils.h"
 #include "AssetRegistry.h"
 #include "DefaultObjects.h"

--- a/engine/src/quoll/asset/AssetRegistry.h
+++ b/engine/src/quoll/asset/AssetRegistry.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "quoll/renderer/RenderStorage.h"
-#include "quoll/rhi/RenderDevice.h"
 #include "AnimationAsset.h"
 #include "AnimatorAsset.h"
 #include "Asset.h"
@@ -19,6 +17,8 @@
 #include "TextureAsset.h"
 
 namespace quoll {
+
+class RenderStorage;
 
 /**
  * Registry of all the loaded assets

--- a/engine/src/quoll/imgui/ImguiRenderer.cpp
+++ b/engine/src/quoll/imgui/ImguiRenderer.cpp
@@ -3,6 +3,7 @@
 #include "quoll/renderer/TextureUtils.h"
 #include "ImguiRenderer.h"
 #include <imgui_impl_glfw.h>
+#include <implot.h>
 
 static constexpr u64 BufferMemoryAlignment = 256;
 
@@ -55,9 +56,13 @@ ImguiRenderer::ImguiRenderer(Window &window, RenderStorage &renderStorage)
 
     x.indexBuffer = renderStorage.createBuffer(indexDesc);
   }
+
+  ImPlot::CreateContext();
 }
 
 ImguiRenderer::~ImguiRenderer() {
+  ImPlot::DestroyContext();
+
   for (auto &x : mFrameData) {
     mDevice->destroyBuffer(x.vertexBuffer.getHandle());
     mDevice->destroyBuffer(x.indexBuffer.getHandle());

--- a/engine/src/quoll/loop/MainLoop.cpp
+++ b/engine/src/quoll/loop/MainLoop.cpp
@@ -9,20 +9,24 @@ namespace quoll {
 MainLoop::MainLoop(Window &window, FPSCounter &fpsCounter)
     : mWindow(window), mFpsCounter(fpsCounter) {}
 
-void MainLoop::setUpdateFn(const std::function<void(f32)> &updateFn) {
+void MainLoop::setUpdateFn(std::function<void(f32)> &&updateFn) {
   mUpdateFn = updateFn;
 }
 
-void MainLoop::setFixedUpdateFn(const std::function<void(f32)> &fixedUpdateFn) {
+void MainLoop::setFixedUpdateFn(std::function<void(f32)> &&fixedUpdateFn) {
   mFixedUpdateFn = fixedUpdateFn;
 }
 
-void MainLoop::setRenderFn(const std::function<void()> &renderFn) {
+void MainLoop::setRenderFn(std::function<void()> &&renderFn) {
   mRenderFn = renderFn;
 }
 
-void MainLoop::setPrepareFn(const std::function<void()> &prepareFn) {
+void MainLoop::setPrepareFn(std::function<void()> &&prepareFn) {
   mPrepareFn = prepareFn;
+}
+
+void MainLoop::setStatsFn(std::function<void(u32)> &&statsFn) {
+  mStatsFn = statsFn;
 }
 
 void MainLoop::stop() { mRunning = false; }
@@ -72,6 +76,7 @@ void MainLoop::run() {
             .count() >= OneSecondInMs) {
       prevFrameTime = currentTime;
       mFpsCounter.collectFPS(frames);
+      mStatsFn(frames);
       frames = 0;
     } else {
       frames++;

--- a/engine/src/quoll/loop/MainLoop.h
+++ b/engine/src/quoll/loop/MainLoop.h
@@ -18,13 +18,22 @@ public:
 
   void run();
 
-  void setFixedUpdateFn(const std::function<void(f32)> &fixedUpdateFn);
+  void setFixedUpdateFn(std::function<void(f32)> &&fixedUpdateFn);
 
-  void setUpdateFn(const std::function<void(f32)> &updateFn);
+  void setUpdateFn(std::function<void(f32)> &&updateFn);
 
-  void setRenderFn(const std::function<void()> &renderFn);
+  void setRenderFn(std::function<void()> &&renderFn);
 
-  void setPrepareFn(const std::function<void()> &prepareFn);
+  void setPrepareFn(std::function<void()> &&prepareFn);
+
+  /**
+   * @brief Set stats function
+   *
+   * Stats function is performed after render and once every second.
+   *
+   * @param statsFn Callback that accepts number of frames
+   */
+  void setStatsFn(std::function<void(u32)> &&statsFn);
 
   void stop();
 
@@ -35,6 +44,7 @@ private:
   FPSCounter &mFpsCounter;
   std::function<void(f32)> mUpdateFn = [](f32) {};
   std::function<void(f32)> mFixedUpdateFn = [](f32) {};
+  std::function<void(u32)> mStatsFn = [](u32) {};
 
   std::function<void()> mRenderFn = []() {};
   std::function<void()> mPrepareFn = []() {};

--- a/engine/src/quoll/profiler/GpuSpan.cpp
+++ b/engine/src/quoll/profiler/GpuSpan.cpp
@@ -1,0 +1,33 @@
+#include "quoll/core/Base.h"
+#include "GpuSpan.h"
+#include "MetricsCollector.h"
+
+namespace quoll {
+
+GpuSpan::GpuSpan(MetricsCollector &collector, usize spanIndex, usize startMark,
+                 usize endMark)
+    : mMetricsCollector(collector), mSpanIndex(spanIndex),
+      mStartMark(startMark), mEndMark(endMark) {}
+
+void GpuSpan::begin(rhi::RenderCommandList &commandList) {
+  mMetricsCollector.mQueries.at(mStartMark) =
+      static_cast<u32>(mMetricsCollector.mRecordedTimestamps.size());
+
+  mMetricsCollector.mRecordedTimestamps.push_back(0);
+
+  commandList.writeTimestamp(mMetricsCollector.getQueryForMark(mStartMark),
+                             rhi::PipelineStage::PipeTop);
+}
+
+void GpuSpan::end(rhi::RenderCommandList &commandList) {
+  mMetricsCollector.mQueries.at(mEndMark) =
+      static_cast<u32>(mMetricsCollector.mRecordedTimestamps.size());
+
+  mMetricsCollector.mRecordedTimestamps.push_back(0);
+  mMetricsCollector.mRecordedSpans.push_back(mSpanIndex);
+
+  commandList.writeTimestamp(mMetricsCollector.getQueryForMark(mEndMark),
+                             rhi::PipelineStage::PipeBottom);
+}
+
+} // namespace quoll

--- a/engine/src/quoll/profiler/GpuSpan.h
+++ b/engine/src/quoll/profiler/GpuSpan.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "quoll/rhi/RenderCommandList.h"
+
+namespace quoll {
+
+class MetricsCollector;
+
+class GpuSpan {
+public:
+  GpuSpan(MetricsCollector &collector, usize spanIndex, usize startMark,
+          usize endMark);
+
+  void begin(rhi::RenderCommandList &commandList);
+
+  void end(rhi::RenderCommandList &commandList);
+
+  inline usize getIndex() const { return mSpanIndex; }
+
+  inline usize getStartMark() const { return mStartMark; }
+
+  inline usize getEndMark() const { return mEndMark; }
+
+private:
+  MetricsCollector &mMetricsCollector;
+  usize mSpanIndex;
+  usize mStartMark;
+  usize mEndMark;
+};
+
+} // namespace quoll

--- a/engine/src/quoll/profiler/ImguiDebugLayer.h
+++ b/engine/src/quoll/profiler/ImguiDebugLayer.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "quoll/profiler/FPSCounter.h"
 #include "quoll/rhi/DeviceStats.h"
 #include "quoll/rhi/PhysicalDeviceInformation.h"
+#include "FPSCounter.h"
+#include "MetricsCollector.h"
 
 namespace quoll {
 
@@ -10,7 +11,8 @@ class ImguiDebugLayer {
 public:
   ImguiDebugLayer(const rhi::PhysicalDeviceInformation &physicalDeviceInfo,
                   const rhi::DeviceStats &deviceStats,
-                  const FPSCounter &fpsCounter);
+                  const FPSCounter &fpsCounter,
+                  MetricsCollector &metricsCollector);
 
   void renderMenu();
 
@@ -31,6 +33,7 @@ private:
   rhi::PhysicalDeviceInformation mPhysicalDeviceInfo;
   const FPSCounter &mFpsCounter;
   const rhi::DeviceStats &mDeviceStats;
+  MetricsCollector &mMetricsCollector;
 
   bool mUsageMetricsVisible = false;
   bool mPhysicalDeviceInfoVisible = false;

--- a/engine/src/quoll/profiler/MetricsCollector.cpp
+++ b/engine/src/quoll/profiler/MetricsCollector.cpp
@@ -1,0 +1,84 @@
+#include "quoll/core/Base.h"
+#include "quoll/core/Profiler.h"
+#include "MetricsCollector.h"
+
+namespace quoll {
+
+static constexpr usize TimestampsInitialSize = 100;
+static constexpr usize TimestampsPoolSize = 500;
+
+GpuSpan MetricsCollector::createGpuSpan(String label) {
+  mRecordedTimestamps.reserve(TimestampsInitialSize);
+
+  auto start = createMark();
+  auto end = createMark();
+
+  auto index =
+      mGpuSpans.insert({.label = label, .markStart = start, .markEnd = end});
+
+  return GpuSpan(*this, index, start, end);
+}
+
+void MetricsCollector::deleteGpuSpan(GpuSpan span) {
+  const auto &spanData = mGpuSpans.at(span.getIndex());
+
+  mQueries.erase(spanData.markStart);
+  mQueries.erase(spanData.markEnd);
+  mGpuSpans.erase(span.getIndex());
+}
+
+void MetricsCollector::getResults(rhi::RenderDevice *device) {
+  if (!mCollect) {
+    mRecordedTimestamps.clear();
+    mRecordedSpans.clear();
+    return;
+  }
+
+  QUOLL_PROFILE_EVENT("MetricsCollector::getResults");
+  device->collectTimestamps(mRecordedTimestamps);
+
+  mCollectedTimestamps.reserve(mRecordedTimestamps.size());
+  mCollectedTimestamps.clear();
+  for (auto ts : mRecordedTimestamps) {
+    mCollectedTimestamps.push_back(ts);
+  }
+  mRecordedTimestamps.clear();
+
+  mCollectedSpans.reserve(mRecordedSpans.size());
+  mCollectedSpans.clear();
+  for (auto spanIndex : mRecordedSpans) {
+    mCollectedSpans.push_back(spanIndex);
+  }
+  mRecordedSpans.clear();
+
+  mCollect = false;
+}
+
+void MetricsCollector::markForCollection() { mCollect = true; }
+
+std::vector<MetricsCollector::Metric> MetricsCollector::measure(f32 converter) {
+  std::vector<Metric> metrics;
+  metrics.reserve(mGpuSpans.size());
+  for (auto spanIndex : mCollectedSpans) {
+    const auto &span = mGpuSpans.at(spanIndex);
+
+    f32 value =
+        static_cast<f32>(mCollectedTimestamps.at(mQueries.at(span.markEnd)) -
+                         mCollectedTimestamps.at(mQueries.at(span.markStart))) *
+        converter;
+
+    metrics.push_back({.label = span.label, .value = value});
+  }
+
+  return metrics;
+}
+
+usize MetricsCollector::createMark() {
+  auto mark = mQueries.insert(0);
+
+  mRecordedTimestamps.reserve(mQueries.size());
+
+  return mark;
+}
+
+} // namespace quoll

--- a/engine/src/quoll/profiler/MetricsCollector.h
+++ b/engine/src/quoll/profiler/MetricsCollector.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "quoll/core/SparseSet.h"
+#include "quoll/rhi/RenderDevice.h"
+#include "GpuSpan.h"
+
+namespace quoll {
+
+class MetricsCollector {
+  friend class GpuSpan;
+
+private:
+  struct GpuSpanData {
+    String label;
+    usize markStart;
+    usize markEnd;
+  };
+
+  struct Metric {
+    String label;
+    f32 value;
+  };
+
+public:
+  GpuSpan createGpuSpan(String label);
+
+  void deleteGpuSpan(GpuSpan span);
+
+  void getResults(rhi::RenderDevice *device);
+
+  void markForCollection();
+
+  std::vector<Metric> measure(f32 converter);
+
+  inline u32 getQueryForMark(usize mark) {
+    QuollAssert(mQueries.contains(mark), "Query does not exist");
+    return mQueries.at(mark);
+  }
+
+  inline const GpuSpanData &getGpuSpanData(usize index) const {
+    QuollAssert(index < mGpuSpans.size(), "Span does not exist");
+    return mGpuSpans.at(index);
+  }
+
+  inline usize getNumQueries() const { return mQueries.size(); }
+
+  inline usize getNumCollectedTimestamps() {
+    return mCollectedTimestamps.size();
+  }
+
+private:
+  usize createMark();
+
+private:
+  SparseSet<GpuSpanData> mGpuSpans;
+  SparseSet<u32> mQueries;
+  std::vector<u64> mRecordedTimestamps;
+  std::vector<u64> mCollectedTimestamps;
+
+  std::vector<usize> mRecordedSpans;
+  std::vector<usize> mCollectedSpans;
+
+  bool mCollect = false;
+};
+
+} // namespace quoll

--- a/engine/src/quoll/renderer/Material.cpp
+++ b/engine/src/quoll/renderer/Material.cpp
@@ -1,6 +1,8 @@
 #include "quoll/core/Base.h"
 #include "quoll/core/Engine.h"
+#include "quoll/rhi/BufferDescription.h"
 #include "Material.h"
+#include "RenderStorage.h"
 
 namespace quoll {
 

--- a/engine/src/quoll/renderer/Material.h
+++ b/engine/src/quoll/renderer/Material.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include "quoll/core/Property.h"
-#include "quoll/renderer/RenderStorage.h"
+#include "quoll/rhi/Buffer.h"
 #include "quoll/rhi/Descriptor.h"
+#include "quoll/rhi/DeviceAddress.h"
 #include "quoll/rhi/RenderHandle.h"
 
 namespace quoll {
+
+class RenderStorage;
 
 class Material {
 public:

--- a/engine/src/quoll/renderer/Presenter.cpp
+++ b/engine/src/quoll/renderer/Presenter.cpp
@@ -3,6 +3,7 @@
 #include "quoll/rhi/Descriptor.h"
 #include "quoll/rhi/RenderDevice.h"
 #include "Presenter.h"
+#include "RenderStorage.h"
 
 namespace quoll {
 

--- a/engine/src/quoll/renderer/Presenter.h
+++ b/engine/src/quoll/renderer/Presenter.h
@@ -3,9 +3,10 @@
 #include "quoll/rhi/RenderCommandList.h"
 #include "quoll/rhi/RenderHandle.h"
 #include "quoll/rhi/Swapchain.h"
-#include "RenderStorage.h"
 
 namespace quoll {
+
+class RenderStorage;
 
 class Presenter {
 public:

--- a/engine/src/quoll/renderer/RenderGraph.h
+++ b/engine/src/quoll/renderer/RenderGraph.h
@@ -1,12 +1,16 @@
 #pragma once
 
+#include "quoll/profiler/GpuSpan.h"
 #include "quoll/rhi/RenderDevice.h"
 #include "RenderGraphPass.h"
 #include "RenderGraphRegistry.h"
 #include "RenderGraphResource.h"
-#include "RenderStorage.h"
 
 namespace quoll {
+
+class RenderStorage;
+class GpuSpan;
+class MetricsCollector;
 
 enum class GraphDirty { None, PassChanges, SizeUpdate };
 
@@ -62,12 +66,15 @@ private:
 
   void buildComputePass(RenderGraphPass &pass, RenderStorage &storage);
 
+  void buildTimestamps(MetricsCollector &peformanceCollector);
+
 private:
   RenderGraphRegistry mRegistry;
   String mName;
 
   std::vector<RenderGraphPass> mPasses;
   std::vector<RenderGraphPass> mCompiledPasses;
+  std::vector<GpuSpan> mCompiledPassSpans;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/RenderGraphRegistry.h
+++ b/engine/src/quoll/renderer/RenderGraphRegistry.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "quoll/rhi/BufferDescription.h"
 #include "quoll/rhi/RenderHandle.h"
-#include "RenderStorage.h"
+#include "quoll/rhi/TextureDescription.h"
 
 namespace quoll {
+
+class RenderStorage;
 
 struct RGTextureViewDescription {
   usize textureIndex = 0;

--- a/engine/src/quoll/renderer/RenderStorage.cpp
+++ b/engine/src/quoll/renderer/RenderStorage.cpp
@@ -5,7 +5,9 @@ namespace quoll {
 
 static constexpr u32 Hundred = 100;
 
-RenderStorage::RenderStorage(rhi::RenderDevice *device) : mDevice(device) {
+RenderStorage::RenderStorage(rhi::RenderDevice *device,
+                             MetricsCollector &metricsCollector)
+    : mDevice(device), mMetricsCollector(metricsCollector) {
   static constexpr u32 NumSamplers = 1000;
   static constexpr u32 MaxBuffers = 1000;
 

--- a/engine/src/quoll/renderer/RenderStorage.h
+++ b/engine/src/quoll/renderer/RenderStorage.h
@@ -6,6 +6,8 @@
 
 namespace quoll {
 
+class MetricsCollector;
+
 /**
  * @brief Render storage
  *
@@ -14,7 +16,7 @@ namespace quoll {
  */
 class RenderStorage {
 public:
-  RenderStorage(rhi::RenderDevice *device);
+  RenderStorage(rhi::RenderDevice *device, MetricsCollector &metricsCollector);
 
   RenderStorage(const RenderStorage &) = delete;
   RenderStorage &operator=(const RenderStorage &) = delete;
@@ -81,6 +83,8 @@ public:
         mPipelineDescriptions.at(static_cast<usize>(handle) - 1));
   }
 
+  inline MetricsCollector &getMetricsCollector() { return mMetricsCollector; }
+
 private:
   rhi::RenderDevice *mDevice = nullptr;
 
@@ -102,6 +106,8 @@ private:
   rhi::SamplerHandle mDefaultSampler = rhi::SamplerHandle::Null;
 
   std::unordered_map<String, rhi::ShaderHandle> mShaderMap;
+
+  MetricsCollector &mMetricsCollector;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/Renderer.cpp
+++ b/engine/src/quoll/renderer/Renderer.cpp
@@ -35,7 +35,6 @@ void Renderer::rebuildIfSettingsChanged() {
 }
 
 void Renderer::execute(rhi::RenderCommandList &commandList, u32 frameIndex) {
-
   mGraph.execute(commandList, frameIndex);
 }
 

--- a/engine/src/quoll/renderer/SceneRenderer.cpp
+++ b/engine/src/quoll/renderer/SceneRenderer.cpp
@@ -10,6 +10,7 @@
 #include "Mesh.h"
 #include "MeshRenderUtils.h"
 #include "MeshVertexLayout.h"
+#include "RenderStorage.h"
 #include "SceneRenderer.h"
 #include "SkinnedMesh.h"
 #include "StandardPushConstants.h"

--- a/engine/src/quoll/renderer/SceneRendererFrameData.cpp
+++ b/engine/src/quoll/renderer/SceneRendererFrameData.cpp
@@ -3,6 +3,7 @@
 #include "quoll/rhi/RenderHandle.h"
 #include "quoll/scene/DirectionalLight.h"
 #include "quoll/scene/PointLight.h"
+#include "RenderStorage.h"
 #include "SceneRendererFrameData.h"
 
 namespace quoll {

--- a/engine/tests/quoll-tests/profiler/MetricsCollector.test.cpp
+++ b/engine/tests/quoll-tests/profiler/MetricsCollector.test.cpp
@@ -1,0 +1,322 @@
+#include "quoll/core/Base.h"
+#include "quoll/profiler/MetricsCollector.h"
+#include "quoll/rhi-mock/MockRenderDevice.h"
+#include "quoll-tests/Testing.h"
+
+class MetricsCollectorTest : public ::testing::Test {
+public:
+  quoll::rhi::MockRenderDevice device;
+  quoll::MetricsCollector collector;
+};
+
+using MetricsCollectorDeathTest = MetricsCollectorTest;
+
+TEST_F(MetricsCollectorTest, CreatesGpuSpanWithLabelAndMarks) {
+  {
+    auto spanView = collector.createGpuSpan("Span 1");
+    EXPECT_EQ(spanView.getIndex(), 0);
+    EXPECT_EQ(spanView.getStartMark(), 0);
+    EXPECT_EQ(spanView.getEndMark(), 1);
+
+    auto span = collector.getGpuSpanData(0);
+    EXPECT_EQ(span.label, "Span 1");
+    EXPECT_EQ(span.markStart, 0);
+    EXPECT_EQ(span.markEnd, 1);
+  }
+
+  {
+    auto spanView = collector.createGpuSpan("Span 2");
+    EXPECT_EQ(spanView.getIndex(), 1);
+    EXPECT_EQ(spanView.getStartMark(), 2);
+    EXPECT_EQ(spanView.getEndMark(), 3);
+
+    auto span = collector.getGpuSpanData(1);
+    EXPECT_EQ(span.label, "Span 2");
+    EXPECT_EQ(span.markStart, 2);
+    EXPECT_EQ(span.markEnd, 3);
+  }
+}
+
+TEST_F(MetricsCollectorTest, CreatingSpansInitializesQueriesForEachSpan) {
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+
+  EXPECT_EQ(collector.getNumQueries(), 6);
+  EXPECT_EQ(collector.getQueryForMark(span1.getStartMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span1.getEndMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span2.getStartMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span2.getEndMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span3.getStartMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span3.getEndMark()), 0);
+}
+
+TEST_F(MetricsCollectorDeathTest,
+       DeletingGpuSpanGetsRidOfTheSpanMarksAndTimestamps) {
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+
+  collector.deleteGpuSpan(span2);
+
+  EXPECT_DEATH(collector.getGpuSpanData(1), ".*");
+  EXPECT_DEATH(collector.getQueryForMark(span2.getStartMark()), ".*");
+  EXPECT_DEATH(collector.getQueryForMark(span2.getEndMark()), ".*");
+}
+
+TEST_F(MetricsCollectorTest, DeletingSpanDeletesQueriesAssociatedWithSpan) {
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+  auto span4 = collector.createGpuSpan("Span 4");
+  auto span5 = collector.createGpuSpan("Span 5");
+  auto span6 = collector.createGpuSpan("Span 6");
+
+  EXPECT_EQ(collector.getNumQueries(), 12);
+
+  collector.deleteGpuSpan(span3);
+
+  EXPECT_EQ(collector.getNumQueries(), 10);
+  EXPECT_EQ(collector.getQueryForMark(span1.getStartMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span1.getEndMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span2.getStartMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span2.getEndMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span4.getStartMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span4.getEndMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span5.getStartMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span5.getEndMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span6.getStartMark()), 0);
+  EXPECT_EQ(collector.getQueryForMark(span6.getEndMark()), 0);
+}
+
+TEST_F(MetricsCollectorTest, CreatingSpansDoesNotAffectTimestamps) {
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+
+  EXPECT_EQ(collector.getNumCollectedTimestamps(), 0);
+}
+
+TEST_F(MetricsCollectorTest, DeletingSpansDoesNotAffectTimestamps) {
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+
+  collector.deleteGpuSpan(span2);
+
+  EXPECT_EQ(collector.getNumCollectedTimestamps(), 0);
+}
+
+TEST_F(MetricsCollectorTest,
+       GetResultsDoesNothingIfNoSpanHasWrittenTimestamps) {
+  device.setTimestampCollectorFn([](auto &timestamps) {
+    for (usize i = 0; i < timestamps.size(); ++i) {
+      timestamps.at(i) = (i + 2) * (i + 2);
+    }
+  });
+
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+
+  collector.getResults(&device);
+
+  EXPECT_EQ(collector.getNumCollectedTimestamps(), 0);
+}
+
+TEST_F(MetricsCollectorTest, GpuSpanBeginCallsTimestampWithBeginQueryIndex) {
+  auto commandList = device.requestImmediateCommandList();
+
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+
+  span1.begin(commandList);
+  span2.begin(commandList);
+
+  const auto &commands = static_cast<const quoll::rhi::MockCommandList *>(
+                             commandList.getNativeRenderCommandList().get())
+                             ->getCommands();
+
+  EXPECT_EQ(commands.size(), 2);
+
+  auto *cmd0 =
+      static_cast<quoll::rhi::MockCommandTimestamp *>(commands.at(0).get());
+  auto *cmd1 =
+      static_cast<quoll::rhi::MockCommandTimestamp *>(commands.at(1).get());
+
+  EXPECT_EQ(cmd0->queryIndex, 0);
+  EXPECT_EQ(cmd0->stage, quoll::rhi::PipelineStage::PipeTop);
+  EXPECT_EQ(cmd1->queryIndex, 1);
+  EXPECT_EQ(cmd1->stage, quoll::rhi::PipelineStage::PipeTop);
+}
+
+TEST_F(MetricsCollectorTest, GpuSpanEndCallsTimestampWithEndQueryIndex) {
+  auto commandList = device.requestImmediateCommandList();
+
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+
+  span1.end(commandList);
+  span2.end(commandList);
+
+  const auto &commands = static_cast<const quoll::rhi::MockCommandList *>(
+                             commandList.getNativeRenderCommandList().get())
+                             ->getCommands();
+
+  EXPECT_EQ(commands.size(), 2);
+
+  auto *cmd0 =
+      static_cast<quoll::rhi::MockCommandTimestamp *>(commands.at(0).get());
+  auto *cmd1 =
+      static_cast<quoll::rhi::MockCommandTimestamp *>(commands.at(1).get());
+
+  EXPECT_EQ(cmd0->queryIndex, 0);
+  EXPECT_EQ(cmd0->stage, quoll::rhi::PipelineStage::PipeBottom);
+  EXPECT_EQ(cmd1->queryIndex, 1);
+  EXPECT_EQ(cmd1->stage, quoll::rhi::PipelineStage::PipeBottom);
+}
+
+TEST_F(MetricsCollectorTest,
+       GetResultProvidesTimestampsForSpansThatHaveWrittenTimestamps) {
+  auto commandList = device.requestImmediateCommandList();
+
+  device.setTimestampCollectorFn([](auto &timestamps) {
+    for (usize i = 0; i < timestamps.size(); ++i) {
+      timestamps.at(i) = (i + 2) * (i + 2);
+    }
+  });
+
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+
+  span1.begin(commandList);
+  span3.end(commandList);
+
+  collector.markForCollection();
+  collector.getResults(&device);
+
+  EXPECT_EQ(collector.getNumCollectedTimestamps(), 2);
+}
+
+TEST_F(MetricsCollectorTest,
+       SubsequentTimestampWritesIncreasesNumberOfTimestamps) {
+  auto commandList = device.requestImmediateCommandList();
+
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+
+  span1.begin(commandList);
+  span3.end(commandList);
+
+  span1.begin(commandList);
+  span3.end(commandList);
+
+  collector.markForCollection();
+  collector.getResults(&device);
+
+  EXPECT_EQ(collector.getNumCollectedTimestamps(), 4);
+}
+
+TEST_F(MetricsCollectorTest, GetResultClearsRecordedTimestamps) {
+  auto commandList = device.requestImmediateCommandList();
+
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+
+  span1.begin(commandList);
+  span3.end(commandList);
+
+  collector.markForCollection();
+  collector.getResults(&device);
+
+  span1.begin(commandList);
+  span3.end(commandList);
+
+  EXPECT_EQ(collector.getNumCollectedTimestamps(), 2);
+}
+
+TEST_F(MetricsCollectorTest, GetResultsDoesNothingIfNotMarkedForCollection) {
+  auto commandList = device.requestImmediateCommandList();
+
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+
+  span1.begin(commandList);
+  span3.end(commandList);
+
+  collector.getResults(&device);
+
+  span1.begin(commandList);
+  span3.end(commandList);
+
+  EXPECT_EQ(collector.getNumCollectedTimestamps(), 0);
+}
+
+TEST_F(MetricsCollectorTest, MeasureCalculatesSpanDurationsBasedOnTimestamps) {
+  auto commandList = device.requestImmediateCommandList();
+
+  device.setTimestampCollectorFn([](auto &timestamps) {
+    for (usize i = 0; i < timestamps.size(); ++i) {
+      timestamps.at(i) = (i + 2) * (i + 2);
+    }
+  });
+
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+
+  span1.begin(commandList);
+  span1.end(commandList);
+  span2.begin(commandList);
+  span2.end(commandList);
+  span3.begin(commandList);
+  span3.end(commandList);
+
+  collector.markForCollection();
+  collector.getResults(&device);
+
+  auto metrics = collector.measure(2.5f);
+
+  EXPECT_EQ(metrics.size(), 3);
+  EXPECT_EQ(metrics.at(0).label, "Span 1");
+  EXPECT_EQ(metrics.at(1).label, "Span 2");
+  EXPECT_EQ(metrics.at(2).label, "Span 3");
+
+  EXPECT_EQ(metrics.at(0).value, 12.5f);
+  EXPECT_EQ(metrics.at(1).value, 22.5f);
+  EXPECT_EQ(metrics.at(2).value, 32.5f);
+}
+
+TEST_F(MetricsCollectorTest, MeasureIgnoresSpansThatHaveNotWrittenTimestamps) {
+  auto commandList = device.requestImmediateCommandList();
+
+  device.setTimestampCollectorFn([](auto &timestamps) {
+    for (usize i = 0; i < timestamps.size(); ++i) {
+      timestamps.at(i) = (i + 2) * (i + 2);
+    }
+  });
+
+  auto span1 = collector.createGpuSpan("Span 1");
+  auto span2 = collector.createGpuSpan("Span 2");
+  auto span3 = collector.createGpuSpan("Span 3");
+
+  span1.begin(commandList);
+  span1.end(commandList);
+  span3.begin(commandList);
+  span3.end(commandList);
+
+  collector.markForCollection();
+  collector.getResults(&device);
+
+  auto metrics = collector.measure(2.5f);
+
+  EXPECT_EQ(metrics.size(), 2);
+  EXPECT_EQ(metrics.at(0).label, "Span 1");
+  EXPECT_EQ(metrics.at(1).label, "Span 3");
+
+  EXPECT_EQ(metrics.at(0).value, 12.5f);
+  EXPECT_EQ(metrics.at(1).value, 22.5f);
+}

--- a/engine/tests/quoll-tests/renderer/Material.test.cpp
+++ b/engine/tests/quoll-tests/renderer/Material.test.cpp
@@ -1,13 +1,17 @@
 #include "quoll/core/Base.h"
+#include "quoll/profiler/MetricsCollector.h"
 #include "quoll/renderer/Material.h"
+#include "quoll/renderer/RenderStorage.h"
 #include "quoll/rhi-mock/MockRenderDevice.h"
 #include "quoll-tests/Testing.h"
 
 class MaterialTest : public ::testing::Test {
 public:
-  MaterialTest() : renderStorage(&device) {}
+  MaterialTest() : renderStorage(&device, metricsCollector) {}
 
   quoll::rhi::MockRenderDevice device;
+  quoll::MetricsCollector metricsCollector;
+
   quoll::RenderStorage renderStorage;
 };
 

--- a/engine/tests/quoll-tests/renderer/MaterialPBR.test.cpp
+++ b/engine/tests/quoll-tests/renderer/MaterialPBR.test.cpp
@@ -1,13 +1,17 @@
 #include "quoll/core/Base.h"
+#include "quoll/profiler/MetricsCollector.h"
 #include "quoll/renderer/MaterialPBR.h"
+#include "quoll/renderer/RenderStorage.h"
 #include "quoll/rhi-mock/MockRenderDevice.h"
 #include "quoll-tests/Testing.h"
 
 class MaterialPBRTest : public ::testing::Test {
 public:
-  MaterialPBRTest() : renderStorage(&device) {}
+  MaterialPBRTest() : renderStorage(&device, metricsCollector) {}
 
   quoll::rhi::MockRenderDevice device;
+  quoll::MetricsCollector metricsCollector;
+
   quoll::RenderStorage renderStorage;
 };
 

--- a/engine/tests/quoll-tests/renderer/RenderGraph.test.cpp
+++ b/engine/tests/quoll-tests/renderer/RenderGraph.test.cpp
@@ -1,5 +1,7 @@
 #include "quoll/core/Base.h"
+#include "quoll/profiler/MetricsCollector.h"
 #include "quoll/renderer/RenderGraph.h"
+#include "quoll/renderer/RenderStorage.h"
 #include "quoll/rhi-mock/MockRenderDevice.h"
 #include "quoll-tests/Testing.h"
 
@@ -7,7 +9,7 @@ using namespace quoll::rhi;
 
 class RenderGraphTest : public ::testing::Test {
 public:
-  RenderGraphTest() : graph("TestGraph"), storage(&device) {}
+  RenderGraphTest() : graph("TestGraph"), storage(&device, metricsCollector) {}
 
   quoll::RenderGraphResource<TextureHandle>
   createTexture(quoll::rhi::TextureDescription desc) {
@@ -15,6 +17,7 @@ public:
   }
 
   MockRenderDevice device;
+  quoll::MetricsCollector metricsCollector;
   quoll::RenderStorage storage;
   quoll::RenderGraph graph;
 

--- a/rhi/core/include/quoll/rhi/NativeRenderCommandListInterface.h
+++ b/rhi/core/include/quoll/rhi/NativeRenderCommandListInterface.h
@@ -74,6 +74,8 @@ public:
 
   virtual void blitTexture(TextureHandle source, TextureHandle destination,
                            std::span<BlitRegion> regions, Filter filter) = 0;
+
+  virtual void writeTimestamp(u32 timestamp, PipelineStage stage) = 0;
 };
 
 } // namespace quoll::rhi

--- a/rhi/core/include/quoll/rhi/RenderCommandList.h
+++ b/rhi/core/include/quoll/rhi/RenderCommandList.h
@@ -117,6 +117,10 @@ public:
     mNativeRenderCommandList->blitTexture(source, destination, regions, filter);
   }
 
+  inline void writeTimestamp(u32 queryIndex, PipelineStage stage) {
+    mNativeRenderCommandList->writeTimestamp(queryIndex, stage);
+  }
+
 private:
   std::unique_ptr<NativeRenderCommandListInterface> mNativeRenderCommandList;
 };

--- a/rhi/core/include/quoll/rhi/RenderDevice.h
+++ b/rhi/core/include/quoll/rhi/RenderDevice.h
@@ -39,6 +39,8 @@ public:
 
   virtual void endFrame(const RenderFrame &renderFrame) = 0;
 
+  virtual void collectTimestamps(std::vector<u64> &timestamps) = 0;
+
   virtual void waitForIdle() = 0;
 
   virtual const PhysicalDeviceInformation getDeviceInformation() = 0;

--- a/rhi/core/include/quoll/rhi/StageFlags.h
+++ b/rhi/core/include/quoll/rhi/StageFlags.h
@@ -14,6 +14,8 @@ EnableBitwiseEnum(ShaderStage);
 
 enum class PipelineStage : u64 {
   None = 0ULL,
+  PipeTop = 0x00000001ULL,
+  PipeBottom = 0x00002000ULL,
   DrawIndirect = 0x00000002ULL,
   VertexShader = 0x00000008ULL,
   FragmentShader = 0x00000080ULL,

--- a/rhi/mock/include/quoll/rhi-mock/MockCommand.h
+++ b/rhi/mock/include/quoll/rhi-mock/MockCommand.h
@@ -18,7 +18,8 @@ enum class MockCommandType {
   PipelineBarrier,
   CopyTextureToBuffer,
   CopyBufferToTexture,
-  BlitTexture
+  BlitTexture,
+  Timestamp
 };
 
 struct MockCommand {};
@@ -172,6 +173,12 @@ struct MockCommandBlitTexture
   std::vector<BlitRegion> regions;
 
   Filter filter;
+};
+
+struct MockCommandTimestamp
+    : public MockCommandTyped<MockCommandType::Timestamp> {
+  u32 queryIndex = std::numeric_limits<u32>::max();
+  PipelineStage stage;
 };
 
 } // namespace quoll::rhi

--- a/rhi/mock/include/quoll/rhi-mock/MockCommandList.h
+++ b/rhi/mock/include/quoll/rhi-mock/MockCommandList.h
@@ -73,6 +73,8 @@ public:
 
   void clear();
 
+  void writeTimestamp(u32 queryIndex, PipelineStage stage);
+
 private:
   MockBindings mBindings;
 

--- a/rhi/mock/include/quoll/rhi-mock/MockRenderDevice.h
+++ b/rhi/mock/include/quoll/rhi-mock/MockRenderDevice.h
@@ -18,6 +18,11 @@ public:
     return mBuffers.at(handle).get();
   }
 
+  inline void
+  setTimestampCollectorFn(std::function<void(std::vector<u64> &)> &&fn) {
+    mTimestampCollectorFn = fn;
+  }
+
 public:
   RenderCommandList requestImmediateCommandList() override;
 
@@ -26,6 +31,8 @@ public:
   RenderFrame beginFrame() override;
 
   void endFrame(const RenderFrame &renderFrame) override;
+
+  void collectTimestamps(std::vector<u64> &timestamps) override;
 
   void waitForIdle() override;
 
@@ -133,6 +140,8 @@ private:
   u32 mFrameIndex = 0;
 
   DeviceStats mDeviceStats;
+
+  std::function<void(std::vector<u64> &)> mTimestampCollectorFn = [](auto &) {};
 };
 
 } // namespace quoll::rhi

--- a/rhi/mock/src/MockCommandList.cpp
+++ b/rhi/mock/src/MockCommandList.cpp
@@ -202,4 +202,12 @@ void MockCommandList::clear() {
   mCommands.clear();
 }
 
+void MockCommandList::writeTimestamp(u32 queryIndex, rhi::PipelineStage stage) {
+  auto *command = new MockCommandTimestamp;
+  command->queryIndex = queryIndex;
+  command->stage = stage;
+
+  mCommands.push_back(std::unique_ptr<MockCommand>(command));
+}
+
 } // namespace quoll::rhi

--- a/rhi/mock/src/MockRenderDevice.cpp
+++ b/rhi/mock/src/MockRenderDevice.cpp
@@ -35,6 +35,10 @@ void MockRenderDevice::endFrame(const RenderFrame &renderFrame) {
   mockCommandList->clear();
 }
 
+void MockRenderDevice::collectTimestamps(std::vector<u64> &timestamps) {
+  mTimestampCollectorFn(timestamps);
+}
+
 void MockRenderDevice::waitForIdle() {
   // Do nothing
 }

--- a/rhi/vulkan/include/quoll/rhi-vulkan/VulkanCommandBuffer.h
+++ b/rhi/vulkan/include/quoll/rhi-vulkan/VulkanCommandBuffer.h
@@ -4,6 +4,7 @@
 #include "quoll/rhi/NativeRenderCommandListInterface.h"
 #include "VulkanDescriptorPool.h"
 #include "VulkanResourceRegistry.h"
+#include "VulkanTimestampManager.h"
 
 namespace quoll::rhi {
 
@@ -12,6 +13,7 @@ public:
   VulkanCommandBuffer(VkCommandBuffer commandBuffer,
                       const VulkanResourceRegistry &registry,
                       const VulkanDescriptorPool &descriptorPool,
+                      const VulkanTimestampManager &timestampManager,
                       DeviceStats &stats);
 
   ~VulkanCommandBuffer() = default;
@@ -72,11 +74,14 @@ public:
   void blitTexture(TextureHandle source, TextureHandle destination,
                    std::span<BlitRegion> regions, Filter filter) override;
 
+  void writeTimestamp(u32 queryIndex, PipelineStage stage) override;
+
 private:
   VkCommandBuffer mCommandBuffer = VK_NULL_HANDLE;
 
   const VulkanResourceRegistry &mRegistry;
   const VulkanDescriptorPool &mDescriptorPool;
+  const VulkanTimestampManager &mTimestampManager;
   DeviceStats &mStats;
 };
 

--- a/rhi/vulkan/include/quoll/rhi-vulkan/VulkanCommandPool.h
+++ b/rhi/vulkan/include/quoll/rhi-vulkan/VulkanCommandPool.h
@@ -4,6 +4,7 @@
 #include "quoll/rhi/RenderCommandList.h"
 #include "VulkanDescriptorPool.h"
 #include "VulkanDeviceObject.h"
+#include "VulkanTimestampManager.h"
 
 namespace quoll::rhi {
 
@@ -12,6 +13,7 @@ public:
   VulkanCommandPool(VulkanDeviceObject &device, u32 queueFamilyIndex,
                     const VulkanResourceRegistry &registry,
                     const VulkanDescriptorPool &descriptorPool,
+                    const VulkanTimestampManager &timestampManager,
                     DeviceStats &stats);
 
   ~VulkanCommandPool();
@@ -31,6 +33,7 @@ private:
   DeviceStats &mStats;
   const VulkanResourceRegistry &mRegistry;
   const VulkanDescriptorPool &mDescriptorPool;
+  const VulkanTimestampManager &mTimestampManager;
   u32 mQueueFamilyIndex = 0;
 };
 

--- a/rhi/vulkan/include/quoll/rhi-vulkan/VulkanRenderDevice.h
+++ b/rhi/vulkan/include/quoll/rhi-vulkan/VulkanRenderDevice.h
@@ -13,6 +13,7 @@
 #include "VulkanResourceAllocator.h"
 #include "VulkanResourceRegistry.h"
 #include "VulkanSwapchain.h"
+#include "VulkanTimestampManager.h"
 #include "VulkanUploadContext.h"
 
 namespace quoll::rhi {
@@ -29,6 +30,8 @@ public:
   RenderFrame beginFrame() override;
 
   void endFrame(const RenderFrame &renderFrame) override;
+
+  void collectTimestamps(std::vector<u64> &timestamps) override;
 
   void waitForIdle() override;
 
@@ -100,6 +103,7 @@ private:
   VulkanQueue mGraphicsQueue;
 
   VulkanFrameManager mFrameManager;
+  VulkanTimestampManager mTimestampManager;
   VulkanResourceAllocator mAllocator;
   VulkanResourceRegistry mRegistry;
   VulkanPipelineLayoutCache mPipelineLayoutCache;

--- a/rhi/vulkan/include/quoll/rhi-vulkan/VulkanTimestampManager.h
+++ b/rhi/vulkan/include/quoll/rhi-vulkan/VulkanTimestampManager.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "quoll/rhi/RenderDevice.h"
+#include "VulkanDeviceObject.h"
+
+namespace quoll::rhi {
+
+class VulkanTimestampManager {
+public:
+  VulkanTimestampManager(VulkanDeviceObject &device);
+
+  ~VulkanTimestampManager();
+
+  VulkanTimestampManager(const VulkanTimestampManager &) = delete;
+  VulkanTimestampManager &operator=(const VulkanTimestampManager &) = delete;
+  VulkanTimestampManager(VulkanTimestampManager &&) = delete;
+  VulkanTimestampManager &operator=(VulkanTimestampManager &&) = delete;
+
+  inline VkQueryPool getQueryPool() const {
+    return mQueryPools.at(mCurrentFrame);
+  }
+
+  void reset();
+
+  void setCurrentFrame(u32 frameIndex);
+
+private:
+  VulkanDeviceObject &mDevice;
+  usize mCurrentFrame = 0;
+  std::array<VkQueryPool, RenderDevice::NumFrames> mQueryPools{};
+};
+
+} // namespace quoll::rhi

--- a/rhi/vulkan/src/VulkanCommandBuffer.cpp
+++ b/rhi/vulkan/src/VulkanCommandBuffer.cpp
@@ -11,9 +11,11 @@ namespace quoll::rhi {
 
 VulkanCommandBuffer::VulkanCommandBuffer(
     VkCommandBuffer commandBuffer, const VulkanResourceRegistry &registry,
-    const VulkanDescriptorPool &descriptorPool, DeviceStats &stats)
+    const VulkanDescriptorPool &descriptorPool,
+    const VulkanTimestampManager &timestampManager, DeviceStats &stats)
     : mCommandBuffer(commandBuffer), mRegistry(registry),
-      mDescriptorPool(descriptorPool), mStats(stats) {}
+      mDescriptorPool(descriptorPool), mTimestampManager(timestampManager),
+      mStats(stats) {}
 
 void VulkanCommandBuffer::beginRenderPass(rhi::RenderPassHandle renderPass,
                                           FramebufferHandle framebuffer,
@@ -327,6 +329,12 @@ void VulkanCommandBuffer::blitTexture(TextureHandle source,
                  dstImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                  static_cast<u32>(regions.size()), vkRegions.data(),
                  VulkanMapping::getFilter(filter));
+}
+
+void VulkanCommandBuffer::writeTimestamp(u32 queryIndex, PipelineStage stage) {
+  vkCmdWriteTimestamp2KHR(mCommandBuffer,
+                          VulkanMapping::getPipelineStageFlags(stage),
+                          mTimestampManager.getQueryPool(), queryIndex);
 }
 
 } // namespace quoll::rhi

--- a/rhi/vulkan/src/VulkanCommandPool.cpp
+++ b/rhi/vulkan/src/VulkanCommandPool.cpp
@@ -7,13 +7,14 @@
 
 namespace quoll::rhi {
 
-VulkanCommandPool::VulkanCommandPool(VulkanDeviceObject &device,
-                                     u32 queueFamilyIndex,
-                                     const VulkanResourceRegistry &registry,
-                                     const VulkanDescriptorPool &descriptorPool,
-                                     DeviceStats &stats)
+VulkanCommandPool::VulkanCommandPool(
+    VulkanDeviceObject &device, u32 queueFamilyIndex,
+    const VulkanResourceRegistry &registry,
+    const VulkanDescriptorPool &descriptorPool,
+    const VulkanTimestampManager &timestampManager, DeviceStats &stats)
     : mDevice(device), mRegistry(registry), mDescriptorPool(descriptorPool),
-      mStats(stats), mQueueFamilyIndex(queueFamilyIndex) {
+      mStats(stats), mQueueFamilyIndex(queueFamilyIndex),
+      mTimestampManager(timestampManager) {
   VkCommandPoolCreateInfo poolInfo{};
   poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
   poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
@@ -50,9 +51,9 @@ VulkanCommandPool::createCommandLists(u32 count) {
       "Failed to allocate command buffers");
 
   for (usize i = 0; i < count; ++i) {
-    renderCommandLists.at(i) =
-        std::move(RenderCommandList(new VulkanCommandBuffer(
-            commandBuffers.at(i), mRegistry, mDescriptorPool, mStats)));
+    renderCommandLists.at(i) = std::move(RenderCommandList(
+        new VulkanCommandBuffer(commandBuffers.at(i), mRegistry,
+                                mDescriptorPool, mTimestampManager, mStats)));
   }
 
   LOG_DEBUG_VK("Command buffers allocated for queue family "

--- a/rhi/vulkan/src/VulkanTimestampManager.cpp
+++ b/rhi/vulkan/src/VulkanTimestampManager.cpp
@@ -1,0 +1,50 @@
+#include "quoll/core/Base.h"
+#include "VulkanError.h"
+#include "VulkanLog.h"
+#include "VulkanTimestampManager.h"
+
+namespace quoll::rhi {
+
+static constexpr u32 QueryCount = 1000;
+
+VulkanTimestampManager::VulkanTimestampManager(VulkanDeviceObject &device)
+    : mDevice(device) {
+
+  VkQueryPoolCreateInfo createInfo{};
+  createInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+  createInfo.pNext = nullptr;
+  createInfo.flags = 0;
+  createInfo.queryCount = QueryCount;
+  createInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
+
+  for (usize i = 0; i < mQueryPools.size(); ++i) {
+    VkQueryPool queryPool = VK_NULL_HANDLE;
+    String name = "timestamp query pool frame " + std::to_string(i);
+    checkForVulkanError(
+        vkCreateQueryPool(mDevice, &createInfo, nullptr, &queryPool),
+        "Cannot create query pool", name);
+
+    mDevice.setObjectName(name, VK_OBJECT_TYPE_QUERY_POOL, queryPool);
+
+    mQueryPools.at(i) = queryPool;
+    LOG_DEBUG_VK("Query pool " << name << " created", queryPool);
+  }
+}
+
+VulkanTimestampManager::~VulkanTimestampManager() {
+  for (VkQueryPool queryPool : mQueryPools) {
+    vkDestroyQueryPool(mDevice, queryPool, nullptr);
+    LOG_DEBUG_VK("Query pool destroyed", queryPool);
+  }
+}
+
+void VulkanTimestampManager::setCurrentFrame(u32 frameIndex) {
+  mCurrentFrame = static_cast<usize>(frameIndex);
+}
+
+void VulkanTimestampManager::reset() {
+  vkResetQueryPool(mDevice, mQueryPools.at(static_cast<usize>(mCurrentFrame)),
+                   0, QueryCount);
+}
+
+} // namespace quoll::rhi

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -18,6 +18,10 @@
       "features": ["docking-experimental", "glfw-binding"]
     },
     {
+      "name": "implot",
+      "default-features": false
+    },
+    {
       "name": "imguizmo",
       "default-features": false
     },


### PR DESCRIPTION
- Create metrics collector that manages spans and fetches results from render device
- Create Vulkan timestamp manager that handles query pool for timestamps across frames
- Add GPU timings to imgui debug layer
- Add write timestamps function to command list
- Add stats function to main loop that is run once a second after rendering
- Install and enable implot = Add PipeTop and PipeBottom stage flags