### PR TITLE
Use asset ref for materials

### DIFF
--- a/editor/src/quoll/editor/actions/EntityMeshRendererActions.cpp
+++ b/editor/src/quoll/editor/actions/EntityMeshRendererActions.cpp
@@ -15,7 +15,7 @@ EntitySetMeshRendererMaterial::onExecute(WorkspaceState &state,
   mOldMaterial =
       scene.entityDatabase.get<MeshRenderer>(mEntity).materials.at(mSlot);
   scene.entityDatabase.get<MeshRenderer>(mEntity).materials.at(mSlot) =
-      mNewMaterial.handle();
+      mNewMaterial;
 
   ActionExecutorResult result{};
   result.addToHistory = true;
@@ -62,7 +62,7 @@ EntityAddMeshRendererMaterialSlot::onExecute(WorkspaceState &state,
   auto &scene = state.scene;
 
   scene.entityDatabase.get<MeshRenderer>(mEntity).materials.push_back(
-      mNewMaterial.handle());
+      mNewMaterial);
 
   ActionExecutorResult result{};
   result.entitiesToSave.push_back(mEntity);

--- a/editor/src/quoll/editor/actions/EntityMeshRendererActions.h
+++ b/editor/src/quoll/editor/actions/EntityMeshRendererActions.h
@@ -21,7 +21,7 @@ public:
 private:
   Entity mEntity;
   usize mSlot;
-  AssetHandle<MaterialAsset> mOldMaterial;
+  AssetRef<MaterialAsset> mOldMaterial;
   AssetRef<MaterialAsset> mNewMaterial;
 };
 
@@ -57,7 +57,7 @@ public:
 
 private:
   Entity mEntity;
-  AssetHandle<MaterialAsset> mOldMaterial;
+  AssetRef<MaterialAsset> mOldMaterial;
 };
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/actions/EntitySkinnedMeshRendererActions.cpp
+++ b/editor/src/quoll/editor/actions/EntitySkinnedMeshRendererActions.cpp
@@ -16,7 +16,7 @@ EntitySetSkinnedMeshRendererMaterial::onExecute(WorkspaceState &state,
       scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.at(
           mSlot);
   scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.at(mSlot) =
-      mNewMaterial.handle();
+      mNewMaterial;
 
   ActionExecutorResult result{};
   result.addToHistory = true;
@@ -64,7 +64,7 @@ EntityAddSkinnedMeshRendererMaterialSlot::onExecute(WorkspaceState &state,
   auto &scene = state.scene;
 
   scene.entityDatabase.get<SkinnedMeshRenderer>(mEntity).materials.push_back(
-      mNewMaterial.handle());
+      mNewMaterial);
 
   ActionExecutorResult result{};
   result.entitiesToSave.push_back(mEntity);

--- a/editor/src/quoll/editor/actions/EntitySkinnedMeshRendererActions.h
+++ b/editor/src/quoll/editor/actions/EntitySkinnedMeshRendererActions.h
@@ -21,7 +21,7 @@ public:
 private:
   Entity mEntity;
   usize mSlot;
-  AssetHandle<MaterialAsset> mOldMaterial;
+  AssetRef<MaterialAsset> mOldMaterial;
   AssetRef<MaterialAsset> mNewMaterial;
 };
 
@@ -57,7 +57,7 @@ public:
 
 private:
   Entity mEntity;
-  AssetHandle<MaterialAsset> mOldMaterial;
+  AssetRef<MaterialAsset> mOldMaterial;
 };
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/asset/gltf/GLTFImportData.h
+++ b/editor/src/quoll/editor/asset/gltf/GLTFImportData.h
@@ -42,7 +42,7 @@ struct GLTFImportData {
 
   GLTFToAsset<AssetRef<TextureAsset>> textures;
 
-  GLTFToAsset<AssetHandle<MaterialAsset>> materials;
+  GLTFToAsset<AssetRef<MaterialAsset>> materials;
 
   SkeletonData skeletons;
 
@@ -50,7 +50,7 @@ struct GLTFImportData {
 
   GLTFToAsset<AssetRef<MeshAsset>> meshes;
 
-  std::map<AssetHandle<MeshAsset>, std::vector<AssetHandle<MaterialAsset>>>
+  std::map<AssetHandle<MeshAsset>, std::vector<AssetRef<MaterialAsset>>>
       meshMaterials;
 
   GLTFToAsset<DirectionalLight> directionalLights;

--- a/editor/src/quoll/editor/asset/gltf/MaterialStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/MaterialStep.cpp
@@ -90,11 +90,15 @@ void loadMaterials(GLTFImportData &importData) {
     }
 
     auto path = assetCache.createFromData(material);
-    auto handle = assetCache.load<MaterialAsset>(material.uuid);
-    importData.materials.map.insert_or_assign(i, handle);
+    auto ref = assetCache.request<MaterialAsset>(material.uuid);
+    if (ref) {
+      importData.materials.map.insert_or_assign(i, ref.data());
 
-    importData.outputUuids.insert_or_assign(
-        assetName, assetCache.getRegistry().getMeta(handle.data()).uuid);
+      importData.outputUuids.insert_or_assign(assetName,
+                                              ref.data().meta().uuid);
+    } else {
+      importData.warnings.push_back(ref.error());
+    }
   }
 }
 

