### PR TITLE
Use new asset methods for texture asset

### DIFF
--- a/editor/src/quoll/editor/actions/EntitySpriteActions.cpp
+++ b/editor/src/quoll/editor/actions/EntitySpriteActions.cpp
@@ -34,7 +34,7 @@ ActionExecutorResult EntitySetSprite::onUndo(WorkspaceState &state,
 
 bool EntitySetSprite::predicate(WorkspaceState &state,
                                 AssetRegistry &assetRegistry) {
-  return assetRegistry.getTextures().hasAsset(mSprite);
+  return assetRegistry.has(mSprite);
 }
 
 EntityCreateSprite::EntityCreateSprite(Entity entity,
@@ -58,7 +58,7 @@ bool EntityCreateSprite::predicate(WorkspaceState &state,
                                    AssetRegistry &assetRegistry) {
   auto &scene = state.scene;
   return !scene.entityDatabase.has<Sprite>(mEntity) &&
-         assetRegistry.getTextures().hasAsset(mHandle);
+         assetRegistry.has(mHandle);
 }
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/actions/SpawnEntityActions.cpp
+++ b/editor/src/quoll/editor/actions/SpawnEntityActions.cpp
@@ -206,7 +206,7 @@ bool SpawnSpriteAtView::predicate(WorkspaceState &state,
                                   AssetRegistry &assetRegistry) {
   auto &scene = state.scene;
 
-  return assetRegistry.getTextures().hasAsset(mHandle) &&
+  return assetRegistry.has(mHandle) &&
          scene.entityDatabase.has<Camera>(mCamera);
 }
 

--- a/editor/src/quoll/editor/asset/AssetManager.cpp
+++ b/editor/src/quoll/editor/asset/AssetManager.cpp
@@ -128,7 +128,7 @@ void AssetManager::generatePreview(const Path &sourceAssetPath,
           mHDRIImporter.loadFromPathToDevice(sourceAssetPath, renderStorage);
     }
   } else if (res.first == AssetType::Texture) {
-    auto &asset = mAssetCache.getRegistry().getTextures().getAsset(
+    auto &asset = mAssetCache.getRegistry().get(
         static_cast<quoll::AssetHandle<quoll::TextureAsset>>(handle));
 
     if (!rhi::isHandleValid(asset.preview)) {
@@ -354,8 +354,7 @@ Result<UUIDMap> AssetManager::loadSourceTexture(const Path &sourceAssetPath,
     auto res = mAssetCache.loadTexture(uuid);
 
     if (res.hasData()) {
-      auto uuid =
-          mAssetCache.getRegistry().getTextures().getAsset(res.getData()).uuid;
+      auto uuid = mAssetCache.getRegistry().get(res.getData()).uuid;
       return Result<UUIDMap>::Ok({{"root", uuid}});
     }
 

--- a/editor/src/quoll/editor/asset/HDRIImporter.cpp
+++ b/editor/src/quoll/editor/asset/HDRIImporter.cpp
@@ -129,8 +129,7 @@ Result<UUIDMap> HDRIImporter::loadFromPath(const Path &sourceAssetPath,
 
   if (specularCubemap.hasError()) {
     device->destroyTexture(unfilteredCubemap.texture);
-    mAssetCache.getRegistry().getTextures().deleteAsset(
-        irradianceCubemap.getData());
+    mAssetCache.getRegistry().remove(irradianceCubemap.getData());
 
     return Result<UUIDMap>::Error(specularCubemap.getError());
   }
@@ -157,10 +156,8 @@ Result<UUIDMap> HDRIImporter::loadFromPath(const Path &sourceAssetPath,
 
   UUIDMap output{
       {"root", registry.getEnvironments().getAsset(loadRes.getData()).uuid},
-      {"irradiance",
-       registry.getTextures().getAsset(environment.data.irradianceMap).uuid},
-      {"specular",
-       registry.getTextures().getAsset(environment.data.specularMap).uuid}};
+      {"irradiance", registry.get(environment.data.irradianceMap).uuid},
+      {"specular", registry.get(environment.data.specularMap).uuid}};
 
   return Result<UUIDMap>::Ok(output);
 }

--- a/editor/src/quoll/editor/asset/ImageLoader.cpp
+++ b/editor/src/quoll/editor/asset/ImageLoader.cpp
@@ -99,7 +99,7 @@ Result<Uuid> ImageLoader::loadFromMemory(void *data, u32 width, u32 height,
   }
 
   return Result<Uuid>::Ok(
-      mAssetCache.getRegistry().getTextures().getAsset(loadRes.getData()).uuid);
+      mAssetCache.getRegistry().get(loadRes.getData()).uuid);
 }
 
 std::vector<u8> ImageLoader::generateMipMapsFromTextureData(

--- a/editor/src/quoll/editor/asset/gltf/TextureUtils.cpp
+++ b/editor/src/quoll/editor/asset/gltf/TextureUtils.cpp
@@ -46,10 +46,10 @@ AssetHandle<TextureAsset> loadTexture(GLTFImportData &importData, usize index,
   }
 
   auto handle =
-      assetCache.getRegistry().getTextures().findHandleByUuid(uuid.getData());
+      assetCache.getRegistry().findHandleByUuid<TextureAsset>(uuid.getData());
 
   importData.outputUuids.insert_or_assign(
-      assetName, assetCache.getRegistry().getTextures().getAsset(handle).uuid);
+      assetName, assetCache.getRegistry().get(handle).uuid);
 
   importData.textures.map.insert_or_assign(index, handle);
   return handle;

--- a/editor/src/quoll/editor/scene/ui/EntityPanel.cpp
+++ b/editor/src/quoll/editor/scene/ui/EntityPanel.cpp
@@ -632,7 +632,7 @@ void EntityPanel::renderSprite(Scene &scene, AssetRegistry &assetRegistry,
     if (auto _ = widgets::Section(SectionName.c_str())) {
       auto handle = scene.entityDatabase.get<Sprite>(mSelectedEntity).handle;
 
-      const auto &asset = assetRegistry.getTextures().getAsset(handle);
+      const auto &asset = assetRegistry.get(handle);
       static constexpr glm::vec2 TextureSize(80.0f, 80.0f);
 
       if (auto table = widgets::Table("TableSprite", 2)) {
@@ -1401,7 +1401,7 @@ void EntityPanel::renderScripting(Scene &scene, AssetRegistry &assetRegistry,
                          LuaScriptVariableType::AssetTexture)) {
             auto handle =
                 script.variables.at(name).get<AssetHandle<TextureAsset>>();
-            value = assetRegistry.getTextures().getAsset(handle).name;
+            value = assetRegistry.get(handle).name;
           }
 
           table.row(name, type, value);
@@ -1474,8 +1474,7 @@ void EntityPanel::renderScripting(Scene &scene, AssetRegistry &assetRegistry,
               widgets::Button("Drag texture here", ImVec2(width, halfWidth));
             } else {
               String buttonLabel =
-                  "Replace current texture: " +
-                  assetRegistry.getTextures().getAsset(value).name;
+                  "Replace current texture: " + assetRegistry.get(value).name;
               widgets::Button(buttonLabel.c_str(), ImVec2(width, halfWidth));
             }
 

--- a/editor/src/quoll/editor/ui/MaterialViewer.cpp
+++ b/editor/src/quoll/editor/ui/MaterialViewer.cpp
@@ -10,9 +10,8 @@ static void renderTextureIfExists(widgets::Table &table, const String &label,
                                   AssetRegistry &assetRegistry) {
   static constexpr glm::vec2 TextureSize(80.0f, 80.0f);
 
-  if (assetRegistry.getTextures().hasAsset(handle)) {
-    auto texture =
-        assetRegistry.getTextures().getAsset(handle).data.deviceHandle;
+  if (assetRegistry.has(handle)) {
+    auto texture = assetRegistry.get<TextureAsset>(handle).data.deviceHandle;
 
     table.column(label);
     table.column(texture, TextureSize);

--- a/editor/tests/quoll/editor-tests/actions/EntitySpriteActions.test.cpp
+++ b/editor/tests/quoll/editor-tests/actions/EntitySpriteActions.test.cpp
@@ -52,7 +52,7 @@ TEST_F(EntityCreateSpriteActionTest,
 TEST_F(EntityCreateSpriteActionTest,
        PredicateReturnsTrueIfSpriteDoesNotExistAndAssetIsValid) {
   auto entity = state.scene.entityDatabase.create();
-  auto handle = assetRegistry.getTextures().addAsset({});
+  auto handle = assetRegistry.add<quoll::TextureAsset>({});
 
   quoll::editor::EntityCreateSprite action(entity, handle);
   EXPECT_TRUE(action.predicate(state, assetRegistry));
@@ -97,7 +97,7 @@ TEST_F(EntitySetSpriteActionTest, PredicateReturnsFalseIfTextureIsInvalid) {
 
 TEST_F(EntitySetSpriteActionTest, PredicateReturnsTrueIfSpriteExists) {
   auto entity = state.scene.entityDatabase.create();
-  auto handle = assetRegistry.getTextures().addAsset({});
+  auto handle = assetRegistry.add<quoll::TextureAsset>({});
 
   quoll::editor::EntitySetSprite action(entity, handle);
   EXPECT_TRUE(action.predicate(state, assetRegistry));

--- a/editor/tests/quoll/editor-tests/actions/SpawnEntityActions.test.cpp
+++ b/editor/tests/quoll/editor-tests/actions/SpawnEntityActions.test.cpp
@@ -310,7 +310,7 @@ TEST_F(SpawnSpriteAtViewActionTest, ExecutorSpawnsSpriteAtView) {
   quoll::AssetData<quoll::TextureAsset> data{};
   data.name = "my-texture";
   data.data.deviceHandle = quoll::rhi::TextureHandle{25};
-  auto textureAsset = assetRegistry.getTextures().addAsset(data);
+  auto textureAsset = assetRegistry.add(data);
 
   auto camera = state.scene.entityDatabase.create();
   glm::mat4 viewMatrix =
@@ -344,7 +344,7 @@ TEST_F(SpawnSpriteAtViewActionTest, ExecutorSpawnsSpriteAtView) {
 TEST_F(SpawnSpriteAtViewActionTest, UndoRemovesSpawnedEntity) {
   quoll::AssetData<quoll::TextureAsset> data{};
   data.data.deviceHandle = quoll::rhi::TextureHandle{25};
-  auto textureAsset = assetRegistry.getTextures().addAsset(data);
+  auto textureAsset = assetRegistry.add(data);
 
   auto camera = state.scene.entityDatabase.create();
   state.scene.entityDatabase.set<quoll::Camera>(camera, {});
@@ -365,7 +365,7 @@ TEST_F(SpawnSpriteAtViewActionTest,
        UndoSetsSelectedEntityToNullIfSpawnedEntityIsSelected) {
   quoll::AssetData<quoll::TextureAsset> data{};
   data.data.deviceHandle = quoll::rhi::TextureHandle{25};
-  auto textureAsset = assetRegistry.getTextures().addAsset(data);
+  auto textureAsset = assetRegistry.add(data);
 
   auto camera = state.scene.entityDatabase.create();
   state.scene.entityDatabase.set<quoll::Camera>(camera, {});
@@ -386,7 +386,7 @@ TEST_F(
     UndoSetsSelectedEntityToNullIfSelectedEntityIsADescendantOfSpawnedEntity) {
   quoll::AssetData<quoll::TextureAsset> data{};
   data.data.deviceHandle = quoll::rhi::TextureHandle{25};
-  auto textureAsset = assetRegistry.getTextures().addAsset(data);
+  auto textureAsset = assetRegistry.add(data);
 
   auto camera = state.scene.entityDatabase.create();
   state.scene.entityDatabase.set<quoll::Camera>(camera, {});
@@ -416,7 +416,7 @@ TEST_F(SpawnSpriteAtViewActionTest,
        UndoDoesNotSetSelectedEntityToNullIfSelectedEntityIsNotSpawnedEntity) {
   quoll::AssetData<quoll::TextureAsset> data{};
   data.data.deviceHandle = quoll::rhi::TextureHandle{25};
-  auto textureAsset = assetRegistry.getTextures().addAsset(data);
+  auto textureAsset = assetRegistry.add(data);
 
   auto camera = state.scene.entityDatabase.create();
   state.scene.entityDatabase.set<quoll::Camera>(camera, {});
@@ -433,7 +433,7 @@ TEST_F(SpawnSpriteAtViewActionTest,
 
 TEST_F(SpawnSpriteAtViewActionTest,
        PredicateReturnsTrueIfCameraEntityHasCameraAndAssetExists) {
-  auto textureAsset = assetRegistry.getTextures().addAsset({});
+  auto textureAsset = assetRegistry.add<quoll::TextureAsset>({});
 
   auto camera = state.scene.entityDatabase.create();
   state.scene.entityDatabase.set<quoll::Camera>(camera, {});
@@ -446,7 +446,7 @@ TEST_F(SpawnSpriteAtViewActionTest,
 
 TEST_F(SpawnSpriteAtViewActionTest,
        PredicateReturnsFalseIfCameraEntityHasNoCamera) {
-  auto textureAsset = assetRegistry.getTextures().addAsset({});
+  auto textureAsset = assetRegistry.add<quoll::TextureAsset>({});
 
   auto camera = state.scene.entityDatabase.create();
   state.camera = camera;

--- a/engine/src/quoll/asset/AssetCache.h
+++ b/engine/src/quoll/asset/AssetCache.h
@@ -102,6 +102,15 @@ private:
     return Uuid{};
   }
 
+  template <typename TAssetData>
+  Uuid getAssetUuid(AssetHandle<TAssetData> handle) {
+    if (handle) {
+      return mRegistry.get<TAssetData>(handle).uuid;
+    }
+
+    return Uuid{};
+  }
+
   Result<AssetFileHeader> checkAssetFile(InputBinaryStream &file,
                                          const Path &filePath,
                                          AssetType assetType);

--- a/engine/src/quoll/asset/AssetCacheEnvironment.cpp
+++ b/engine/src/quoll/asset/AssetCacheEnvironment.cpp
@@ -14,11 +14,9 @@ Result<Path> AssetCache::createEnvironmentFromAsset(
     return Result<Path>::Error("Invalid uuid provided");
   }
 
-  auto irradianceMapUuid =
-      mRegistry.getTextures().getAsset(asset.data.irradianceMap).uuid;
+  auto irradianceMapUuid = mRegistry.get(asset.data.irradianceMap).uuid;
 
-  auto specularMapUuid =
-      mRegistry.getTextures().getAsset(asset.data.specularMap).uuid;
+  auto specularMapUuid = mRegistry.get(asset.data.specularMap).uuid;
 
   auto assetPath = getPathFromUuid(asset.uuid);
 
@@ -53,7 +51,7 @@ AssetCache::loadEnvironmentDataFromInputStream(InputBinaryStream &stream,
 
   auto specularMapRes = getOrLoadTexture(specularMapUuid);
   if (specularMapRes.hasError()) {
-    mRegistry.getTextures().deleteAsset(irradianceMapRes.getData());
+    mRegistry.remove(irradianceMapRes.getData());
     return Result<AssetHandle<EnvironmentAsset>>::Error(
         specularMapRes.getError());
   }

--- a/engine/src/quoll/asset/AssetCacheMaterial.cpp
+++ b/engine/src/quoll/asset/AssetCacheMaterial.cpp
@@ -29,33 +29,29 @@ AssetCache::createMaterialFromAsset(const AssetData<MaterialAsset> &asset) {
   header.name = asset.name;
   file.write(header);
 
-  auto baseColorTexture =
-      getAssetUuid(mRegistry.getTextures(), asset.data.baseColorTexture);
+  auto baseColorTexture = getAssetUuid(asset.data.baseColorTexture);
   file.write(baseColorTexture);
   file.write(asset.data.baseColorTextureCoord);
   file.write(asset.data.baseColorFactor);
 
-  auto metallicRoughnessTexture = getAssetUuid(
-      mRegistry.getTextures(), asset.data.metallicRoughnessTexture);
+  auto metallicRoughnessTexture =
+      getAssetUuid(asset.data.metallicRoughnessTexture);
   file.write(metallicRoughnessTexture);
   file.write(asset.data.metallicRoughnessTextureCoord);
   file.write(asset.data.metallicFactor);
   file.write(asset.data.roughnessFactor);
 
-  auto normalTexture =
-      getAssetUuid(mRegistry.getTextures(), asset.data.normalTexture);
+  auto normalTexture = getAssetUuid(asset.data.normalTexture);
   file.write(normalTexture);
   file.write(asset.data.normalTextureCoord);
   file.write(asset.data.normalScale);
 
-  auto occlusionTexture =
-      getAssetUuid(mRegistry.getTextures(), asset.data.occlusionTexture);
+  auto occlusionTexture = getAssetUuid(asset.data.occlusionTexture);
   file.write(occlusionTexture);
   file.write(asset.data.occlusionTextureCoord);
   file.write(asset.data.occlusionStrength);
 
-  auto emissiveTexture =
-      getAssetUuid(mRegistry.getTextures(), asset.data.emissiveTexture);
+  auto emissiveTexture = getAssetUuid(asset.data.emissiveTexture);
   file.write(emissiveTexture);
   file.write(asset.data.emissiveTextureCoord);
   file.write(asset.data.emissiveFactor);

--- a/engine/src/quoll/asset/AssetCacheTexture.cpp
+++ b/engine/src/quoll/asset/AssetCacheTexture.cpp
@@ -272,8 +272,7 @@ Result<AssetHandle<TextureAsset>> AssetCache::loadTexture(const Uuid &uuid) {
 
   ktxTexture_Destroy(ktxTextureData);
 
-  return Result<AssetHandle<TextureAsset>>::Ok(
-      mRegistry.getTextures().addAsset(texture));
+  return Result<AssetHandle<TextureAsset>>::Ok(mRegistry.add(texture));
 }
 
 Result<AssetHandle<TextureAsset>>
@@ -282,7 +281,7 @@ AssetCache::getOrLoadTexture(const Uuid &uuid) {
     return Result<AssetHandle<TextureAsset>>::Ok(AssetHandle<TextureAsset>());
   }
 
-  auto handle = mRegistry.getTextures().findHandleByUuid(uuid);
+  auto handle = mRegistry.findHandleByUuid<TextureAsset>(uuid);
   if (handle) {
     return Result<AssetHandle<TextureAsset>>::Ok(handle);
   }

--- a/engine/src/quoll/asset/AssetMap.h
+++ b/engine/src/quoll/asset/AssetMap.h
@@ -50,7 +50,7 @@ public:
     return mAssets.find(handle) != mAssets.end();
   }
 
-  void deleteAsset(Handle handle) { mAssets.erase(handle); }
+  void removeAsset(Handle handle) { mAssets.erase(handle); }
 
 private:
   Handle getNewHandle() { return Handle(mLastHandle++); }

--- a/engine/src/quoll/asset/AssetRegistry.h
+++ b/engine/src/quoll/asset/AssetRegistry.h
@@ -61,8 +61,6 @@ public:
 
   void syncWithDevice(RenderStorage &renderStorage);
 
-  inline TextureMap &getTextures() { return mTextures; }
-
   inline FontMap &getFonts() { return mFonts; }
 
   inline MaterialMap &getMaterials() { return mMaterials; }
@@ -88,6 +86,82 @@ public:
   inline InputMapMap &getInputMaps() { return mInputMaps; }
 
   std::pair<AssetType, u32> getAssetByUuid(const Uuid &uuid);
+
+  template <typename TAssetData>
+  const AssetData<TAssetData> &get(AssetHandle<TAssetData> handle) const {
+    auto &map = getMap<TAssetData>();
+    return map.getAsset(handle);
+  }
+
+  template <typename TAssetData>
+  AssetData<TAssetData> &get(AssetHandle<TAssetData> handle) {
+    auto &map = getMap<TAssetData>();
+    return map.getAsset(handle);
+  }
+
+  template <typename TAssetData> bool has(AssetHandle<TAssetData> handle) {
+    auto &map = getMap<TAssetData>();
+    return map.hasAsset(handle);
+  }
+
+  template <typename TAssetData> void remove(AssetHandle<TAssetData> handle) {
+    auto &map = getMap<TAssetData>();
+    map.removeAsset(handle);
+  }
+
+  template <typename TAssetData>
+  AssetHandle<TAssetData> add(const AssetData<TAssetData> &data) {
+    auto &map = getMap<TAssetData>();
+    return map.addAsset(data);
+  }
+
+  template <typename TAssetData>
+  void update(AssetHandle<TAssetData> handle,
+              const AssetData<TAssetData> &data) {
+    auto &map = getMap<TAssetData>();
+    map.updateAsset(handle, data);
+  }
+
+  template <typename TAssetData>
+  AssetHandle<TAssetData> findHandleByUuid(const Uuid &uuid) {
+    auto &map = getMap<TAssetData>();
+    return map.findHandleByUuid(uuid);
+  }
+
+  template <typename TAssetData> usize count() {
+    return getMap<TAssetData>().getAssets().size();
+  }
+
+private:
+  template <typename TAssetData> constexpr auto &getMap() {
+    if constexpr (std::is_same_v<TAssetData, TextureAsset>) {
+      return mTextures;
+    } else if constexpr (std::is_same_v<TAssetData, FontAsset>) {
+      return mFonts;
+    } else if constexpr (std::is_same_v<TAssetData, MaterialAsset>) {
+      return mMaterials;
+    } else if constexpr (std::is_same_v<TAssetData, MeshAsset>) {
+      return mMeshes;
+    } else if constexpr (std::is_same_v<TAssetData, SkeletonAsset>) {
+      return mSkeletons;
+    } else if constexpr (std::is_same_v<TAssetData, AnimationAsset>) {
+      return mAnimations;
+    } else if constexpr (std::is_same_v<TAssetData, AnimatorAsset>) {
+      return mAnimators;
+    } else if constexpr (std::is_same_v<TAssetData, AudioAsset>) {
+      return mAudios;
+    } else if constexpr (std::is_same_v<TAssetData, PrefabAsset>) {
+      return mPrefabs;
+    } else if constexpr (std::is_same_v<TAssetData, LuaScriptAsset>) {
+      return mLuaScripts;
+    } else if constexpr (std::is_same_v<TAssetData, EnvironmentAsset>) {
+      return mEnvironments;
+    } else if constexpr (std::is_same_v<TAssetData, SceneAsset>) {
+      return mScenes;
+    } else if constexpr (std::is_same_v<TAssetData, InputMapAsset>) {
+      return mInputMaps;
+    }
+  }
 
 private:
   TextureMap mTextures;

--- a/engine/src/quoll/entity/EntitySpawner.cpp
+++ b/engine/src/quoll/entity/EntitySpawner.cpp
@@ -220,7 +220,7 @@ Entity EntitySpawner::spawnSprite(AssetHandle<TextureAsset> handle,
                                   LocalTransform transform) {
   auto entity = mEntityDatabase.create();
 
-  auto name = mAssetRegistry.getTextures().getAsset(handle).name;
+  auto name = mAssetRegistry.get(handle).name;
 
   mEntityDatabase.set(entity, transform);
   mEntityDatabase.set<WorldTransform>(entity, {});

--- a/engine/src/quoll/entity/EntitySpawnerLuaTable.cpp
+++ b/engine/src/quoll/entity/EntitySpawnerLuaTable.cpp
@@ -55,7 +55,7 @@ EntitySpawnerLuaTable::spawnPrefab(AssetHandleType handle) {
 sol_maybe<EntityLuaTable>
 EntitySpawnerLuaTable::spawnSprite(AssetHandleType handle) {
   AssetHandle<TextureAsset> texture(handle);
-  if (!mScriptGlobals.assetRegistry.getTextures().hasAsset(texture)) {
+  if (!mScriptGlobals.assetRegistry.has(texture)) {
     Engine::getUserLogger().error() << lua::Messages::assetNotFound(
         "EntitySpawner", "spawnSprite", getAssetTypeString(AssetType::Texture));
 

--- a/engine/src/quoll/lua-scripting/ScriptSerializer.cpp
+++ b/engine/src/quoll/lua-scripting/ScriptSerializer.cpp
@@ -36,8 +36,8 @@ void ScriptSerializer::serialize(YAML::Node &node,
           }
         } else if (value.isType(LuaScriptVariableType::AssetTexture)) {
           auto handle = value.get<AssetHandle<TextureAsset>>();
-          if (assetRegistry.getTextures().hasAsset(handle)) {
-            auto uuid = assetRegistry.getTextures().getAsset(handle).uuid;
+          if (assetRegistry.has(handle)) {
+            auto uuid = assetRegistry.get(handle).uuid;
 
             node["script"]["variables"][name]["type"] = "texture";
             node["script"]["variables"][name]["value"] = uuid;
@@ -79,7 +79,7 @@ void ScriptSerializer::deserialize(const YAML::Node &node,
             }
           } else if (type == "texture") {
             auto handle =
-                assetRegistry.getTextures().findHandleByUuid(Uuid(value));
+                assetRegistry.findHandleByUuid<TextureAsset>(Uuid(value));
             if (handle) {
               script.variables.insert_or_assign(name, handle);
             }

--- a/engine/src/quoll/renderer/SceneRenderer.cpp
+++ b/engine/src/quoll/renderer/SceneRenderer.cpp
@@ -784,8 +784,7 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
 
   for (auto [entity, sprite, world] :
        entityDatabase.view<Sprite, WorldTransform>()) {
-    auto handle =
-        mAssetRegistry.getTextures().getAsset(sprite.handle).data.deviceHandle;
+    auto handle = mAssetRegistry.get(sprite.handle).data.deviceHandle;
     frameData.addSprite(entity, handle, world.worldTransform);
   }
 
@@ -870,7 +869,6 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
   };
 
   // Environments
-  const auto &textures = mAssetRegistry.getTextures();
   for (auto [entity, environment] : entityDatabase.view<EnvironmentSkybox>()) {
     rhi::TextureHandle irradianceMap{0};
     rhi::TextureHandle specularMap{0};
@@ -883,9 +881,9 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
           mAssetRegistry.getEnvironments().getAsset(environment.texture).data;
 
       frameData.setSkyboxTexture(
-          textures.getAsset(asset.specularMap).data.deviceHandle);
-      irradianceMap = textures.getAsset(asset.irradianceMap).data.deviceHandle;
-      specularMap = textures.getAsset(asset.specularMap).data.deviceHandle;
+          mAssetRegistry.get(asset.specularMap).data.deviceHandle);
+      irradianceMap = mAssetRegistry.get(asset.irradianceMap).data.deviceHandle;
+      specularMap = mAssetRegistry.get(asset.specularMap).data.deviceHandle;
     }
 
     if (entityDatabase.has<EnvironmentLightingSkyboxSource>(entity)) {

--- a/engine/src/quoll/scene/SpriteSerializer.cpp
+++ b/engine/src/quoll/scene/SpriteSerializer.cpp
@@ -10,8 +10,8 @@ void SpriteSerializer::serialize(YAML::Node &node,
                                  AssetRegistry &assetRegistry) {
   if (entityDatabase.has<Sprite>(entity)) {
     auto handle = entityDatabase.get<Sprite>(entity).handle;
-    if (assetRegistry.getTextures().hasAsset(handle)) {
-      auto uuid = assetRegistry.getTextures().getAsset(handle).uuid;
+    if (assetRegistry.has(handle)) {
+      auto uuid = assetRegistry.get(handle).uuid;
 
       node["sprite"] = uuid;
     }
@@ -25,7 +25,7 @@ void SpriteSerializer::deserialize(const YAML::Node &node,
   if (node["sprite"]) {
     auto uuid = node["sprite"].as<Uuid>(Uuid{});
 
-    auto handle = assetRegistry.getTextures().findHandleByUuid(uuid);
+    auto handle = assetRegistry.findHandleByUuid<TextureAsset>(uuid);
 
     if (handle) {
       entityDatabase.set<Sprite>(entity, {handle});

--- a/engine/src/quoll/ui/UICanvasUpdater.cpp
+++ b/engine/src/quoll/ui/UICanvasUpdater.cpp
@@ -18,8 +18,7 @@ void renderView(UIComponent component, YGNodeRef node,
   ImGui::SetCursorPos({left, top});
 
   if (auto *image = std::get_if<UIImage>(&component)) {
-    auto texture =
-        assetRegistry.getTextures().getAsset(image->texture).data.deviceHandle;
+    auto texture = assetRegistry.get(image->texture).data.deviceHandle;
 
     imgui::image(texture, ImVec2(ImageSize, ImageSize));
   } else if (auto *text = std::get_if<UIText>(&component)) {

--- a/engine/tests/quoll-tests/asset/AssetCacheEnvironment.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheEnvironment.test.cpp
@@ -74,15 +74,15 @@ TEST_F(AssetCacheEnvironmentTest,
   asset.data.specularMap = specularMap;
   auto createRes = cache.createEnvironmentFromAsset(asset);
 
-  cache.getRegistry().getTextures().deleteAsset(irradianceMap);
-  cache.getRegistry().getTextures().deleteAsset(specularMap);
+  cache.getRegistry().remove(irradianceMap);
+  cache.getRegistry().remove(specularMap);
 
   {
     std::filesystem::remove(cache.getPathFromUuid(irradianceUuid));
     auto res = cache.loadEnvironment(asset.uuid);
 
     EXPECT_TRUE(res.hasError());
-    EXPECT_TRUE(cache.getRegistry().getTextures().getAssets().empty());
+    EXPECT_EQ(cache.getRegistry().count<quoll::TextureAsset>(), 0);
   }
 
   {
@@ -93,7 +93,7 @@ TEST_F(AssetCacheEnvironmentTest,
     auto res = cache.loadEnvironment(asset.uuid);
 
     EXPECT_TRUE(res.hasError());
-    EXPECT_TRUE(cache.getRegistry().getTextures().getAssets().empty());
+    EXPECT_EQ(cache.getRegistry().count<quoll::TextureAsset>(), 0);
   }
 }
 
@@ -110,10 +110,10 @@ TEST_F(AssetCacheEnvironmentTest,
   asset.data.specularMap = specularMap;
   auto createRes = cache.createEnvironmentFromAsset(asset);
 
-  cache.getRegistry().getTextures().deleteAsset(irradianceMap);
-  cache.getRegistry().getTextures().deleteAsset(specularMap);
+  cache.getRegistry().remove(irradianceMap);
+  cache.getRegistry().remove(specularMap);
 
-  EXPECT_TRUE(cache.getRegistry().getTextures().getAssets().empty());
+  EXPECT_EQ(cache.getRegistry().count<quoll::TextureAsset>(), 0);
 
   auto res = cache.loadEnvironment(asset.uuid);
 
@@ -121,7 +121,7 @@ TEST_F(AssetCacheEnvironmentTest,
   EXPECT_FALSE(res.hasError());
   EXPECT_FALSE(res.hasWarnings());
 
-  EXPECT_EQ(cache.getRegistry().getTextures().getAssets().size(), 2);
+  EXPECT_EQ(cache.getRegistry().count<quoll::TextureAsset>(), 2);
   EXPECT_FALSE(cache.getRegistry().getEnvironments().getAssets().empty());
 
   const auto &environment =
@@ -145,7 +145,7 @@ TEST_F(AssetCacheEnvironmentTest,
   asset.data.specularMap = specularMap;
   auto createRes = cache.createEnvironmentFromAsset(asset);
 
-  EXPECT_EQ(cache.getRegistry().getTextures().getAssets().size(), 2);
+  EXPECT_EQ(cache.getRegistry().count<quoll::TextureAsset>(), 2);
 
   auto res = cache.loadEnvironment(asset.uuid);
 
@@ -153,7 +153,7 @@ TEST_F(AssetCacheEnvironmentTest,
   EXPECT_FALSE(res.hasError());
   EXPECT_FALSE(res.hasWarnings());
 
-  EXPECT_EQ(cache.getRegistry().getTextures().getAssets().size(), 2);
+  EXPECT_EQ(cache.getRegistry().count<quoll::TextureAsset>(), 2);
 
   EXPECT_FALSE(cache.getRegistry().getEnvironments().getAssets().empty());
 

--- a/engine/tests/quoll-tests/asset/AssetCacheMaterial.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheMaterial.test.cpp
@@ -22,8 +22,7 @@ public:
       quoll::AssetData<quoll::TextureAsset> texture;
       texture.uuid = quoll::Uuid("base");
 
-      asset.data.baseColorTexture =
-          cache.getRegistry().getTextures().addAsset(texture);
+      asset.data.baseColorTexture = cache.getRegistry().add(texture);
     }
 
     asset.data.metallicFactor = 1.0f;
@@ -33,8 +32,7 @@ public:
       quoll::AssetData<quoll::TextureAsset> texture;
       texture.uuid = quoll::Uuid("mr");
 
-      asset.data.metallicRoughnessTexture =
-          cache.getRegistry().getTextures().addAsset(texture);
+      asset.data.metallicRoughnessTexture = cache.getRegistry().add(texture);
     }
 
     asset.data.normalScale = 0.6f;
@@ -43,8 +41,7 @@ public:
       quoll::AssetData<quoll::TextureAsset> texture;
       texture.uuid = quoll::Uuid("normal");
 
-      asset.data.normalTexture =
-          cache.getRegistry().getTextures().addAsset(texture);
+      asset.data.normalTexture = cache.getRegistry().add(texture);
     }
 
     asset.data.occlusionStrength = 0.4f;
@@ -53,8 +50,7 @@ public:
       quoll::AssetData<quoll::TextureAsset> texture;
       texture.uuid = quoll::Uuid("occlusion");
 
-      asset.data.occlusionTexture =
-          cache.getRegistry().getTextures().addAsset(texture);
+      asset.data.occlusionTexture = cache.getRegistry().add(texture);
     }
 
     asset.data.emissiveFactor = glm::vec3(0.5f, 0.6f, 2.5f);
@@ -63,8 +59,7 @@ public:
       quoll::AssetData<quoll::TextureAsset> texture;
       texture.uuid = quoll::Uuid("emissive");
 
-      asset.data.emissiveTexture =
-          cache.getRegistry().getTextures().addAsset(texture);
+      asset.data.emissiveTexture = cache.getRegistry().add(texture);
     }
 
     return asset;
@@ -338,8 +333,8 @@ TEST_F(AssetCacheMaterialTest, LoadsTexturesWithMaterials) {
   material.data.baseColorTexture = texture.getData();
   auto path = cache.createMaterialFromAsset(material);
 
-  cache.getRegistry().getTextures().deleteAsset(texture.getData());
-  EXPECT_FALSE(cache.getRegistry().getTextures().hasAsset(texture.getData()));
+  cache.getRegistry().remove(texture.getData());
+  EXPECT_FALSE(cache.getRegistry().has(texture.getData()));
 
   auto handle = cache.loadMaterial(material.uuid);
 
@@ -349,7 +344,6 @@ TEST_F(AssetCacheMaterialTest, LoadsTexturesWithMaterials) {
   EXPECT_NE(newMaterial.data.baseColorTexture,
             quoll::AssetHandle<quoll::TextureAsset>());
 
-  auto &newTexture = cache.getRegistry().getTextures().getAsset(
-      newMaterial.data.baseColorTexture);
+  auto &newTexture = cache.getRegistry().get(newMaterial.data.baseColorTexture);
   EXPECT_EQ(newTexture.uuid, textureUuid);
 }

--- a/engine/tests/quoll-tests/asset/AssetCachePrefab.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCachePrefab.test.cpp
@@ -605,9 +605,8 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabFile) {
 TEST_F(AssetCachePrefabTest, LoadsPrefabWithMeshAnimationSkeleton) {
   // Create texture
   auto tempTextureHandle = cache.loadTexture(textureUuid).getData();
-  auto tempTextureAsset =
-      cache.getRegistry().getTextures().getAsset(tempTextureHandle);
-  cache.getRegistry().getTextures().deleteAsset(tempTextureHandle);
+  auto tempTextureAsset = cache.getRegistry().get(tempTextureHandle);
+  cache.getRegistry().remove(tempTextureHandle);
 
   auto texturePath = cache.createTextureFromAsset(tempTextureAsset).getData();
   auto textureHandle = cache.loadTexture(textureUuid);
@@ -663,11 +662,11 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabWithMeshAnimationSkeleton) {
   auto prefabPath = cache.createPrefabFromAsset(prefabData);
 
   // Delete all existing assets
-  cache.getRegistry().getTextures().deleteAsset(textureHandle.getData());
-  cache.getRegistry().getMeshes().deleteAsset(meshHandle.getData());
-  cache.getRegistry().getSkeletons().deleteAsset(skeletonHandle.getData());
-  cache.getRegistry().getAnimations().deleteAsset(animationHandle.getData());
-  cache.getRegistry().getAnimators().deleteAsset(animatorHandle.getData());
+  cache.getRegistry().remove(textureHandle.getData());
+  cache.getRegistry().remove(meshHandle.getData());
+  cache.getRegistry().remove(skeletonHandle.getData());
+  cache.getRegistry().remove(animationHandle.getData());
+  cache.getRegistry().remove(animatorHandle.getData());
 
   auto prefabHandle = cache.loadPrefab(prefabData.uuid);
   EXPECT_NE(prefabHandle.getData(), quoll::AssetHandle<quoll::PrefabAsset>());

--- a/engine/tests/quoll-tests/asset/AssetCacheTexture.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheTexture.test.cpp
@@ -33,9 +33,9 @@ TEST_F(AssetCacheTextureTest, CreatesTextureFromAsset) {
   auto texture = cache.loadTexture(uuid);
   auto handle = texture.getData();
 
-  auto asset = cache.getRegistry().getTextures().getAsset(handle);
+  auto asset = cache.getRegistry().get(handle);
 
-  cache.getRegistry().getTextures().deleteAsset(handle);
+  cache.getRegistry().remove(handle);
 
   auto filePath = cache.createTextureFromAsset(asset);
   EXPECT_TRUE(filePath.hasData());
@@ -57,7 +57,7 @@ TEST_F(AssetCacheTextureTest, LoadsTextureToRegistry) {
   auto texture = cache.loadTexture(uuid);
   auto handle = texture.getData();
 
-  auto asset = cache.getRegistry().getTextures().getAsset(handle);
+  auto asset = cache.getRegistry().get(handle);
 
   EXPECT_EQ(asset.path, filePath.getData());
   EXPECT_EQ(asset.name, "1x1-2d.ktx");
@@ -92,7 +92,7 @@ TEST_F(AssetCacheTextureTest, LoadsTexture2D) {
   auto texture = cache.loadTexture(uuid);
   EXPECT_TRUE(texture.hasData());
 
-  auto &asset = cache.getRegistry().getTextures().getAsset(texture.getData());
+  auto &asset = cache.getRegistry().get(texture.getData());
 
   EXPECT_EQ(asset.data.width, 1);
   EXPECT_EQ(asset.data.height, 1);
@@ -109,8 +109,7 @@ TEST_F(AssetCacheTextureTest, LoadsTextureCubemap) {
 
   EXPECT_TRUE(texture.hasData());
 
-  const auto &asset =
-      cache.getRegistry().getTextures().getAsset(texture.getData());
+  const auto &asset = cache.getRegistry().get(texture.getData());
 
   EXPECT_EQ(asset.data.width, 1);
   EXPECT_EQ(asset.data.height, 1);

--- a/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
@@ -446,7 +446,7 @@ TEST_F(EntitySpawnerTest,
   asset.uuid = quoll::Uuid("121311231");
   asset.name = "my-sprite";
   asset.data.deviceHandle = quoll::rhi::TextureHandle{25};
-  auto assetHandle = assetRegistry.getTextures().addAsset(asset);
+  auto assetHandle = assetRegistry.add(asset);
 
   quoll::LocalTransform transform{glm::vec3(0.5f, 0.5f, 0.5f)};
 

--- a/engine/tests/quoll-tests/entity/EntitySpawnerLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntitySpawnerLuaTable.test.cpp
@@ -76,7 +76,7 @@ TEST_F(EntitySpawnerLuaTableTest, SpawnSpriteReturnsNullIfTextureDoesNotExist) {
 
 TEST_F(EntitySpawnerLuaTableTest,
        SpawnSpriteCreatesSpriteEntityAndReturnsEntityTable) {
-  auto texture = assetCache.getRegistry().getTextures().addAsset({});
+  auto texture = assetCache.getRegistry().add<quoll::TextureAsset>({});
   ASSERT_EQ(texture, quoll::AssetHandle<quoll::TextureAsset>{1});
 
   auto entity = entityDatabase.create();

--- a/engine/tests/quoll-tests/io/EntitySerializer.test.cpp
+++ b/engine/tests/quoll-tests/io/EntitySerializer.test.cpp
@@ -177,7 +177,7 @@ TEST_F(EntitySerializerTest,
 TEST_F(EntitySerializerTest, CreatesSpriteFieldIfTextureAssetIsInRegistry) {
   quoll::AssetData<quoll::TextureAsset> texture{};
   texture.uuid = quoll::Uuid("texture.tex");
-  auto handle = assetRegistry.getTextures().addAsset(texture);
+  auto handle = assetRegistry.add(texture);
 
   auto entity = entityDatabase.create();
   entityDatabase.set<quoll::Sprite>(entity, {handle});
@@ -694,7 +694,7 @@ TEST_F(EntitySerializerTest, CreatesScriptFieldIfScriptAssetIsRegistry) {
 
   quoll::AssetData<quoll::TextureAsset> texture{};
   texture.uuid = quoll::Uuid("test.ktx2");
-  auto textureHandle = assetRegistry.getTextures().addAsset(texture);
+  auto textureHandle = assetRegistry.add(texture);
 
   auto entity = entityDatabase.create();
 

--- a/engine/tests/quoll-tests/io/SceneLoader.test.cpp
+++ b/engine/tests/quoll-tests/io/SceneLoader.test.cpp
@@ -255,7 +255,7 @@ TEST_F(SceneLoaderSpriteTest,
 TEST_F(SceneLoaderSpriteTest, CreatesSpriteComponentWithFileDataIfValidField) {
   quoll::AssetData<quoll::TextureAsset> data{};
   data.uuid = quoll::Uuid("hello");
-  auto handle = assetRegistry.getTextures().addAsset(data);
+  auto handle = assetRegistry.add(data);
 
   auto [node, entity] = createNode();
   node["sprite"] = data.uuid;
@@ -1665,7 +1665,7 @@ TEST_F(SceneLoaderScriptTest,
 
   quoll::AssetData<quoll::TextureAsset> textureData{};
   textureData.uuid = quoll::Uuid("my-texture");
-  auto textureHandle = assetRegistry.getTextures().addAsset(textureData);
+  auto textureHandle = assetRegistry.add(textureData);
 
   auto [node, entity] = createNode();
   node["script"]["asset"] = data.uuid;


### PR DESCRIPTION
- Add template methods for asset registry that accept asset data as template parameter
- Use new methods for TextureAsset
- Remove getTextures method from asset registry
- Rename deleteAsset to removeAsset
- Fix material viewer opening wrong data in asset browser