### PR TITLE
Unify creating assets from asset cache

### DIFF
--- a/editor/src/quoll/editor/asset/AssetManager.cpp
+++ b/editor/src/quoll/editor/asset/AssetManager.cpp
@@ -344,7 +344,8 @@ Result<UUIDMap> AssetManager::loadSourceTexture(const Path &sourceAssetPath,
 
   if (sourceAssetPath.extension() == ".ktx2") {
     auto uuid = getOrCreateUuidFromMap(uuids, "root");
-    auto createRes = mAssetCache.createTextureFromSource(sourceAssetPath, uuid);
+    auto createRes =
+        mAssetCache.createFromSource<TextureAsset>(sourceAssetPath, uuid);
     if (!createRes) {
       return createRes.error();
     }
@@ -373,7 +374,8 @@ Result<UUIDMap> AssetManager::loadSourceTexture(const Path &sourceAssetPath,
 Result<UUIDMap> AssetManager::loadSourceAudio(const Path &sourceAssetPath,
                                               const UUIDMap &uuids) {
   auto uuid = getOrCreateUuidFromMap(uuids, "root");
-  auto createRes = mAssetCache.createAudioFromSource(sourceAssetPath, uuid);
+  auto createRes =
+      mAssetCache.createFromSource<AudioAsset>(sourceAssetPath, uuid);
   if (!createRes) {
     return createRes.error();
   }
@@ -390,7 +392,8 @@ Result<UUIDMap> AssetManager::loadSourceAudio(const Path &sourceAssetPath,
 Result<UUIDMap> AssetManager::loadSourceScript(const Path &sourceAssetPath,
                                                const UUIDMap &uuids) {
   auto uuid = getOrCreateUuidFromMap(uuids, "root");
-  auto createRes = mAssetCache.createLuaScriptFromSource(sourceAssetPath, uuid);
+  auto createRes =
+      mAssetCache.createFromSource<LuaScriptAsset>(sourceAssetPath, uuid);
   if (!createRes) {
     return createRes.error();
   }
@@ -408,7 +411,8 @@ Result<UUIDMap> AssetManager::loadSourceScript(const Path &sourceAssetPath,
 Result<UUIDMap> AssetManager::loadSourceFont(const Path &sourceAssetPath,
                                              const UUIDMap &uuids) {
   auto uuid = getOrCreateUuidFromMap(uuids, "root");
-  auto createRes = mAssetCache.createFontFromSource(sourceAssetPath, uuid);
+  auto createRes =
+      mAssetCache.createFromSource<FontAsset>(sourceAssetPath, uuid);
   if (!createRes) {
     return createRes.error();
   }
@@ -426,7 +430,8 @@ Result<UUIDMap> AssetManager::loadSourceFont(const Path &sourceAssetPath,
 Result<UUIDMap> AssetManager::loadSourceAnimator(const Path &sourceAssetPath,
                                                  const UUIDMap &uuids) {
   auto uuid = getOrCreateUuidFromMap(uuids, "root");
-  auto createRes = mAssetCache.createAnimatorFromSource(sourceAssetPath, uuid);
+  auto createRes =
+      mAssetCache.createFromSource<AnimatorAsset>(sourceAssetPath, uuid);
   if (!createRes) {
     return createRes.error();
   }
@@ -444,7 +449,8 @@ Result<UUIDMap> AssetManager::loadSourceAnimator(const Path &sourceAssetPath,
 Result<UUIDMap> AssetManager::loadSourceInputMap(const Path &sourceAssetPath,
                                                  const UUIDMap &uuids) {
   auto uuid = getOrCreateUuidFromMap(uuids, "root");
-  auto createRes = mAssetCache.createInputMapFromSource(sourceAssetPath, uuid);
+  auto createRes =
+      mAssetCache.createFromSource<InputMapAsset>(sourceAssetPath, uuid);
   if (!createRes) {
     return createRes.error();
   }
@@ -473,7 +479,8 @@ Result<UUIDMap> AssetManager::loadSourceEnvironment(const Path &sourceAssetPath,
 Result<UUIDMap> AssetManager::loadSourceScene(const Path &sourceAssetPath,
                                               const UUIDMap &uuids) {
   auto uuid = getOrCreateUuidFromMap(uuids, "root");
-  auto createRes = mAssetCache.createSceneFromSource(sourceAssetPath, uuid);
+  auto createRes =
+      mAssetCache.createFromSource<SceneAsset>(sourceAssetPath, uuid);
   if (!createRes) {
     return createRes.error();
   }

--- a/editor/src/quoll/editor/asset/HDRIImporter.cpp
+++ b/editor/src/quoll/editor/asset/HDRIImporter.cpp
@@ -141,7 +141,7 @@ Result<UUIDMap> HDRIImporter::loadFromPath(const Path &sourceAssetPath,
   environment.data.specularMap = specularCubemap;
   environment.data.irradianceMap = irradianceCubemap;
 
-  auto createdFileRes = mAssetCache.createEnvironmentFromAsset(environment);
+  auto createdFileRes = mAssetCache.createFromData(environment);
 
   if (!createdFileRes) {
     return createdFileRes.error();
@@ -378,7 +378,7 @@ HDRIImporter::generateIrradianceMap(const CubemapData &unfilteredCubemap,
       CubemapSides, asset.data.levels, asset.data.data.data());
   device->destroyTexture(irradianceCubemap);
 
-  auto createdFileRes = mAssetCache.createTextureFromAsset(asset);
+  auto createdFileRes = mAssetCache.createFromData(asset);
   if (!createdFileRes) {
     return createdFileRes.error();
   }
@@ -472,7 +472,7 @@ HDRIImporter::generateSpecularMap(const CubemapData &unfilteredCubemap,
       CubemapSides, asset.data.levels, asset.data.data.data());
   device->destroyTexture(specularCubemap);
 
-  auto createdFileRes = mAssetCache.createTextureFromAsset(asset);
+  auto createdFileRes = mAssetCache.createFromData(asset);
   if (!createdFileRes) {
     return createdFileRes.error();
   }

--- a/editor/src/quoll/editor/asset/ImageLoader.cpp
+++ b/editor/src/quoll/editor/asset/ImageLoader.cpp
@@ -87,7 +87,7 @@ Result<Uuid> ImageLoader::loadFromMemory(void *data, u32 width, u32 height,
   asset.data.levels = levels;
   asset.data.format = format;
 
-  auto createdFileRes = mAssetCache.createTextureFromAsset(asset);
+  auto createdFileRes = mAssetCache.createFromData(asset);
 
   if (!createdFileRes) {
     return createdFileRes.error();

--- a/editor/src/quoll/editor/asset/gltf/AnimationStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/AnimationStep.cpp
@@ -222,7 +222,7 @@ void loadAnimations(GLTFImportData &importData) {
       continue;
     }
 
-    auto filePath = assetCache.createAnimationFromAsset(animation);
+    auto filePath = assetCache.createFromData(animation);
     auto handle = assetCache.load<quoll::AnimationAsset>(animation.uuid);
     importData.outputUuids.insert_or_assign(
         assetName, assetCache.getRegistry().getMeta(handle.data()).uuid);
@@ -275,7 +275,7 @@ void loadAnimations(GLTFImportData &importData) {
       }
     }
 
-    auto path = assetCache.createAnimatorFromAsset(asset);
+    auto path = assetCache.createFromData(asset);
     auto handle = assetCache.load<quoll::AnimatorAsset>(asset.uuid);
     importData.animations.skinAnimatorMap.insert_or_assign(skin, handle);
 
@@ -312,7 +312,7 @@ void loadAnimations(GLTFImportData &importData) {
       }
     }
 
-    auto path = assetCache.createAnimatorFromAsset(asset);
+    auto path = assetCache.createFromData(asset);
     auto handle = assetCache.load<quoll::AnimatorAsset>(asset.uuid);
     importData.animations.nodeAnimatorMap.insert_or_assign(node, handle);
     importData.outputUuids.insert_or_assign(

--- a/editor/src/quoll/editor/asset/gltf/MaterialStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/MaterialStep.cpp
@@ -89,7 +89,7 @@ void loadMaterials(GLTFImportData &importData) {
       }
     }
 
-    auto path = assetCache.createMaterialFromAsset(material);
+    auto path = assetCache.createFromData(material);
     auto handle = assetCache.load<quoll::MaterialAsset>(material.uuid);
     importData.materials.map.insert_or_assign(i, handle);
 

--- a/editor/src/quoll/editor/asset/gltf/MeshStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/MeshStep.cpp
@@ -436,7 +436,7 @@ void loadMeshes(GLTFImportData &importData) {
     mesh.name = getGLTFAssetName(importData, assetName);
     mesh.uuid = getOrCreateGLTFUuid(importData, assetName);
 
-    auto path = assetCache.createMeshFromAsset(mesh);
+    auto path = assetCache.createFromData(mesh);
 
     auto handle = assetCache.load<quoll::MeshAsset>(mesh.uuid);
     importData.meshes.map.insert_or_assign(i, handle);

--- a/editor/src/quoll/editor/asset/gltf/PrefabStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/PrefabStep.cpp
@@ -130,7 +130,7 @@ void loadPrefabs(GLTFImportData &importData) {
     }
   }
 
-  auto path = assetCache.createPrefabFromAsset(prefab);
+  auto path = assetCache.createFromData(prefab);
 
   if (path) {
     auto handle = assetCache.load<PrefabAsset>(prefab.uuid);

--- a/editor/src/quoll/editor/asset/gltf/SkeletonStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/SkeletonStep.cpp
@@ -123,7 +123,7 @@ void loadSkeletons(GLTFImportData &importData) {
       asset.data.jointParents.push_back(parent >= 0 ? parent : 0);
     }
 
-    auto path = assetCache.createSkeletonFromAsset(asset);
+    auto path = assetCache.createFromData(asset);
     auto handle = assetCache.load<quoll::SkeletonAsset>(asset.uuid);
 
     importData.skeletons.skeletonMap.map.insert_or_assign(

--- a/engine/src/quoll/asset/AssetCacheAnimation.cpp
+++ b/engine/src/quoll/asset/AssetCacheAnimation.cpp
@@ -7,20 +7,8 @@
 
 namespace quoll {
 
-Result<Path>
-AssetCache::createAnimationFromAsset(const AssetData<AnimationAsset> &asset) {
-  if (asset.uuid.isEmpty()) {
-    QuollAssert(false, "Invalid uuid provided");
-    return Error("Invalid uuid provided");
-  }
-
-  auto assetPath = getPathFromUuid(asset.uuid);
-
-  auto metaRes = createAssetMeta(AssetType::Animation, asset.name, assetPath);
-  if (!metaRes) {
-    return Error("Cannot create animation asset: " + asset.name);
-  }
-
+Result<void> AssetCache::createAnimationFromData(const AnimationAsset &data,
+                                                 const Path &assetPath) {
   OutputBinaryStream file(assetPath);
 
   if (!file.good()) {
@@ -32,11 +20,11 @@ AssetCache::createAnimationFromAsset(const AssetData<AnimationAsset> &asset) {
   header.magic = AssetFileHeader::MagicConstant;
   file.write(header);
 
-  file.write(asset.data.time);
-  u32 numKeyframes = static_cast<u32>(asset.data.keyframes.size());
+  file.write(data.time);
+  u32 numKeyframes = static_cast<u32>(data.keyframes.size());
   file.write(numKeyframes);
 
-  for (auto &keyframe : asset.data.keyframes) {
+  for (auto &keyframe : data.keyframes) {
     file.write(keyframe.target);
     file.write(keyframe.interpolation);
     file.write(keyframe.jointTarget);
@@ -48,7 +36,7 @@ AssetCache::createAnimationFromAsset(const AssetData<AnimationAsset> &asset) {
     file.write(keyframe.keyframeValues);
   }
 
-  return assetPath;
+  return Ok();
 }
 
 Result<AnimationAsset>

--- a/engine/src/quoll/asset/AssetCacheAudio.cpp
+++ b/engine/src/quoll/asset/AssetCacheAudio.cpp
@@ -12,35 +12,6 @@ static AudioAssetFormat getAudioFormatFromExtension(StringView extension) {
   return AudioAssetFormat::Unknown;
 }
 
-Result<Path> AssetCache::createAudioFromSource(const Path &sourcePath,
-                                               const Uuid &uuid) {
-  if (uuid.isEmpty()) {
-    QuollAssert(false, "Invalid uuid provided");
-    return Error("Invalid uuid provided");
-  }
-
-  using co = std::filesystem::copy_options;
-
-  auto assetPath = getPathFromUuid(uuid);
-
-  if (!std::filesystem::copy_file(sourcePath, assetPath,
-                                  co::overwrite_existing)) {
-    return Error("Cannot create audio from source: " +
-                 sourcePath.stem().string());
-  }
-
-  auto metaRes = createAssetMeta(AssetType::Audio,
-                                 sourcePath.filename().string(), assetPath);
-
-  if (!metaRes) {
-    std::filesystem::remove(assetPath);
-    return Error("Cannot create audio from source: " +
-                 sourcePath.stem().string());
-  }
-
-  return assetPath;
-}
-
 Result<AudioAsset> AssetCache::loadAudio(const Uuid &uuid) {
   auto filePath = getPathFromUuid(uuid);
 

--- a/engine/src/quoll/asset/AssetCacheEnvironment.cpp
+++ b/engine/src/quoll/asset/AssetCacheEnvironment.cpp
@@ -6,22 +6,10 @@
 
 namespace quoll {
 
-Result<Path> AssetCache::createEnvironmentFromAsset(
-    const AssetData<EnvironmentAsset> &asset) {
-  if (asset.uuid.isEmpty()) {
-    QuollAssert(false, "Invalid uuid provided");
-    return Error("Invalid uuid provided");
-  }
-
-  auto assetPath = getPathFromUuid(asset.uuid);
-
-  auto metaRes = createAssetMeta(AssetType::Environment, asset.name, assetPath);
-  if (!metaRes) {
-    return Error("Cannot create environment asset: " + asset.name);
-  }
-
-  auto irradianceMapUuid = mRegistry.getMeta(asset.data.irradianceMap).uuid;
-  auto specularMapUuid = mRegistry.getMeta(asset.data.specularMap).uuid;
+Result<void> AssetCache::createEnvironmentFromData(const EnvironmentAsset &data,
+                                                   const Path &assetPath) {
+  auto irradianceMapUuid = mRegistry.getMeta(data.irradianceMap).uuid;
+  auto specularMapUuid = mRegistry.getMeta(data.specularMap).uuid;
 
   OutputBinaryStream stream(assetPath);
   AssetFileHeader header{};
@@ -32,7 +20,7 @@ Result<Path> AssetCache::createEnvironmentFromAsset(
   stream.write(irradianceMapUuid);
   stream.write(specularMapUuid);
 
-  return assetPath;
+  return Ok();
 }
 
 Result<EnvironmentAsset>

--- a/engine/src/quoll/asset/AssetCacheFont.cpp
+++ b/engine/src/quoll/asset/AssetCacheFont.cpp
@@ -8,35 +8,6 @@
 
 namespace quoll {
 
-Result<Path> AssetCache::createFontFromSource(const Path &sourcePath,
-                                              const Uuid &uuid) {
-  if (uuid.isEmpty()) {
-    QuollAssert(false, "Invalid uuid provided");
-    return Error("Invalid uuid provided");
-  }
-
-  using co = std::filesystem::copy_options;
-
-  auto assetPath = getPathFromUuid(uuid);
-
-  if (!std::filesystem::copy_file(sourcePath, assetPath,
-                                  co::overwrite_existing)) {
-    return Error("Cannot create font from source: " +
-                 sourcePath.stem().string());
-  }
-
-  auto metaRes = createAssetMeta(AssetType::Font,
-                                 sourcePath.filename().string(), assetPath);
-
-  if (!metaRes) {
-    std::filesystem::remove(assetPath);
-    return Error("Cannot create font from source: " +
-                 sourcePath.stem().string());
-  }
-
-  return assetPath;
-}
-
 Result<FontAsset> AssetCache::loadFont(const Uuid &uuid) {
   auto filePath = getPathFromUuid(uuid);
 

--- a/engine/src/quoll/asset/AssetCacheInputMap.cpp
+++ b/engine/src/quoll/asset/AssetCacheInputMap.cpp
@@ -284,33 +284,4 @@ Result<InputMapAsset> AssetCache::loadInputMap(const Uuid &uuid) {
   return asset;
 }
 
-Result<Path> AssetCache::createInputMapFromSource(const Path &sourcePath,
-                                                  const Uuid &uuid) {
-  if (uuid.isEmpty()) {
-    QuollAssert(false, "Invalid uuid provided");
-    return Error("Invalid uuid provided");
-  }
-
-  using co = std::filesystem::copy_options;
-
-  auto assetPath = getPathFromUuid(uuid);
-
-  if (!std::filesystem::copy_file(sourcePath, assetPath,
-                                  co::overwrite_existing)) {
-    return Error("Cannot create input map from source: " +
-                 sourcePath.stem().string());
-  }
-
-  auto metaRes = createAssetMeta(AssetType::InputMap,
-                                 sourcePath.filename().string(), assetPath);
-
-  if (!metaRes) {
-    std::filesystem::remove(assetPath);
-    return Error("Cannot create input map from source: " +
-                 sourcePath.stem().string());
-  }
-
-  return assetPath;
-}
-
 } // namespace quoll

--- a/engine/src/quoll/asset/AssetCacheLuaScript.cpp
+++ b/engine/src/quoll/asset/AssetCacheLuaScript.cpp
@@ -44,36 +44,6 @@ static void injectInputVarsInterface(sol::state &state, LuaScriptAsset &data) {
   );
 }
 
-Result<Path>
-quoll::AssetCache::createLuaScriptFromSource(const Path &sourcePath,
-                                             const Uuid &uuid) {
-  if (uuid.isEmpty()) {
-    QuollAssert(false, "Invalid uuid provided");
-    return Error("Invalid uuid provided");
-  }
-
-  using co = std::filesystem::copy_options;
-
-  auto assetPath = getPathFromUuid(uuid);
-
-  if (!std::filesystem::copy_file(sourcePath, assetPath,
-                                  co::overwrite_existing)) {
-    return Error("Cannot create Lua script from source: " +
-                 sourcePath.stem().string());
-  }
-
-  auto metaRes = createAssetMeta(AssetType::LuaScript,
-                                 sourcePath.filename().string(), assetPath);
-
-  if (!metaRes) {
-    std::filesystem::remove(assetPath);
-    return Error("Cannot create Lua script from source: " +
-                 sourcePath.stem().string());
-  }
-
-  return assetPath;
-}
-
 Result<LuaScriptAsset> AssetCache::loadLuaScript(const Uuid &uuid) {
   auto filePath = getPathFromUuid(uuid);
 

--- a/engine/src/quoll/asset/AssetCacheMaterial.cpp
+++ b/engine/src/quoll/asset/AssetCacheMaterial.cpp
@@ -6,20 +6,8 @@
 
 namespace quoll {
 
-Result<Path>
-AssetCache::createMaterialFromAsset(const AssetData<MaterialAsset> &asset) {
-  if (asset.uuid.isEmpty()) {
-    QuollAssert(false, "Invalid uuid provided");
-    return Error("Invalid uuid provided");
-  }
-
-  auto assetPath = getPathFromUuid(asset.uuid);
-
-  auto metaRes = createAssetMeta(AssetType::Material, asset.name, assetPath);
-  if (!metaRes) {
-    return Error("Cannot create material asset: " + asset.name);
-  }
-
+Result<void> AssetCache::createMaterialFromData(const MaterialAsset &data,
+                                                const Path &assetPath) {
   OutputBinaryStream file(assetPath);
 
   if (!file.good()) {
@@ -31,34 +19,33 @@ AssetCache::createMaterialFromAsset(const AssetData<MaterialAsset> &asset) {
   header.magic = AssetFileHeader::MagicConstant;
   file.write(header);
 
-  auto baseColorTexture = getAssetUuid(asset.data.baseColorTexture);
+  auto baseColorTexture = getAssetUuid(data.baseColorTexture);
   file.write(baseColorTexture);
-  file.write(asset.data.baseColorTextureCoord);
-  file.write(asset.data.baseColorFactor);
+  file.write(data.baseColorTextureCoord);
+  file.write(data.baseColorFactor);
 
-  auto metallicRoughnessTexture =
-      getAssetUuid(asset.data.metallicRoughnessTexture);
+  auto metallicRoughnessTexture = getAssetUuid(data.metallicRoughnessTexture);
   file.write(metallicRoughnessTexture);
-  file.write(asset.data.metallicRoughnessTextureCoord);
-  file.write(asset.data.metallicFactor);
-  file.write(asset.data.roughnessFactor);
+  file.write(data.metallicRoughnessTextureCoord);
+  file.write(data.metallicFactor);
+  file.write(data.roughnessFactor);
 
-  auto normalTexture = getAssetUuid(asset.data.normalTexture);
+  auto normalTexture = getAssetUuid(data.normalTexture);
   file.write(normalTexture);
-  file.write(asset.data.normalTextureCoord);
-  file.write(asset.data.normalScale);
+  file.write(data.normalTextureCoord);
+  file.write(data.normalScale);
 
-  auto occlusionTexture = getAssetUuid(asset.data.occlusionTexture);
+  auto occlusionTexture = getAssetUuid(data.occlusionTexture);
   file.write(occlusionTexture);
-  file.write(asset.data.occlusionTextureCoord);
-  file.write(asset.data.occlusionStrength);
+  file.write(data.occlusionTextureCoord);
+  file.write(data.occlusionStrength);
 
-  auto emissiveTexture = getAssetUuid(asset.data.emissiveTexture);
+  auto emissiveTexture = getAssetUuid(data.emissiveTexture);
   file.write(emissiveTexture);
-  file.write(asset.data.emissiveTextureCoord);
-  file.write(asset.data.emissiveFactor);
+  file.write(data.emissiveTextureCoord);
+  file.write(data.emissiveFactor);
 
-  return assetPath;
+  return Ok();
 }
 
 Result<MaterialAsset>

--- a/engine/src/quoll/asset/AssetCacheMesh.cpp
+++ b/engine/src/quoll/asset/AssetCacheMesh.cpp
@@ -6,20 +6,8 @@
 
 namespace quoll {
 
-Result<Path>
-AssetCache::createMeshFromAsset(const AssetData<MeshAsset> &asset) {
-  if (asset.uuid.isEmpty()) {
-    QuollAssert(false, "Invalid uuid provided");
-    return Error("Invalid uuid provided");
-  }
-
-  auto assetPath = getPathFromUuid(asset.uuid);
-
-  auto metaRes = createAssetMeta(asset.type, asset.name, assetPath);
-  if (!metaRes) {
-    return Error("Cannot create mesh asset: " + asset.name);
-  }
-
+Result<void> AssetCache::createMeshFromData(const MeshAsset &data,
+                                            const Path &assetPath) {
   OutputBinaryStream file(assetPath);
 
   if (!file.good()) {
@@ -27,14 +15,14 @@ AssetCache::createMeshFromAsset(const AssetData<MeshAsset> &asset) {
   }
 
   AssetFileHeader header{};
-  header.type = asset.type;
+  header.type = AssetType::Mesh;
   header.magic = AssetFileHeader::MagicConstant;
   file.write(header);
 
-  auto numGeometries = asset.data.geometries.size();
+  auto numGeometries = data.geometries.size();
   file.write(numGeometries);
 
-  for (auto &geometry : asset.data.geometries) {
+  for (auto &geometry : data.geometries) {
     file.write(geometry.positions.size());
     file.write(geometry.positions);
     file.write(geometry.normals.size());
@@ -53,7 +41,7 @@ AssetCache::createMeshFromAsset(const AssetData<MeshAsset> &asset) {
     file.write(geometry.indices);
   }
 
-  return assetPath;
+  return Ok();
 }
 
 Result<MeshAsset> AssetCache::loadMeshDataFromInputStream(const Path &path) {

--- a/engine/src/quoll/asset/AssetCacheScene.cpp
+++ b/engine/src/quoll/asset/AssetCacheScene.cpp
@@ -3,31 +3,6 @@
 
 namespace quoll {
 
-Result<Path> AssetCache::createSceneFromSource(const Path &sourcePath,
-                                               const Uuid &uuid) {
-  using co = std::filesystem::copy_options;
-
-  auto assetPath = getPathFromUuid(uuid);
-
-  std::error_code code;
-  if (!std::filesystem::copy_file(sourcePath, assetPath, co::overwrite_existing,
-                                  code)) {
-    return Error("Cannot create scene from source: " +
-                 sourcePath.stem().string() + "; " + code.message());
-  }
-
-  auto metaRes = createAssetMeta(AssetType::Scene,
-                                 sourcePath.filename().string(), assetPath);
-
-  if (!metaRes) {
-    std::filesystem::remove(assetPath);
-    return Error("Cannot create scene from source: " +
-                 sourcePath.stem().string());
-  }
-
-  return assetPath;
-}
-
 Result<SceneAsset> AssetCache::loadScene(const Uuid &uuid) {
   auto filePath = getPathFromUuid(uuid);
 

--- a/engine/src/quoll/asset/AssetCacheSkeleton.cpp
+++ b/engine/src/quoll/asset/AssetCacheSkeleton.cpp
@@ -7,19 +7,8 @@
 
 namespace quoll {
 
-Result<Path>
-AssetCache::createSkeletonFromAsset(const AssetData<SkeletonAsset> &asset) {
-  if (asset.uuid.isEmpty()) {
-    QuollAssert(false, "Invalid uuid provided");
-    return Error("Invalid uuid provided");
-  }
-
-  auto assetPath = getPathFromUuid(asset.uuid);
-  auto metaRes = createAssetMeta(AssetType::Skeleton, asset.name, assetPath);
-  if (!metaRes) {
-    return Error("Cannot create skeleton asset: " + asset.name);
-  }
-
+Result<void> AssetCache::createSkeletonFromData(const SkeletonAsset &data,
+                                                const Path &assetPath) {
   OutputBinaryStream file(assetPath);
 
   if (!file.good()) {
@@ -31,17 +20,17 @@ AssetCache::createSkeletonFromAsset(const AssetData<SkeletonAsset> &asset) {
   header.magic = AssetFileHeader::MagicConstant;
   file.write(header);
 
-  auto numJoints = static_cast<u32>(asset.data.jointLocalPositions.size());
+  auto numJoints = static_cast<u32>(data.jointLocalPositions.size());
   file.write(numJoints);
 
-  file.write(asset.data.jointLocalPositions);
-  file.write(asset.data.jointLocalRotations);
-  file.write(asset.data.jointLocalScales);
-  file.write(asset.data.jointParents);
-  file.write(asset.data.jointInverseBindMatrices);
-  file.write(asset.data.jointNames);
+  file.write(data.jointLocalPositions);
+  file.write(data.jointLocalRotations);
+  file.write(data.jointLocalScales);
+  file.write(data.jointParents);
+  file.write(data.jointInverseBindMatrices);
+  file.write(data.jointNames);
 
-  return assetPath;
+  return Ok();
 }
 
 Result<SkeletonAsset>

--- a/engine/tests/quoll-tests/asset/AssetCacheAnimation.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheAnimation.test.cpp
@@ -54,7 +54,7 @@ quoll::AssetData<quoll::AnimationAsset> createRandomizedAnimation() {
 
 TEST_F(AssetCacheAnimationTest, CreatesMetaFileFromAsset) {
   auto asset = createRandomizedAnimation();
-  auto filePath = cache.createAnimationFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto meta = cache.getAssetMeta(asset.uuid);
 
   EXPECT_EQ(meta.type, quoll::AssetType::Animation);
@@ -63,7 +63,7 @@ TEST_F(AssetCacheAnimationTest, CreatesMetaFileFromAsset) {
 
 TEST_F(AssetCacheAnimationTest, CreatesAnimationFile) {
   auto asset = createRandomizedAnimation();
-  auto filePath = cache.createAnimationFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   quoll::InputBinaryStream file(filePath);
   EXPECT_TRUE(file.good());
 
@@ -117,7 +117,7 @@ TEST_F(AssetCacheAnimationTest, CreatesAnimationFile) {
 TEST_F(AssetCacheAnimationTest, LoadsAnimationAssetFromFile) {
   auto asset = createRandomizedAnimation();
 
-  auto filePath = cache.createAnimationFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto handle = cache.load<quoll::AnimationAsset>(asset.uuid);
   EXPECT_TRUE(handle);
   EXPECT_NE(handle, quoll::AssetHandle<quoll::AnimationAsset>());

--- a/engine/tests/quoll-tests/asset/AssetCacheAnimator.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheAnimator.test.cpp
@@ -15,8 +15,8 @@ public:
 
 TEST_F(AssetCacheAnimatorTest, CreatesAnimatorFromSource) {
   auto uuid = quoll::Uuid::generate();
-  auto filePath =
-      cache.createAnimatorFromSource(FixturesPath / "test.animator", uuid);
+  auto filePath = cache.createFromSource<quoll::AnimatorAsset>(
+      FixturesPath / "test.animator", uuid);
   EXPECT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
 
@@ -68,7 +68,7 @@ TEST_F(AssetCacheAnimatorTest, CreatesAnimatorFileFromAsset) {
   asset.data.states.push_back(stateWalk);
   asset.data.states.push_back(stateRun);
 
-  auto filePath = cache.createAnimatorFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
 
   EXPECT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
@@ -536,7 +536,7 @@ TEST_F(AssetCacheAnimatorTest,
        LoadAnimatorLoadsAnimationsBeforeLoadingAnimator) {
   quoll::AssetData<quoll::AnimationAsset> animData{};
   animData.uuid = quoll::Uuid::generate();
-  auto path = cache.createAnimationFromAsset(animData).data();
+  auto path = cache.createFromData(animData).data();
 
   YAML::Node node;
   node["version"] = "0.1";
@@ -553,7 +553,7 @@ TEST_F(AssetCacheAnimatorTest,
   stream.close();
 
   auto uuid = quoll::Uuid::generate();
-  auto filePath = cache.createAnimatorFromSource(FilePath, uuid);
+  auto filePath = cache.createFromSource<quoll::AnimatorAsset>(FilePath, uuid);
 
   auto res = cache.load<quoll::AnimatorAsset>(uuid);
   EXPECT_TRUE(res);
@@ -578,7 +578,7 @@ TEST_F(AssetCacheAnimatorTest,
   animData.name = "old-name";
   animData.uuid = quoll::Uuid::generate();
   animData.data.states.push_back({});
-  auto animatorPath = cache.createAnimatorFromAsset(animData);
+  auto animatorPath = cache.createFromData(animData);
 
   auto result = cache.load<quoll::AnimatorAsset>(animData.uuid);
   EXPECT_TRUE(result);
@@ -593,7 +593,7 @@ TEST_F(AssetCacheAnimatorTest,
   }
 
   animData.name = "new-name";
-  cache.createAnimatorFromAsset(animData);
+  cache.createFromData(animData);
 
   {
     auto res = cache.load<quoll::AnimatorAsset>(animData.uuid);

--- a/engine/tests/quoll-tests/asset/AssetCacheAudioTest.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheAudioTest.test.cpp
@@ -12,7 +12,7 @@ TEST_F(AssetCacheAudioTest, CreatesAudioFromSource) {
 
   auto uuid = quoll::Uuid::generate();
 
-  auto filePath = cache.createAudioFromSource(audioPath, uuid);
+  auto filePath = cache.createFromSource<quoll::AudioAsset>(audioPath, uuid);
   EXPECT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
 
@@ -28,7 +28,7 @@ TEST_F(AssetCacheAudioTest, LoadsWavAudioFileIntoRegistry) {
 
   auto uuid = quoll::Uuid::generate();
 
-  auto filePath = cache.createAudioFromSource(audioPath, uuid);
+  auto filePath = cache.createFromSource<quoll::AudioAsset>(audioPath, uuid);
   auto result = cache.load<quoll::AudioAsset>(uuid);
 
   EXPECT_TRUE(result);

--- a/engine/tests/quoll-tests/asset/AssetCacheEnvironment.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheEnvironment.test.cpp
@@ -14,10 +14,10 @@ public:
     irradianceUuid = quoll::Uuid::generate();
     specularUuid = quoll::Uuid::generate();
 
-    cache.createTextureFromSource(FixturesPath / "1x1-cubemap.ktx",
-                                  irradianceUuid);
-    cache.createTextureFromSource(FixturesPath / "1x1-cubemap.ktx",
-                                  specularUuid);
+    cache.createFromSource<quoll::TextureAsset>(
+        FixturesPath / "1x1-cubemap.ktx", irradianceUuid);
+    cache.createFromSource<quoll::TextureAsset>(
+        FixturesPath / "1x1-cubemap.ktx", specularUuid);
   }
 
   quoll::Uuid irradianceUuid;
@@ -34,7 +34,7 @@ TEST_F(AssetCacheEnvironmentTest, CreatesMetaFileFromAsset) {
   asset.data.irradianceMap = irradianceMap;
   asset.data.specularMap = specularMap;
 
-  auto filePath = cache.createEnvironmentFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto meta = cache.getAssetMeta(asset.uuid);
 
   EXPECT_EQ(meta.type, quoll::AssetType::Environment);
@@ -51,7 +51,7 @@ TEST_F(AssetCacheEnvironmentTest, CreatesEnvironmentFileFromEnvironmentAsset) {
   asset.data.irradianceMap = irradianceMap;
   asset.data.specularMap = specularMap;
 
-  auto filePath = cache.createEnvironmentFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   EXPECT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
 
@@ -82,7 +82,7 @@ TEST_F(AssetCacheEnvironmentTest,
   asset.uuid = quoll::Uuid::generate();
   asset.data.irradianceMap = irradianceMap;
   asset.data.specularMap = specularMap;
-  auto createRes = cache.createEnvironmentFromAsset(asset);
+  auto createRes = cache.createFromData(asset);
 
   cache.getRegistry().remove(irradianceMap.data());
   cache.getRegistry().remove(specularMap.data());
@@ -96,8 +96,8 @@ TEST_F(AssetCacheEnvironmentTest,
   }
 
   {
-    cache.createTextureFromSource(FixturesPath / "1x1-cubemap.ktx",
-                                  irradianceUuid);
+    cache.createFromSource<quoll::TextureAsset>(
+        FixturesPath / "1x1-cubemap.ktx", irradianceUuid);
     std::filesystem::remove(cache.getPathFromUuid(specularUuid));
 
     auto res = cache.load<quoll::EnvironmentAsset>(asset.uuid);
@@ -117,7 +117,7 @@ TEST_F(AssetCacheEnvironmentTest,
   asset.uuid = quoll::Uuid::generate();
   asset.data.irradianceMap = irradianceMap;
   asset.data.specularMap = specularMap;
-  auto createRes = cache.createEnvironmentFromAsset(asset);
+  auto createRes = cache.createFromData(asset);
 
   cache.getRegistry().remove(irradianceMap.data());
   cache.getRegistry().remove(specularMap.data());
@@ -148,7 +148,7 @@ TEST_F(AssetCacheEnvironmentTest,
   asset.uuid = quoll::Uuid::generate();
   asset.data.irradianceMap = irradianceMap;
   asset.data.specularMap = specularMap;
-  auto createRes = cache.createEnvironmentFromAsset(asset);
+  auto createRes = cache.createFromData(asset);
 
   EXPECT_EQ(cache.getRegistry().count<quoll::TextureAsset>(), 2);
 

--- a/engine/tests/quoll-tests/asset/AssetCacheFont.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheFont.test.cpp
@@ -10,7 +10,7 @@ public:
 TEST_F(AssetCacheFontTest, CreatesFontFromSource) {
   auto uuid = quoll::Uuid::generate();
   auto sourcePath = FixturesPath / "valid-font.ttf";
-  auto filePath = cache.createFontFromSource(sourcePath, uuid);
+  auto filePath = cache.createFromSource<quoll::FontAsset>(sourcePath, uuid);
 
   EXPECT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
@@ -26,7 +26,7 @@ TEST_F(AssetCacheFontTest, CreatesFontFromSource) {
 TEST_F(AssetCacheFontTest, LoadsTTFFontFromFile) {
   auto sourcePath = FixturesPath / "valid-font.ttf";
   auto uuid = quoll::Uuid::generate();
-  auto filePath = cache.createFontFromSource(sourcePath, uuid);
+  auto filePath = cache.createFromSource<quoll::FontAsset>(sourcePath, uuid);
 
   auto result = cache.load<quoll::FontAsset>(uuid);
 
@@ -45,7 +45,7 @@ TEST_F(AssetCacheFontTest, LoadsTTFFontFromFile) {
 TEST_F(AssetCacheFontTest, LoadsOTFFontFromFile) {
   auto sourcePath = FixturesPath / "valid-font.otf";
   auto uuid = quoll::Uuid::generate();
-  auto filePath = cache.createFontFromSource(sourcePath, uuid);
+  auto filePath = cache.createFromSource<quoll::FontAsset>(sourcePath, uuid);
 
   auto result = cache.load<quoll::FontAsset>(uuid);
 

--- a/engine/tests/quoll-tests/asset/AssetCacheInputMap.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheInputMap.test.cpp
@@ -59,8 +59,8 @@ public:
 
 TEST_F(AssetCacheInputMapTest, CreateInputMapFromSource) {
   auto uuid = quoll::Uuid::generate();
-  auto filePath =
-      cache.createInputMapFromSource(FixturesPath / "test.inputmap", uuid);
+  auto filePath = cache.createFromSource<quoll::InputMapAsset>(
+      FixturesPath / "test.inputmap", uuid);
   EXPECT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
 

--- a/engine/tests/quoll-tests/asset/AssetCacheLuaScript.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheLuaScript.test.cpp
@@ -9,7 +9,8 @@ public:
   quoll::Result<quoll::AssetHandle<quoll::LuaScriptAsset>>
   loadFromSource(quoll::Path sourcePath) {
     auto uuid = quoll::Uuid::generate();
-    auto cachePath = cache.createLuaScriptFromSource(sourcePath, uuid);
+    auto cachePath =
+        cache.createFromSource<quoll::LuaScriptAsset>(sourcePath, uuid);
 
     return cache.load<quoll::LuaScriptAsset>(uuid);
   }
@@ -21,7 +22,8 @@ TEST_F(AssetCacheLuaScriptTest, CreateLuaScriptFromSource) {
   auto scriptPath = FixturesPath / "script-asset-valid.lua";
 
   auto uuid = quoll::Uuid::generate();
-  auto filePath = cache.createLuaScriptFromSource(scriptPath, uuid);
+  auto filePath =
+      cache.createFromSource<quoll::LuaScriptAsset>(scriptPath, uuid);
   EXPECT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
 
@@ -102,7 +104,7 @@ TEST_F(AssetCacheLuaScriptTest, LoadsLuaScriptIntoRegistry) {
 TEST_F(AssetCacheLuaScriptTest,
        UpdatesExistingLuaScriptIfAssetWithUuidAlreadyExists) {
   auto uuid1 = quoll::Uuid::generate();
-  auto filePath = cache.createLuaScriptFromSource(
+  auto filePath = cache.createFromSource<quoll::LuaScriptAsset>(
       FixturesPath / "component-script.lua", uuid1);
 
   auto result = cache.load<quoll::LuaScriptAsset>(uuid1);
@@ -116,8 +118,8 @@ TEST_F(AssetCacheLuaScriptTest,
     EXPECT_EQ(script.name, "component-script.lua");
   }
 
-  cache.createLuaScriptFromSource(FixturesPath / "component-script-2.lua",
-                                  uuid1);
+  cache.createFromSource<quoll::LuaScriptAsset>(
+      FixturesPath / "component-script-2.lua", uuid1);
 
   {
     auto result = cache.load<quoll::LuaScriptAsset>(uuid1);

--- a/engine/tests/quoll-tests/asset/AssetCacheMaterial.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheMaterial.test.cpp
@@ -69,7 +69,8 @@ public:
     AssetCacheTestBase::SetUp();
 
     textureUuid = quoll::Uuid::generate();
-    cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx", textureUuid);
+    cache.createFromSource<quoll::TextureAsset>(FixturesPath / "1x1-2d.ktx",
+                                                textureUuid);
   }
 
   quoll::Uuid textureUuid;
@@ -77,7 +78,7 @@ public:
 
 TEST_F(AssetCacheMaterialTest, CreatesMetaFileFromAsset) {
   auto asset = createMaterialAsset(true);
-  auto filePath = cache.createMaterialFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto meta = cache.getAssetMeta(asset.uuid);
 
   EXPECT_EQ(meta.type, quoll::AssetType::Material);
@@ -86,7 +87,7 @@ TEST_F(AssetCacheMaterialTest, CreatesMetaFileFromAsset) {
 
 TEST_F(AssetCacheMaterialTest, CreatesMaterialWithTexturesFromAsset) {
   auto asset = createMaterialAsset(true);
-  auto filePath = cache.createMaterialFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
 
   ASSERT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
@@ -166,7 +167,7 @@ TEST_F(AssetCacheMaterialTest,
        CreatesMaterialWithoutTexturesFromAssetIfReferencedTexturesAreInvalid) {
   auto asset = createMaterialAsset(false);
 
-  auto filePath = cache.createMaterialFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
 
   {
     quoll::InputBinaryStream file(filePath);
@@ -241,7 +242,7 @@ TEST_F(AssetCacheMaterialTest,
 TEST_F(AssetCacheMaterialTest, LoadsMaterialWithTexturesFromFile) {
   auto asset = createMaterialAsset(true);
 
-  auto assetFile = cache.createMaterialFromAsset(asset);
+  auto assetFile = cache.createFromData(asset);
   EXPECT_TRUE(assetFile);
   EXPECT_FALSE(assetFile.hasWarnings());
 
@@ -291,7 +292,7 @@ TEST_F(AssetCacheMaterialTest, LoadsMaterialWithTexturesFromFile) {
 TEST_F(AssetCacheMaterialTest, LoadsMaterialWithoutTexturesFromFile) {
   auto asset = createMaterialAsset(false);
 
-  auto assetFile = cache.createMaterialFromAsset(asset);
+  auto assetFile = cache.createFromData(asset);
   EXPECT_TRUE(assetFile);
   EXPECT_FALSE(assetFile.hasWarnings());
 
@@ -343,7 +344,7 @@ TEST_F(AssetCacheMaterialTest, LoadsTexturesWithMaterials) {
   quoll::AssetData<quoll::MaterialAsset> material{};
   material.uuid = quoll::Uuid::generate();
   material.data.baseColorTexture = texture;
-  auto path = cache.createMaterialFromAsset(material);
+  auto path = cache.createFromData(material);
 
   cache.getRegistry().remove(texture);
   EXPECT_FALSE(cache.getRegistry().has(texture));

--- a/engine/tests/quoll-tests/asset/AssetCacheMesh.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheMesh.test.cpp
@@ -88,7 +88,7 @@ public:
 
 TEST_F(AssetCacheMeshTest, CreatesMetaFileFromAsset) {
   auto asset = createRandomizedMeshAsset();
-  auto filePath = cache.createMeshFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto meta = cache.getAssetMeta(asset.uuid);
 
   EXPECT_EQ(meta.type, quoll::AssetType::Mesh);
@@ -97,7 +97,7 @@ TEST_F(AssetCacheMeshTest, CreatesMetaFileFromAsset) {
 
 TEST_F(AssetCacheMeshTest, CreatesMeshFileFromMeshAsset) {
   auto asset = createRandomizedMeshAsset();
-  auto filePath = cache.createMeshFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
 
   quoll::InputBinaryStream file(filePath);
   EXPECT_TRUE(file.good());
@@ -204,7 +204,7 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadMeshIfItHasNoVertices) {
     geometry.positions.clear();
   }
 
-  auto filePath = cache.createMeshFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto handle = cache.load<quoll::MeshAsset>(asset.uuid);
   EXPECT_FALSE(handle);
 }
@@ -215,14 +215,14 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadMeshIfItHasNoIndices) {
     geometry.indices.clear();
   }
 
-  auto filePath = cache.createMeshFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto handle = cache.load<quoll::MeshAsset>(asset.uuid);
   EXPECT_FALSE(handle);
 }
 
 TEST_F(AssetCacheMeshTest, LoadsMeshFromFile) {
   auto asset = createRandomizedMeshAsset();
-  auto filePath = cache.createMeshFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto handleRes = cache.load<quoll::MeshAsset>(asset.uuid);
   auto handle = handleRes.data();
 
@@ -257,7 +257,7 @@ TEST_F(AssetCacheMeshTest, LoadsMeshFromFile) {
 TEST_F(AssetCacheMeshTest, CreateMeshAssetWithSkinData) {
   auto asset = createRandomizedSkinnedMeshAsset();
 
-  auto filePath = cache.createMeshFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
 
   quoll::InputBinaryStream file(filePath);
   EXPECT_TRUE(file.good());
@@ -364,7 +364,7 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadSkinnedMeshIfItHasNoVertices) {
     geometry.positions.clear();
   }
 
-  auto filePath = cache.createMeshFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto handle = cache.load<quoll::MeshAsset>(asset.uuid);
   EXPECT_FALSE(handle);
 }
@@ -375,7 +375,7 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadSkinnedMeshIfItHasNoIndices) {
     geometry.indices.clear();
   }
 
-  auto filePath = cache.createMeshFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto handle = cache.load<quoll::MeshAsset>(asset.uuid);
   EXPECT_FALSE(handle);
 }
@@ -383,7 +383,7 @@ TEST_F(AssetCacheMeshTest, DoesNotLoadSkinnedMeshIfItHasNoIndices) {
 TEST_F(AssetCacheMeshTest, LoadsSkinnedMeshFromFile) {
   auto asset = createRandomizedSkinnedMeshAsset();
 
-  auto filePath = cache.createMeshFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto handle = cache.load<quoll::MeshAsset>(asset.uuid).data();
   EXPECT_NE(handle, quoll::AssetHandle<quoll::MeshAsset>());
   auto &mesh = cache.getRegistry().get(handle);

--- a/engine/tests/quoll-tests/asset/AssetCachePrefab.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCachePrefab.test.cpp
@@ -153,7 +153,8 @@ public:
     AssetCacheTestBase::SetUp();
 
     textureUuid = quoll::Uuid::generate();
-    cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx", textureUuid);
+    cache.createFromSource<quoll::TextureAsset>(FixturesPath / "1x1-2d.ktx",
+                                                textureUuid);
   }
 
   quoll::Uuid textureUuid;
@@ -161,7 +162,7 @@ public:
 
 TEST_F(AssetCachePrefabTest, CreatesMetaFileFromAsset) {
   auto asset = createPrefabAsset();
-  auto filePath = cache.createPrefabFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto meta = cache.getAssetMeta(asset.uuid);
 
   EXPECT_EQ(meta.type, quoll::AssetType::Prefab);
@@ -171,7 +172,7 @@ TEST_F(AssetCachePrefabTest, CreatesMetaFileFromAsset) {
 TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
   auto asset = createPrefabAsset();
 
-  auto filePath = cache.createPrefabFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   quoll::InputBinaryStream file(filePath);
   EXPECT_TRUE(file.good());
 
@@ -486,7 +487,7 @@ TEST_F(AssetCachePrefabTest, FailsLoadingPrefabIfPrefabHasNoComponents) {
   quoll::AssetData<quoll::PrefabAsset> asset;
   asset.uuid = quoll::Uuid::generate();
 
-  auto filePath = cache.createPrefabFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
 
   auto res = cache.load<quoll::PrefabAsset>(asset.uuid);
   EXPECT_FALSE(res);
@@ -494,7 +495,7 @@ TEST_F(AssetCachePrefabTest, FailsLoadingPrefabIfPrefabHasNoComponents) {
 
 TEST_F(AssetCachePrefabTest, LoadsPrefabFile) {
   auto asset = createPrefabAsset();
-  auto filePath = cache.createPrefabFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto handle = cache.load<quoll::PrefabAsset>(asset.uuid);
   EXPECT_NE(handle, quoll::AssetHandle<quoll::PrefabAsset>());
   EXPECT_FALSE(handle.hasWarnings());
@@ -608,7 +609,7 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabWithMeshAnimationSkeleton) {
   auto tempTextureAsset = cache.getRegistry().getMeta(tempTextureHandle);
   cache.getRegistry().remove(tempTextureHandle);
 
-  auto texturePath = cache.createTextureFromAsset(tempTextureAsset).data();
+  auto texturePath = cache.createFromData(tempTextureAsset).data();
   auto textureHandle = cache.load<quoll::TextureAsset>(textureUuid);
 
   // Create mesh
@@ -627,28 +628,28 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabWithMeshAnimationSkeleton) {
 
   geometry.indices.push_back(0);
   meshData.data.geometries.push_back(geometry);
-  auto meshPath = cache.createMeshFromAsset(meshData).data();
+  auto meshPath = cache.createFromData(meshData).data();
   auto meshHandle = cache.load<quoll::MeshAsset>(meshData.uuid);
 
   // Create skeleton
   quoll::AssetData<quoll::SkeletonAsset> skeletonData{};
   skeletonData.uuid = quoll::Uuid::generate();
 
-  auto skeletonPath = cache.createSkeletonFromAsset(skeletonData);
+  auto skeletonPath = cache.createFromData(skeletonData);
   auto skeletonHandle = cache.load<quoll::SkeletonAsset>(skeletonData.uuid);
 
   // Create animation
   quoll::AssetData<quoll::AnimationAsset> animationData{};
   animationData.data.time = 2.5;
   animationData.uuid = quoll::Uuid::generate();
-  auto animationPath = cache.createAnimationFromAsset(animationData);
+  auto animationPath = cache.createFromData(animationData);
   auto animationHandle = cache.load<quoll::AnimationAsset>(animationData.uuid);
 
   // Create animator
   quoll::AssetData<quoll::AnimatorAsset> animatorData{};
   animatorData.data.states.push_back({"INITIAL"});
   animatorData.uuid = quoll::Uuid::generate();
-  auto animatorPath = cache.createAnimatorFromAsset(animatorData);
+  auto animatorPath = cache.createFromData(animatorData);
   auto animatorHandle = cache.load<quoll::AnimatorAsset>(animatorData.uuid);
 
   // Create prefab
@@ -659,7 +660,7 @@ TEST_F(AssetCachePrefabTest, LoadsPrefabWithMeshAnimationSkeleton) {
   prefabData.data.animations.push_back(animationHandle);
   prefabData.data.animators.push_back({0U, animatorHandle});
 
-  auto prefabPath = cache.createPrefabFromAsset(prefabData);
+  auto prefabPath = cache.createFromData(prefabData);
 
   // Delete all existing assets
   cache.getRegistry().remove(textureHandle.data());

--- a/engine/tests/quoll-tests/asset/AssetCacheScene.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheScene.test.cpp
@@ -11,8 +11,8 @@ public:
 
 TEST_F(AssetCacheSceneTest, CreatesSceneFromSource) {
   auto uuid = quoll::Uuid::generate();
-  auto filePath =
-      cache.createSceneFromSource(FixturesPath / "test.scene", uuid);
+  auto filePath = cache.createFromSource<quoll::SceneAsset>(
+      FixturesPath / "test.scene", uuid);
   EXPECT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
 

--- a/engine/tests/quoll-tests/asset/AssetCacheSkeleton.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheSkeleton.test.cpp
@@ -60,7 +60,7 @@ TEST_F(AssetCacheSkeletonTest, CreatesMetaFileFromAsset) {
     }
   }
 
-  auto filePath = cache.createSkeletonFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto meta = cache.getAssetMeta(asset.uuid);
 
   EXPECT_EQ(meta.type, quoll::AssetType::Skeleton);
@@ -116,7 +116,7 @@ TEST_F(AssetCacheSkeletonTest, CreatesSkeletonFileFromSkeletonAsset) {
     }
   }
 
-  auto filePath = cache.createSkeletonFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
 
   quoll::InputBinaryStream file(filePath);
   EXPECT_TRUE(file.good());
@@ -203,7 +203,7 @@ TEST_F(AssetCacheSkeletonTest, LoadsSkeletonAssetFromFile) {
     }
   }
 
-  auto filePath = cache.createSkeletonFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   auto handle = cache.load<quoll::SkeletonAsset>(asset.uuid);
 
   EXPECT_NE(handle, quoll::AssetHandle<quoll::SkeletonAsset>());

--- a/engine/tests/quoll-tests/asset/AssetCacheTexture.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCacheTexture.test.cpp
@@ -12,8 +12,8 @@ public:
 
 TEST_F(AssetCacheTextureTest, CreatesTextureFromSource) {
   auto uuid = quoll::Uuid::generate();
-  auto filePath =
-      cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx", uuid);
+  auto filePath = cache.createFromSource<quoll::TextureAsset>(
+      FixturesPath / "1x1-2d.ktx", uuid);
   EXPECT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
 
@@ -27,8 +27,8 @@ TEST_F(AssetCacheTextureTest, CreatesTextureFromSource) {
 
 TEST_F(AssetCacheTextureTest, CreatesTextureFromAsset) {
   auto uuid = quoll::Uuid::generate();
-  auto createdRes =
-      cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx", uuid);
+  auto createdRes = cache.createFromSource<quoll::TextureAsset>(
+      FixturesPath / "1x1-2d.ktx", uuid);
   auto texture = cache.load<quoll::TextureAsset>(uuid);
   auto handle = texture.data();
 
@@ -36,7 +36,7 @@ TEST_F(AssetCacheTextureTest, CreatesTextureFromAsset) {
 
   cache.getRegistry().remove(handle);
 
-  auto filePath = cache.createTextureFromAsset(asset);
+  auto filePath = cache.createFromData(asset);
   EXPECT_TRUE(filePath);
   EXPECT_FALSE(filePath.hasWarnings());
 
@@ -49,8 +49,8 @@ TEST_F(AssetCacheTextureTest, CreatesTextureFromAsset) {
 
 TEST_F(AssetCacheTextureTest, LoadsTextureToRegistry) {
   auto uuid = quoll::Uuid::generate();
-  auto filePath =
-      cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx", uuid);
+  auto filePath = cache.createFromSource<quoll::TextureAsset>(
+      FixturesPath / "1x1-2d.ktx", uuid);
 
   auto texture = cache.load<quoll::TextureAsset>(uuid);
   auto handle = texture.data();
@@ -68,7 +68,7 @@ TEST_F(AssetCacheTextureTest, FailsIfKtxFileCannotBeLoaded) {
 
   // invalid format
   auto uuid = quoll::Uuid::generate();
-  auto filePath = cache.createTextureFromSource(
+  auto filePath = cache.createFromSource<quoll::TextureAsset>(
       FixturesPath / "white-image-100x100.png", uuid);
 
   EXPECT_FALSE(cache.load<quoll::TextureAsset>(uuid));
@@ -76,16 +76,16 @@ TEST_F(AssetCacheTextureTest, FailsIfKtxFileCannotBeLoaded) {
 
 TEST_F(AssetCacheTextureTest, FailsIfTextureIsOneDimensional) {
   auto uuid = quoll::Uuid::generate();
-  auto filePath =
-      cache.createTextureFromSource(FixturesPath / "1x1-1d.ktx", uuid);
+  auto filePath = cache.createFromSource<quoll::TextureAsset>(
+      FixturesPath / "1x1-1d.ktx", uuid);
 
   EXPECT_FALSE(cache.load<quoll::TextureAsset>(uuid));
 }
 
 TEST_F(AssetCacheTextureTest, LoadsTexture2D) {
   auto uuid = quoll::Uuid::generate();
-  auto filePath =
-      cache.createTextureFromSource(FixturesPath / "1x1-2d.ktx", uuid);
+  auto filePath = cache.createFromSource<quoll::TextureAsset>(
+      FixturesPath / "1x1-2d.ktx", uuid);
 
   auto texture = cache.load<quoll::TextureAsset>(uuid);
   EXPECT_TRUE(texture);
@@ -101,8 +101,8 @@ TEST_F(AssetCacheTextureTest, LoadsTexture2D) {
 TEST_F(AssetCacheTextureTest, LoadsTextureCubemap) {
   auto uuid = quoll::Uuid::generate();
 
-  auto filePath =
-      cache.createTextureFromSource(FixturesPath / "1x1-cubemap.ktx", uuid);
+  auto filePath = cache.createFromSource<quoll::TextureAsset>(
+      FixturesPath / "1x1-cubemap.ktx", uuid);
   auto texture = cache.load<quoll::TextureAsset>(uuid);
 
   EXPECT_TRUE(texture);

--- a/engine/tests/quoll-tests/scripting/LuaScriptingSystem.test.cpp
+++ b/engine/tests/quoll-tests/scripting/LuaScriptingSystem.test.cpp
@@ -18,7 +18,8 @@ public:
   quoll::AssetHandle<quoll::LuaScriptAsset>
   loadLuaScript(quoll::String filename) {
     auto uuid = quoll::Uuid::generate();
-    cache.createLuaScriptFromSource(FixturesPath / filename, uuid);
+    cache.createFromSource<quoll::LuaScriptAsset>(FixturesPath / filename,
+                                                  uuid);
     return cache.load<quoll::LuaScriptAsset>(uuid);
   }
 

--- a/engine/tests/quoll-tests/test-utils/ScriptingInterfaceTestBase.cpp
+++ b/engine/tests/quoll-tests/test-utils/ScriptingInterfaceTestBase.cpp
@@ -43,7 +43,8 @@ LuaScriptingInterfaceTestBase::call(quoll::Entity entity,
 quoll::AssetHandle<quoll::LuaScriptAsset>
 LuaScriptingInterfaceTestBase::loadScript(quoll::String scriptName) {
   auto uuid = quoll::Uuid::generate();
-  assetCache.createLuaScriptFromSource(FixturesPath / scriptName, uuid);
+  assetCache.createFromSource<quoll::LuaScriptAsset>(FixturesPath / scriptName,
+                                                     uuid);
 
   auto res = assetCache.load<quoll::LuaScriptAsset>(uuid);
   QuollAssert(res, "Error loading script");


### PR DESCRIPTION
- Create template function to create assets from data
- Make all asset specific create functions return void result and accept asset data without headers
- Handle metadata outside of asset data creators
- Create template function to create asset by just copying source
- Remove all other functions that copy source since they all do the same thing but with a different asset type