--- a/editor/src/quoll/editor/asset/gltf/MeshStep.cpp
+++ b/editor/src/quoll/editor/asset/gltf/MeshStep.cpp
@@ -372,7 +372,7 @@ void loadMeshes(GLTFImportData &importData) {
         gltfMesh.name.empty() ? "mesh-" + std::to_string(i) : gltfMesh.name;
     assetName += ".mesh";
 
-    std::vector<AssetHandle<MaterialAsset>> materials;
+    std::vector<AssetRef<MaterialAsset>> materials;
     AssetData<MeshAsset> mesh;
 
     for (usize p = 0; p < gltfMesh.primitives.size(); ++p) {

--- a/editor/src/quoll/editor/scene/SceneEditorWorkspace.cpp
+++ b/editor/src/quoll/editor/scene/SceneEditorWorkspace.cpp
@@ -21,11 +21,10 @@ SceneEditorWorkspace::SceneEditorWorkspace(
       mActionExecutor(mState, mAssetManager.getCache()),
       mSceneAssetHandle(scene),
       mSceneWriter(mState.scene, mAssetManager.getAssetRegistry()),
-      mSceneIO(mAssetManager.getAssetRegistry(), mState.scene),
-      mRenderer(renderer), mSceneRenderer(sceneRenderer),
-      mEditorRenderer(editorRenderer), mMousePickingGraph(mousePickingGraph),
-      mEngineModules(engineModules), mEditorCamera(editorCamera),
-      mWorkspaceManager(workspaceManager) {
+      mSceneIO(mAssetManager.getCache(), mState.scene), mRenderer(renderer),
+      mSceneRenderer(sceneRenderer), mEditorRenderer(editorRenderer),
+      mMousePickingGraph(mousePickingGraph), mEngineModules(engineModules),
+      mEditorCamera(editorCamera), mWorkspaceManager(workspaceManager) {
   mSceneIO.loadScene(scene);
 
   mSceneWriter.open(scenePath);

--- a/editor/src/quoll/editor/scene/SceneSimulatorWorkspace.cpp
+++ b/editor/src/quoll/editor/scene/SceneSimulatorWorkspace.cpp
@@ -19,10 +19,10 @@ SceneSimulatorWorkspace::SceneSimulatorWorkspace(
     : mAssetManager(assetManager), mState{project},
       mActionExecutor(mState, mAssetManager.getCache()),
       mSceneAssetHandle(scene),
-      mSceneIO(mAssetManager.getAssetRegistry(), mState.scene),
-      mRenderer(renderer), mSceneRenderer(sceneRenderer),
-      mEditorRenderer(editorRenderer), mMousePickingGraph(mousePickingGraph),
-      mEngineModules(engineModules), mEditorCamera(editorCamera) {
+      mSceneIO(mAssetManager.getCache(), mState.scene), mRenderer(renderer),
+      mSceneRenderer(sceneRenderer), mEditorRenderer(editorRenderer),
+      mMousePickingGraph(mousePickingGraph), mEngineModules(engineModules),
+      mEditorCamera(editorCamera) {
 
   sourceScene.entityDatabase.duplicate(mState.scene.entityDatabase);
   mState.scene.dummyCamera = sourceScene.dummyCamera;

--- a/editor/src/quoll/editor/scene/ui/AssetBrowser.cpp
+++ b/editor/src/quoll/editor/scene/ui/AssetBrowser.cpp
@@ -489,13 +489,13 @@ void AssetBrowser::fetchPrefab(AssetHandle<PrefabAsset> handle,
 
   for (const auto &renderer : prefab.meshRenderers) {
     for (auto material : renderer.value.materials) {
-      addMaterialEntry(material);
+      addMaterialEntry(material.handle());
     }
   }
 
   for (const auto &renderer : prefab.skinnedMeshRenderers) {
     for (auto material : renderer.value.materials) {
-      addMaterialEntry(material);
+      addMaterialEntry(material.handle());
     }
   }
 

--- a/editor/src/quoll/editor/scene/ui/EntityPanel.cpp
+++ b/editor/src/quoll/editor/scene/ui/EntityPanel.cpp
@@ -706,13 +706,12 @@ void EntityPanel::renderMeshRenderer(Scene &scene, AssetCache &assetCache,
 
     if (auto table = widgets::Table("TableMaterials", 2)) {
       for (usize i = 0; i < renderer.materials.size(); ++i) {
-        auto material = renderer.materials.at(i);
-        const auto &asset = assetRegistry.get(material);
+        const auto &material = renderer.materials.at(i);
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
         ImGui::Text("Slot %d", static_cast<u32>(i));
         ImGui::TableNextColumn();
-        widgets::Button(assetRegistry.getMeta(material).name.c_str());
+        widgets::Button(material.meta().name.c_str());
         if (ImGui::BeginDragDropTarget()) {
           if (auto *payload = ImGui::AcceptDragDropPayload(
                   getAssetTypeString(AssetType::Material).c_str())) {
@@ -779,13 +778,12 @@ void EntityPanel::renderSkinnedMeshRenderer(Scene &scene,
 
     if (auto table = widgets::Table("TableMaterials", 2)) {
       for (usize i = 0; i < renderer.materials.size(); ++i) {
-        auto material = renderer.materials.at(i);
-        const auto &asset = assetRegistry.get(material);
+        const auto &material = renderer.materials.at(i);
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
         ImGui::Text("Slot %d", static_cast<u32>(i));
         ImGui::TableNextColumn();
-        widgets::Button(assetRegistry.getMeta(material).name.c_str());
+        widgets::Button(material.meta().name.c_str());
         if (ImGui::BeginDragDropTarget()) {
           if (auto *payload = ImGui::AcceptDragDropPayload(
                   getAssetTypeString(AssetType::Material).c_str())) {

--- a/editor/tests/quoll/editor-tests/actions/EntityMeshRendererActions.test.cpp
+++ b/editor/tests/quoll/editor-tests/actions/EntityMeshRendererActions.test.cpp
@@ -37,8 +37,7 @@ TEST_F(EntitySetMeshRendererMaterialActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::MeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -61,8 +60,7 @@ TEST_F(EntitySetMeshRendererMaterialActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::MeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -91,8 +89,7 @@ TEST_F(EntitySetMeshRendererMaterialActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::MeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -107,8 +104,7 @@ TEST_F(EntitySetMeshRendererMaterialActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::MeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -123,8 +119,7 @@ TEST_F(EntitySetMeshRendererMaterialActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::MeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -142,8 +137,7 @@ TEST_F(EntityAddMeshRendererMaterialSlotActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::MeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -167,8 +161,7 @@ TEST_F(EntityAddMeshRendererMaterialSlotActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::MeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -224,8 +217,7 @@ TEST_F(EntityRemoveLastMeshRendererMaterialSlotActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::MeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -247,8 +239,7 @@ TEST_F(EntityRemoveLastMeshRendererMaterialSlotActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::MeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -288,8 +279,7 @@ TEST_F(EntityRemoveLastMeshRendererMaterialSlotActionTest,
        PredicateReturnsTrueIfMeshRendererHasMaterials) {
   auto entity = state.scene.entityDatabase.create();
 
-  std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-      mat1.handle()};
+  std::vector materials{mat1};
   quoll::MeshRenderer renderer{materials};
   state.scene.entityDatabase.set(entity, renderer);
 

--- a/editor/tests/quoll/editor-tests/actions/EntitySkinnedMeshRendererActions.test.cpp
+++ b/editor/tests/quoll/editor-tests/actions/EntitySkinnedMeshRendererActions.test.cpp
@@ -37,8 +37,7 @@ TEST_F(EntitySetSkinnedMeshRendererMaterialActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::SkinnedMeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -61,8 +60,7 @@ TEST_F(EntitySetSkinnedMeshRendererMaterialActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::SkinnedMeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -92,8 +90,7 @@ TEST_F(EntitySetSkinnedMeshRendererMaterialActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::SkinnedMeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -109,8 +106,7 @@ TEST_F(EntitySetSkinnedMeshRendererMaterialActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::SkinnedMeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -125,8 +121,7 @@ TEST_F(EntitySetSkinnedMeshRendererMaterialActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::SkinnedMeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -145,8 +140,7 @@ TEST_F(EntityAddSkinnedMeshRendererMaterialSlotActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::SkinnedMeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -170,8 +164,7 @@ TEST_F(EntityAddSkinnedMeshRendererMaterialSlotActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::SkinnedMeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -229,8 +222,7 @@ TEST_F(EntityRemoveLastSkinnedMeshRendererMaterialSlotActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::SkinnedMeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -252,8 +244,7 @@ TEST_F(EntityRemoveLastSkinnedMeshRendererMaterialSlotActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   {
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-        mat1.handle(), mat2.handle()};
+    std::vector materials{mat1, mat2};
     quoll::SkinnedMeshRenderer renderer{materials};
     state.scene.entityDatabase.set(entity, renderer);
   }
@@ -293,8 +284,7 @@ TEST_F(EntityRemoveLastSkinnedMeshRendererMaterialSlotActionTest,
        PredicateReturnsTrueIfSkinnedMeshRendererHasMaterials) {
   auto entity = state.scene.entityDatabase.create();
 
-  std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials{
-      mat1.handle()};
+  std::vector materials{mat1};
   quoll::SkinnedMeshRenderer renderer{materials};
   state.scene.entityDatabase.set(entity, renderer);
 

--- a/engine/src/quoll/asset/AssetCache.h
+++ b/engine/src/quoll/asset/AssetCache.h
@@ -189,7 +189,6 @@ public:
 
   Path getPathFromUuid(const Uuid &uuid) const;
 
-private:
   template <typename TAssetData> static constexpr AssetType getAssetType() {
     if constexpr (std::is_same_v<TAssetData, TextureAsset>) {
       return AssetType::Texture;
@@ -220,6 +219,7 @@ private:
     }
   }
 
+private:
   Result<TextureAsset> loadTexture(const Path &path);
   Result<void> createTextureFromData(const TextureAsset &data,
                                      const Path &assetPath);

--- a/engine/src/quoll/asset/AssetRegistry.cpp
+++ b/engine/src/quoll/asset/AssetRegistry.cpp
@@ -12,7 +12,9 @@ void AssetRegistry::createDefaultObjects() {
   auto mesh = default_objects::createCube();
   mDefaultObjects.cube = mMeshes.addAsset(mesh);
   mDefaultObjects.defaultMaterial =
-      mMaterials.addAsset(default_objects::createDefaultMaterial());
+      AssetRef(&mMaterials,
+               mMaterials.addAsset(default_objects::createDefaultMaterial()));
+
   mDefaultObjects.defaultFont =
       mFonts.addAsset(default_objects::createDefaultFont());
 }

--- a/engine/src/quoll/asset/AssetRegistry.h
+++ b/engine/src/quoll/asset/AssetRegistry.h
@@ -45,7 +45,7 @@ class AssetRegistry : NoCopyMove {
 
   struct DefaultObjects {
     AssetHandle<MeshAsset> cube;
-    AssetHandle<MaterialAsset> defaultMaterial;
+    AssetRef<MaterialAsset> defaultMaterial;
     AssetHandle<FontAsset> defaultFont;
   };
 

--- a/engine/src/quoll/io/EntitySerializer.cpp
+++ b/engine/src/quoll/io/EntitySerializer.cpp
@@ -66,10 +66,8 @@ YAML::Node EntitySerializer::createComponentsNode(Entity entity) {
 
   RigidBodySerializer::serialize(components, mEntityDatabase, entity);
   CollidableSerializer::serialize(components, mEntityDatabase, entity);
-  MeshRendererSerializer::serialize(components, mEntityDatabase, entity,
-                                    mAssetRegistry);
-  SkinnedMeshRendererSerializer::serialize(components, mEntityDatabase, entity,
-                                           mAssetRegistry);
+  MeshRendererSerializer::serialize(components, mEntityDatabase, entity);
+  SkinnedMeshRendererSerializer::serialize(components, mEntityDatabase, entity);
 
   AudioSerializer::serialize(components, mEntityDatabase, entity,
                              mAssetRegistry);

--- a/engine/src/quoll/io/SceneIO.cpp
+++ b/engine/src/quoll/io/SceneIO.cpp
@@ -1,6 +1,6 @@
 #include "quoll/core/Base.h"
 #include "quoll/core/Id.h"
-#include "quoll/asset/AssetRegistry.h"
+#include "quoll/asset/AssetCache.h"
 #include "quoll/scene/Camera.h"
 #include "quoll/scene/PerspectiveLens.h"
 #include "quoll/scene/Scene.h"
@@ -9,15 +9,15 @@
 
 namespace quoll {
 
-SceneIO::SceneIO(AssetRegistry &assetRegistry, Scene &scene)
-    : mScene(scene), mAssetRegistry(assetRegistry) {
+SceneIO::SceneIO(AssetCache &assetCache, Scene &scene)
+    : mScene(scene), mAssetCache(assetCache) {
   reset();
 }
 
 std::vector<Entity> SceneIO::loadScene(AssetHandle<SceneAsset> scene) {
-  detail::SceneLoader sceneLoader(mAssetRegistry, mScene.entityDatabase);
+  detail::SceneLoader sceneLoader(mAssetCache, mScene.entityDatabase);
 
-  const auto &root = mAssetRegistry.get(scene).data;
+  const auto &root = mAssetCache.getRegistry().get(scene).data;
 
   auto currentZone = root["zones"][0];
 

--- a/engine/src/quoll/io/SceneIO.h
+++ b/engine/src/quoll/io/SceneIO.h
@@ -8,12 +8,12 @@
 
 namespace quoll {
 
-class AssetRegistry;
+class AssetCache;
 struct Scene;
 
 class SceneIO {
 public:
-  SceneIO(AssetRegistry &assetRegistry, Scene &scene);
+  SceneIO(AssetCache &assetCache, Scene &scene);
 
   std::vector<Entity> loadScene(AssetHandle<SceneAsset> scene);
 
@@ -24,7 +24,7 @@ private:
 
 private:
   Scene &mScene;
-  AssetRegistry &mAssetRegistry;
+  AssetCache &mAssetCache;
 
   std::unordered_map<u64, Entity> mEntityIdCache;
 };

--- a/engine/src/quoll/io/SceneLoader.cpp
+++ b/engine/src/quoll/io/SceneLoader.cpp
@@ -26,9 +26,8 @@
 
 namespace quoll::detail {
 
-SceneLoader::SceneLoader(AssetRegistry &assetRegistry,
-                         EntityDatabase &entityDatabase)
-    : mAssetRegistry(assetRegistry), mEntityDatabase(entityDatabase) {}
+SceneLoader::SceneLoader(AssetCache &assetCache, EntityDatabase &entityDatabase)
+    : mAssetCache(assetCache), mEntityDatabase(entityDatabase) {}
 
 Result<void> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
                                          EntityIdCache &entityIdCache) {
@@ -36,33 +35,38 @@ Result<void> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
   NameSerializer::deserialize(node, mEntityDatabase, entity, entityIdCache);
   TransformSerializer::deserialize(node, mEntityDatabase, entity,
                                    entityIdCache);
-  SpriteSerializer::deserialize(node, mEntityDatabase, entity, mAssetRegistry);
-  MeshSerializer::deserialize(node, mEntityDatabase, entity, mAssetRegistry);
+  SpriteSerializer::deserialize(node, mEntityDatabase, entity,
+                                mAssetCache.getRegistry());
+  MeshSerializer::deserialize(node, mEntityDatabase, entity,
+                              mAssetCache.getRegistry());
   LightSerializer::deserialize(node, mEntityDatabase, entity);
   CameraSerializer::deserialize(node, mEntityDatabase, entity);
   SkeletonSerializer::deserialize(node, mEntityDatabase, entity,
-                                  mAssetRegistry);
+                                  mAssetCache.getRegistry());
   EnvironmentLightingSerializer::deserialize(node, mEntityDatabase, entity);
   EnvironmentSkyboxSerializer::deserialize(node, mEntityDatabase, entity,
-                                           mAssetRegistry);
+                                           mAssetCache.getRegistry());
 
   JointAttachmentSerializer::deserialize(node, mEntityDatabase, entity);
 
   AnimatorSerializer::deserialize(node, mEntityDatabase, entity,
-                                  mAssetRegistry);
+                                  mAssetCache.getRegistry());
 
   RigidBodySerializer::deserialize(node, mEntityDatabase, entity);
   CollidableSerializer::deserialize(node, mEntityDatabase, entity);
   MeshRendererSerializer::deserialize(node, mEntityDatabase, entity,
-                                      mAssetRegistry);
+                                      mAssetCache);
   SkinnedMeshRendererSerializer::deserialize(node, mEntityDatabase, entity,
-                                             mAssetRegistry);
+                                             mAssetCache);
 
-  AudioSerializer::deserialize(node, mEntityDatabase, entity, mAssetRegistry);
-  ScriptSerializer::deserialize(node, mEntityDatabase, entity, mAssetRegistry);
-  TextSerializer::deserialize(node, mEntityDatabase, entity, mAssetRegistry);
+  AudioSerializer::deserialize(node, mEntityDatabase, entity,
+                               mAssetCache.getRegistry());
+  ScriptSerializer::deserialize(node, mEntityDatabase, entity,
+                                mAssetCache.getRegistry());
+  TextSerializer::deserialize(node, mEntityDatabase, entity,
+                              mAssetCache.getRegistry());
   InputMapSerializer::deserialize(node, mEntityDatabase, entity,
-                                  mAssetRegistry);
+                                  mAssetCache.getRegistry());
   UICanvasSerializer::deserialize(node, mEntityDatabase, entity);
 
   return Ok();

--- a/engine/src/quoll/io/SceneLoader.h
+++ b/engine/src/quoll/io/SceneLoader.h
@@ -6,7 +6,7 @@
 namespace quoll {
 
 class EntityDatabase;
-class AssetRegistry;
+class AssetCache;
 
 } // namespace quoll
 
@@ -16,7 +16,7 @@ using EntityIdCache = std::unordered_map<u64, Entity>;
 
 class SceneLoader {
 public:
-  SceneLoader(AssetRegistry &assetRegistry, EntityDatabase &entityDatabase);
+  SceneLoader(AssetCache &assetCache, EntityDatabase &entityDatabase);
 
   Result<void> loadComponents(const YAML::Node &node, Entity entity,
                               EntityIdCache &entityIdCache);
@@ -28,7 +28,7 @@ public:
                                  EntityIdCache &entityIdCache);
 
 private:
-  AssetRegistry &mAssetRegistry;
+  AssetCache &mAssetCache;
   EntityDatabase &mEntityDatabase;
 };
 

--- a/engine/src/quoll/io/SerializerBase.h
+++ b/engine/src/quoll/io/SerializerBase.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "quoll/asset/AssetRegistry.h"
+#include "quoll/asset/AssetCache.h"
 #include "quoll/entity/EntityDatabase.h"
 #include "quoll/yaml/Yaml.h"
 

--- a/engine/src/quoll/renderer/MeshRenderer.h
+++ b/engine/src/quoll/renderer/MeshRenderer.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "quoll/asset/AssetHandle.h"
+#include "quoll/asset/AssetRef.h"
 #include "MaterialAsset.h"
 
 namespace quoll {
 
 struct MeshRenderer {
-  std::vector<AssetHandle<MaterialAsset>> materials;
+  std::vector<AssetRef<MaterialAsset>> materials;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/MeshRendererSerializer.cpp
+++ b/engine/src/quoll/renderer/MeshRendererSerializer.cpp
@@ -5,17 +5,15 @@ namespace quoll {
 
 void MeshRendererSerializer::serialize(YAML::Node &node,
                                        EntityDatabase &entityDatabase,
-                                       Entity entity,
-                                       AssetRegistry &assetRegistry) {
+                                       Entity entity) {
   if (entityDatabase.has<MeshRenderer>(entity)) {
     const auto &renderer = entityDatabase.get<MeshRenderer>(entity);
 
     node["meshRenderer"]["materials"] = YAML::Node(YAML::NodeType::Sequence);
 
     for (auto material : renderer.materials) {
-      if (assetRegistry.has(material)) {
-        auto uuid = assetRegistry.getMeta(material).uuid;
-        node["meshRenderer"]["materials"].push_back(uuid);
+      if (material) {
+        node["meshRenderer"]["materials"].push_back(material.meta().uuid);
       }
     }
   }
@@ -24,7 +22,7 @@ void MeshRendererSerializer::serialize(YAML::Node &node,
 void MeshRendererSerializer::deserialize(const YAML::Node &node,
                                          EntityDatabase &entityDatabase,
                                          Entity entity,
-                                         AssetRegistry &assetRegistry) {
+                                         AssetCache &assetCache) {
   if (node["meshRenderer"] && node["meshRenderer"].IsMap()) {
     MeshRenderer renderer{};
     auto materials = node["meshRenderer"]["materials"];
@@ -33,12 +31,12 @@ void MeshRendererSerializer::deserialize(const YAML::Node &node,
       for (auto material : materials) {
         auto uuid = material.as<Uuid>(Uuid{});
 
-        auto handle = assetRegistry.findHandleByUuid<MaterialAsset>(uuid);
-        if (!handle) {
+        auto asset = assetCache.request<MaterialAsset>(uuid);
+        if (!asset) {
           continue;
         }
 
-        renderer.materials.push_back(handle);
+        renderer.materials.push_back(asset);
       }
     }
 

--- a/engine/src/quoll/renderer/MeshRendererSerializer.h
+++ b/engine/src/quoll/renderer/MeshRendererSerializer.h
@@ -7,11 +7,11 @@ namespace quoll {
 class MeshRendererSerializer {
 public:
   static void serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                        Entity entity, AssetRegistry &assetRegistry);
+                        Entity entity);
 
   static void deserialize(const YAML::Node &node,
                           EntityDatabase &entityDatabase, Entity entity,
-                          AssetRegistry &assetRegistry);
+                          AssetCache &assetCache);
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/MeshSerializer.cpp
+++ b/engine/src/quoll/renderer/MeshSerializer.cpp
@@ -24,7 +24,6 @@ void MeshSerializer::deserialize(const YAML::Node &node,
     auto handle = assetRegistry.findHandleByUuid<MeshAsset>(uuid);
 
     if (handle) {
-      auto type = assetRegistry.getMeta(handle).type;
       entityDatabase.set<Mesh>(entity, {handle});
     }
   }

--- a/engine/src/quoll/renderer/SceneRenderer.cpp
+++ b/engine/src/quoll/renderer/SceneRenderer.cpp
@@ -776,8 +776,8 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
                           entityDatabase.get<PerspectiveLens>(camera));
 
   frameData.setDefaultMaterial(
-      mAssetRegistry.get(mAssetRegistry.getDefaultObjects().defaultMaterial)
-          .deviceHandle->getAddress());
+      mAssetRegistry.getDefaultObjects()
+          .defaultMaterial->deviceHandle->getAddress());
 
   for (auto [entity, sprite, world] :
        entityDatabase.view<Sprite, WorldTransform>()) {
@@ -792,8 +792,7 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
 
     std::vector<rhi::DeviceAddress> materials;
     for (auto material : renderer.materials) {
-      materials.push_back(
-          mAssetRegistry.get(material).deviceHandle->getAddress());
+      materials.push_back(material->deviceHandle->getAddress());
     }
 
     frameData.addMesh(mesh.handle, entity, world.worldTransform, materials);
@@ -807,8 +806,7 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
 
     std::vector<rhi::DeviceAddress> materials;
     for (auto material : renderer.materials) {
-      materials.push_back(
-          mAssetRegistry.get(material).deviceHandle->getAddress());
+      materials.push_back(material->deviceHandle->getAddress());
     }
 
     frameData.addSkinnedMesh(mesh.handle, entity, world.worldTransform,

--- a/engine/src/quoll/renderer/SkinnedMeshRenderer.h
+++ b/engine/src/quoll/renderer/SkinnedMeshRenderer.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "quoll/asset/AssetHandle.h"
+#include "quoll/asset/AssetRef.h"
 #include "MaterialAsset.h"
 
 namespace quoll {
 
 struct SkinnedMeshRenderer {
-  std::vector<AssetHandle<MaterialAsset>> materials;
+  std::vector<AssetRef<MaterialAsset>> materials;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/SkinnedMeshRendererSerializer.h
+++ b/engine/src/quoll/renderer/SkinnedMeshRendererSerializer.h
@@ -7,11 +7,11 @@ namespace quoll {
 class SkinnedMeshRendererSerializer {
 public:
   static void serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                        Entity entity, AssetRegistry &assetRegistry);
+                        Entity entity);
 
   static void deserialize(const YAML::Node &node,
                           EntityDatabase &entityDatabase, Entity entity,
-                          AssetRegistry &assetRegistry);
+                          AssetCache &assetCache);
 };
 
 } // namespace quoll

--- a/engine/tests/quoll-tests/asset/AssetCachePrefab.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetCachePrefab.test.cpp
@@ -68,12 +68,12 @@ public:
       asset.data.pointLights.push_back({i, light});
     }
 
-    std::vector<quoll::AssetHandle<quoll::MaterialAsset>> materials(
-        numMaterials);
+    std::vector<quoll::AssetRef<quoll::MaterialAsset>> materials(numMaterials);
     for (u32 i = 0; i < numMaterials; ++i) {
       quoll::AssetData<quoll::MaterialAsset> material;
-      material.uuid = quoll::Uuid("material-" + std::to_string(i));
-      materials.at(i) = cache.getRegistry().add(material);
+      material.uuid = quoll::Uuid::generate();
+      cache.getRegistry().add(material);
+      materials.at(i) = cache.request<quoll::MaterialAsset>(material.uuid);
     }
 
     for (u32 i = 0; i < numMeshes; ++i) {
@@ -342,10 +342,8 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
 
       for (usize mi = 0; mi < materialIndices.size(); ++mi) {
         auto materialIndex = materialIndices.at(mi);
-        auto handle = expected.materials.at(mi);
-
-        auto uuid = actualMaterials.at(materialIndex);
-        EXPECT_EQ(uuid, cache.getRegistry().getMeta(handle).uuid);
+        auto expectedMaterial = expected.materials.at(mi).meta().uuid;
+        EXPECT_EQ(expectedMaterial, actualMaterials.at(materialIndex));
       }
     }
   }
@@ -371,10 +369,8 @@ TEST_F(AssetCachePrefabTest, CreatesPrefabFile) {
 
       for (usize mi = 0; mi < materialIndices.size(); ++mi) {
         auto materialIndex = materialIndices.at(mi);
-        auto handle = expected.materials.at(mi);
-
-        auto uuid = actualMaterials.at(materialIndex);
-        EXPECT_EQ(uuid, cache.getRegistry().getMeta(handle).uuid);
+        auto expectedMaterial = expected.materials.at(mi).meta().uuid;
+        EXPECT_EQ(expectedMaterial, actualMaterials.at(materialIndex));
       }
     }
   }

--- a/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
@@ -110,16 +110,24 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
     asset.data.meshes.push_back(mesh);
   }
 
+  std::vector<quoll::AssetRef<quoll::MaterialAsset>> materials;
+  for (u32 i = 0; i < 3; ++i) {
+    quoll::AssetData<quoll::MaterialAsset> data{};
+    data.type = quoll::AssetType::Material;
+    data.uuid = quoll::Uuid::generate();
+    assetCache.getRegistry().add(data);
+
+    auto material = assetCache.request<quoll::MaterialAsset>(data.uuid).data();
+    materials.push_back(material);
+  }
+
   // Create two mesh renderers with 3 materials each
   for (u32 i = 0; i < 2; ++i) {
     quoll::PrefabComponent<quoll::MeshRenderer> renderer{};
     renderer.entity = i;
-    renderer.value.materials.push_back(
-        quoll::AssetHandle<quoll::MaterialAsset>{1});
-    renderer.value.materials.push_back(
-        quoll::AssetHandle<quoll::MaterialAsset>{2});
-    renderer.value.materials.push_back(
-        quoll::AssetHandle<quoll::MaterialAsset>{3});
+    renderer.value.materials.push_back(materials.at(0));
+    renderer.value.materials.push_back(materials.at(1));
+    renderer.value.materials.push_back(materials.at(2));
     asset.data.meshRenderers.push_back(renderer);
   }
 
@@ -127,10 +135,8 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   for (u32 i = 0; i < 3; ++i) {
     quoll::PrefabComponent<quoll::SkinnedMeshRenderer> renderer{};
     renderer.entity = i;
-    renderer.value.materials.push_back(
-        quoll::AssetHandle<quoll::MaterialAsset>{1});
-    renderer.value.materials.push_back(
-        quoll::AssetHandle<quoll::MaterialAsset>{2});
+    renderer.value.materials.push_back(materials.at(0));
+    renderer.value.materials.push_back(materials.at(1));
     asset.data.skinnedMeshRenderers.push_back(renderer);
   }
 

--- a/engine/tests/quoll-tests/io/SceneIO.test.cpp
+++ b/engine/tests/quoll-tests/io/SceneIO.test.cpp
@@ -1,6 +1,6 @@
 #include "quoll/core/Base.h"
 #include "quoll/core/Id.h"
-#include "quoll/asset/AssetRegistry.h"
+#include "quoll/asset/AssetCache.h"
 #include "quoll/entity/EntityDatabase.h"
 #include "quoll/io/EntitySerializer.h"
 #include "quoll/io/SceneIO.h"
@@ -18,7 +18,7 @@ const quoll::Path ScenePath =
 class SceneIOTest : public ::testing::Test {
 
 public:
-  SceneIOTest() : sceneIO(assetRegistry, scene) {}
+  SceneIOTest() : sceneIO(assetCache, scene), assetCache("/") {}
 
   void SetUp() override {
     TearDown();
@@ -75,15 +75,15 @@ public:
     asset.name = "Scene";
     asset.data.data = root;
 
-    return assetRegistry.add(asset);
+    return assetCache.getRegistry().add(asset);
   }
 
   YAML::Node getSceneYaml(quoll::AssetHandle<quoll::SceneAsset> handle) {
-    return assetRegistry.get(handle).data;
+    return assetCache.getRegistry().get(handle).data;
   }
 
 public:
-  quoll::AssetRegistry assetRegistry;
+  quoll::AssetCache assetCache;
   quoll::Scene scene;
   quoll::SceneIO sceneIO;
 };
@@ -207,7 +207,7 @@ TEST_F(SceneIOTest, SetsInitialCameraAsTheActiveCameraOnLoad) {
     scene.entityDatabase.set<quoll::Id>(entity, {3});
     scene.entityDatabase.set<quoll::PerspectiveLens>(entity, {});
 
-    quoll::detail::EntitySerializer serializer(assetRegistry,
+    quoll::detail::EntitySerializer serializer(assetCache.getRegistry(),
                                                scene.entityDatabase);
 
     auto entityNode = serializer.serialize(entity);

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -101,7 +101,7 @@ void Runtime::start() {
     return;
   }
 
-  SceneIO sceneIO(assetCache.getRegistry(), scene);
+  SceneIO sceneIO(assetCache, scene);
   sceneIO.loadScene(handle);
 
   auto systemView = engineModules.createSystemView(scene);


### PR DESCRIPTION
- Replace material asset handles in mesh and skinned meshr enderer to material asset refs
- Pass assetCache to scene io
- Update all scene loader and entity serializer tests to load assets to use new asset loading mechanism