### PR TITLE
Use asset refs in skeleton, input map, audio, environment, mesh, and text components

### DIFF
--- a/editor/src/quoll/editor/scene/renderer/EditorRenderer.cpp
+++ b/editor/src/quoll/editor/scene/renderer/EditorRenderer.cpp
@@ -501,29 +501,28 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
       frameData.addSpriteOutline(world.worldTransform);
     } else if (entityDatabase.has<Mesh>(state.selectedEntity) &&
                entityDatabase.has<MeshRenderer>(state.selectedEntity)) {
-      auto handle = entityDatabase.get<Mesh>(state.selectedEntity).handle;
+      const auto &asset = entityDatabase.get<Mesh>(state.selectedEntity).handle;
 
       const auto &world =
           entityDatabase.get<WorldTransform>(state.selectedEntity);
 
-      const auto &data = assetRegistry.get(handle);
-      frameData.addMeshOutline(data, world.worldTransform);
+      frameData.addMeshOutline(asset.get(), world.worldTransform);
     } else if (entityDatabase.has<Mesh>(state.selectedEntity) &&
                entityDatabase.has<SkinnedMeshRenderer>(state.selectedEntity) &&
                entityDatabase.has<Skeleton>(state.selectedEntity)) {
-      auto handle = entityDatabase.get<Mesh>(state.selectedEntity).handle;
+      const auto &asset = entityDatabase.get<Mesh>(state.selectedEntity).handle;
 
       const auto &world =
           entityDatabase.get<WorldTransform>(state.selectedEntity);
-      const auto &data = assetRegistry.get(handle);
 
       const auto &skeleton = entityDatabase.get<Skeleton>(state.selectedEntity)
                                  .jointFinalTransforms;
 
-      frameData.addSkinnedMeshOutline(data, skeleton, world.worldTransform);
+      frameData.addSkinnedMeshOutline(asset.get(), skeleton,
+                                      world.worldTransform);
     } else if (entityDatabase.has<Text>(state.selectedEntity)) {
       const auto &text = entityDatabase.get<Text>(state.selectedEntity);
-      const auto &font = assetRegistry.get(text.font);
+      const auto &font = text.font.get();
       const auto &world =
           entityDatabase.get<WorldTransform>(state.selectedEntity);
 

--- a/engine/src/quoll/animation/AnimationStateLuaTable.cpp
+++ b/engine/src/quoll/animation/AnimationStateLuaTable.cpp
@@ -4,7 +4,7 @@
 
 namespace quoll {
 
-AnimationStateLuaTable::AnimationStateLuaTable(AnimationState &state)
+AnimationStateLuaTable::AnimationStateLuaTable(const AnimationState &state)
     : mState(state) {}
 
 String AnimationStateLuaTable::getName() { return mState.name; }

--- a/engine/src/quoll/animation/AnimationStateLuaTable.h
+++ b/engine/src/quoll/animation/AnimationStateLuaTable.h
@@ -8,14 +8,14 @@ struct AnimationState;
 
 class AnimationStateLuaTable {
 public:
-  AnimationStateLuaTable(AnimationState &state);
+  AnimationStateLuaTable(const AnimationState &state);
 
   String getName();
 
   static void create(sol::state_view state);
 
 private:
-  AnimationState &mState;
+  const AnimationState &mState;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/animation/AnimationSystem.cpp
+++ b/engine/src/quoll/animation/AnimationSystem.cpp
@@ -18,10 +18,10 @@ void AnimationSystem::prepare(SystemView &view) {
 
   auto &entityDatabase = view.scene->entityDatabase;
   for (auto [entity, animator] : entityDatabase.view<Animator>()) {
-    const auto &animatorAsset = mAssetRegistry.get(animator.asset);
+    const auto &asset = animator.asset.get();
 
-    if (animator.currentState >= animatorAsset.states.size()) {
-      animator.currentState = animatorAsset.initialState;
+    if (animator.currentState >= asset.states.size()) {
+      animator.currentState = asset.initialState;
     }
   }
 }
@@ -32,8 +32,7 @@ void AnimationSystem::update(f32 dt, SystemView &view) {
   auto &entityDatabase = view.scene->entityDatabase;
   for (auto [entity, animator, animatorEvent] :
        entityDatabase.view<Animator, AnimatorEvent>()) {
-    const auto &state =
-        mAssetRegistry.get(animator.asset).states.at(animator.currentState);
+    const auto &state = animator.asset->states.at(animator.currentState);
 
     for (auto &transition : state.transitions) {
       if (transition.eventName == animatorEvent.eventName) {
@@ -49,9 +48,7 @@ void AnimationSystem::update(f32 dt, SystemView &view) {
   for (auto [entity, transform, animator] :
        entityDatabase.view<LocalTransform, Animator>()) {
 
-    const auto &animatorAsset = mAssetRegistry.get(animator.asset);
-
-    const auto &state = animatorAsset.states.at(animator.currentState);
+    const auto &state = animator.asset->states.at(animator.currentState);
 
     const auto &animation = state.animation;
 

--- a/engine/src/quoll/animation/Animator.h
+++ b/engine/src/quoll/animation/Animator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "quoll/asset/AssetHandle.h"
+#include "quoll/asset/AssetRef.h"
 #include "AnimatorAsset.h"
 
 namespace quoll {
@@ -14,7 +14,7 @@ namespace quoll {
  * in range of [0.0, 1.0].
  */
 struct Animator {
-  AssetHandle<AnimatorAsset> asset;
+  AssetRef<AnimatorAsset> asset;
 
   usize currentState = std::numeric_limits<usize>::max();
 

--- a/engine/src/quoll/animation/AnimatorLuaTable.cpp
+++ b/engine/src/quoll/animation/AnimatorLuaTable.cpp
@@ -30,8 +30,7 @@ sol_maybe<AnimationStateLuaTable> AnimatorLuaTable::getCurrentState() {
   }
 
   const auto &animator = mScriptGlobals.entityDatabase.get<Animator>(mEntity);
-  auto &state = mScriptGlobals.assetRegistry.get(animator.asset)
-                    .states.at(animator.currentState);
+  auto &state = animator.asset->states.at(animator.currentState);
 
   return AnimationStateLuaTable(state);
 }

--- a/engine/src/quoll/animation/AnimatorSerializer.cpp
+++ b/engine/src/quoll/animation/AnimatorSerializer.cpp
@@ -5,32 +5,27 @@ namespace quoll {
 
 void AnimatorSerializer::serialize(YAML::Node &node,
                                    EntityDatabase &entityDatabase,
-                                   Entity entity,
-                                   AssetRegistry &assetRegistry) {
+                                   Entity entity) {
   if (entityDatabase.has<Animator>(entity)) {
-    auto handle = entityDatabase.get<Animator>(entity).asset;
+    const auto &asset = entityDatabase.get<Animator>(entity).asset;
 
-    if (assetRegistry.has(handle)) {
-      auto uuid = assetRegistry.getMeta(handle).uuid;
-
-      node["animator"]["asset"] = uuid;
+    if (asset) {
+      node["animator"]["asset"] = asset.meta().uuid;
     }
   }
 }
 
 void AnimatorSerializer::deserialize(const YAML::Node &node,
                                      EntityDatabase &entityDatabase,
-                                     Entity entity,
-                                     AssetRegistry &assetRegistry) {
+                                     Entity entity, AssetCache &assetCache) {
   if (node["animator"] && node["animator"].IsMap() &&
       node["animator"]["asset"]) {
-    auto assetUuid = node["animator"]["asset"].as<Uuid>(Uuid{});
-    auto handle = assetRegistry.findHandleByUuid<AnimatorAsset>(assetUuid);
+    auto uuid = node["animator"]["asset"].as<Uuid>(Uuid{});
+    auto asset = assetCache.request<AnimatorAsset>(uuid);
 
-    if (handle) {
-      const auto &asset = assetRegistry.get(handle);
+    if (asset) {
       Animator animator;
-      animator.asset = handle;
+      animator.asset = asset;
       entityDatabase.set(entity, animator);
     }
   }

--- a/engine/src/quoll/animation/AnimatorSerializer.h
+++ b/engine/src/quoll/animation/AnimatorSerializer.h
@@ -7,11 +7,11 @@ namespace quoll {
 class AnimatorSerializer {
 public:
   static void serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                        Entity entity, AssetRegistry &assetRegistry);
+                        Entity entity);
 
   static void deserialize(const YAML::Node &node,
                           EntityDatabase &entityDatabase, Entity entity,
-                          AssetRegistry &assetRegistry);
+                          AssetCache &assetCache);
 };
 
 } // namespace quoll

--- a/engine/src/quoll/asset/AssetRegistry.cpp
+++ b/engine/src/quoll/asset/AssetRegistry.cpp
@@ -16,7 +16,7 @@ void AssetRegistry::createDefaultObjects() {
                mMaterials.addAsset(default_objects::createDefaultMaterial()));
 
   mDefaultObjects.defaultFont =
-      mFonts.addAsset(default_objects::createDefaultFont());
+      AssetRef(&mFonts, mFonts.addAsset(default_objects::createDefaultFont()));
 }
 
 void AssetRegistry::syncWithDevice(RenderStorage &renderStorage) {

--- a/engine/src/quoll/asset/AssetRegistry.h
+++ b/engine/src/quoll/asset/AssetRegistry.h
@@ -46,7 +46,7 @@ class AssetRegistry : NoCopyMove {
   struct DefaultObjects {
     AssetHandle<MeshAsset> cube;
     AssetRef<MaterialAsset> defaultMaterial;
-    AssetHandle<FontAsset> defaultFont;
+    AssetRef<FontAsset> defaultFont;
   };
 
 public:

--- a/engine/src/quoll/audio/AudioSerializer.cpp
+++ b/engine/src/quoll/audio/AudioSerializer.cpp
@@ -5,28 +5,24 @@
 namespace quoll {
 
 void AudioSerializer::serialize(YAML::Node &node,
-                                EntityDatabase &entityDatabase, Entity entity,
-                                AssetRegistry &assetRegistry) {
+                                EntityDatabase &entityDatabase, Entity entity) {
   if (entityDatabase.has<AudioSource>(entity)) {
-    auto handle = entityDatabase.get<AudioSource>(entity).source;
-    if (assetRegistry.has(handle)) {
-      auto uuid = assetRegistry.getMeta(handle).uuid;
-
-      node["audio"]["source"] = uuid;
+    const auto &asset = entityDatabase.get<AudioSource>(entity).source;
+    if (asset) {
+      node["audio"]["source"] = asset.meta().uuid;
     }
   }
 }
 
 void AudioSerializer::deserialize(const YAML::Node &node,
                                   EntityDatabase &entityDatabase, Entity entity,
-                                  AssetRegistry &assetRegistry) {
+                                  AssetCache &assetCache) {
   if (node["audio"] && node["audio"].IsMap()) {
     auto uuid = node["audio"]["source"].as<Uuid>(Uuid{});
+    auto asset = assetCache.request<AudioAsset>(uuid);
 
-    auto handle = assetRegistry.findHandleByUuid<AudioAsset>(uuid);
-
-    if (handle) {
-      entityDatabase.set<AudioSource>(entity, {handle});
+    if (asset) {
+      entityDatabase.set<AudioSource>(entity, {asset});
     }
   }
 }

--- a/engine/src/quoll/audio/AudioSerializer.h
+++ b/engine/src/quoll/audio/AudioSerializer.h
@@ -7,11 +7,11 @@ namespace quoll {
 class AudioSerializer {
 public:
   static void serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                        Entity entity, AssetRegistry &assetRegistry);
+                        Entity entity);
 
   static void deserialize(const YAML::Node &node,
                           EntityDatabase &entityDatabase, Entity entity,
-                          AssetRegistry &assetRegistry);
+                          AssetCache &assetCache);
 };
 
 } // namespace quoll

--- a/engine/src/quoll/audio/AudioSource.h
+++ b/engine/src/quoll/audio/AudioSource.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "quoll/asset/AssetHandle.h"
+#include "quoll/asset/AssetRef.h"
 #include "AudioAsset.h"
 
 namespace quoll {
 
 struct AudioSource {
-  AssetHandle<AudioAsset> source;
+  AssetRef<AudioAsset> source;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/audio/AudioSystem.h
+++ b/engine/src/quoll/audio/AudioSystem.h
@@ -54,8 +54,8 @@ public:
         if (entityDatabase.has<AudioStatus>(entity)) {
           continue;
         }
-        const auto &asset = mAssetRegistry.get(source.source);
-        void *sound = mBackend.playSound(asset);
+
+        void *sound = mBackend.playSound(source.source.get());
 
         entityDatabase.set<AudioStatus>(entity, {sound});
       }

--- a/engine/src/quoll/entity/EntitySpawner.cpp
+++ b/engine/src/quoll/entity/EntitySpawner.cpp
@@ -112,7 +112,7 @@ std::vector<Entity> EntitySpawner::spawnPrefab(AssetHandle<PrefabAsset> handle,
 
   for (const auto &pMesh : asset.meshes) {
     auto entity = getOrCreateEntity(pMesh.entity);
-    mEntityDatabase.set<Mesh>(entity, {pMesh.value.handle()});
+    mEntityDatabase.set<Mesh>(entity, {pMesh.value});
   }
 
   for (const auto &pRenderer : asset.meshRenderers) {
@@ -132,7 +132,7 @@ std::vector<Entity> EntitySpawner::spawnPrefab(AssetHandle<PrefabAsset> handle,
     usize numJoints = asset.jointLocalPositions.size();
 
     Skeleton skeleton{};
-    skeleton.assetHandle = pSkeleton.value.handle();
+    skeleton.assetHandle = pSkeleton.value;
     skeleton.numJoints = static_cast<u32>(numJoints);
     skeleton.jointNames.resize(numJoints);
     skeleton.jointParents.resize(numJoints);
@@ -160,7 +160,7 @@ std::vector<Entity> EntitySpawner::spawnPrefab(AssetHandle<PrefabAsset> handle,
     auto entity = getOrCreateEntity(item.entity);
 
     Animator animator{};
-    animator.asset = item.value.handle();
+    animator.asset = item.value;
     animator.currentState = item.value->initialState;
     mEntityDatabase.set(entity, animator);
   }

--- a/engine/src/quoll/input/InputMap.h
+++ b/engine/src/quoll/input/InputMap.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "quoll/asset/AssetHandle.h"
+#include "quoll/asset/AssetRef.h"
 #include "InputDataType.h"
 #include "InputMapAsset.h"
 
 namespace quoll {
 
 struct InputMapAssetRef {
-  AssetHandle<InputMapAsset> handle;
+  AssetRef<InputMapAsset> handle;
 
   usize defaultScheme = 0;
 };

--- a/engine/src/quoll/input/InputMapSerializer.h
+++ b/engine/src/quoll/input/InputMapSerializer.h
@@ -7,11 +7,11 @@ namespace quoll {
 class InputMapSerializer {
 public:
   static void serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                        Entity entity, AssetRegistry &assetRegistry);
+                        Entity entity);
 
   static void deserialize(const YAML::Node &node,
                           EntityDatabase &entityDatabase, Entity entity,
-                          AssetRegistry &assetRegistry);
+                          AssetCache &assetCache);
 };
 
 } // namespace quoll

--- a/engine/src/quoll/input/InputMapSystem.cpp
+++ b/engine/src/quoll/input/InputMapSystem.cpp
@@ -14,10 +14,9 @@ InputMapSystem::InputMapSystem(InputDeviceManager &deviceManager,
 void InputMapSystem::update(SystemView &view) {
   auto &entityDatabase = view.scene->entityDatabase;
   for (auto [entity, ref] : entityDatabase.view<InputMapAssetRef>()) {
-    if (mAssetRegistry.has(ref.handle) &&
-        !entityDatabase.has<InputMap>(entity)) {
-      entityDatabase.set(entity, createInputMap(mAssetRegistry.get(ref.handle),
-                                                ref.defaultScheme));
+    if (ref.handle && !entityDatabase.has<InputMap>(entity)) {
+      entityDatabase.set(entity,
+                         createInputMap(ref.handle.get(), ref.defaultScheme));
     }
   }
 

--- a/engine/src/quoll/io/EntitySerializer.cpp
+++ b/engine/src/quoll/io/EntitySerializer.cpp
@@ -49,34 +49,27 @@ YAML::Node EntitySerializer::createComponentsNode(Entity entity) {
   TransformSerializer::serialize(components, mEntityDatabase, entity);
   SpriteSerializer::serialize(components, mEntityDatabase, entity,
                               mAssetRegistry);
-  MeshSerializer::serialize(components, mEntityDatabase, entity,
-                            mAssetRegistry);
+  MeshSerializer::serialize(components, mEntityDatabase, entity);
   LightSerializer::serialize(components, mEntityDatabase, entity);
   CameraSerializer::serialize(components, mEntityDatabase, entity);
-  SkeletonSerializer::serialize(components, mEntityDatabase, entity,
-                                mAssetRegistry);
+  SkeletonSerializer::serialize(components, mEntityDatabase, entity);
   EnvironmentLightingSerializer::serialize(components, mEntityDatabase, entity);
-  EnvironmentSkyboxSerializer::serialize(components, mEntityDatabase, entity,
-                                         mAssetRegistry);
+  EnvironmentSkyboxSerializer::serialize(components, mEntityDatabase, entity);
 
   JointAttachmentSerializer::serialize(components, mEntityDatabase, entity);
 
-  AnimatorSerializer::serialize(components, mEntityDatabase, entity,
-                                mAssetRegistry);
+  AnimatorSerializer::serialize(components, mEntityDatabase, entity);
 
   RigidBodySerializer::serialize(components, mEntityDatabase, entity);
   CollidableSerializer::serialize(components, mEntityDatabase, entity);
   MeshRendererSerializer::serialize(components, mEntityDatabase, entity);
   SkinnedMeshRendererSerializer::serialize(components, mEntityDatabase, entity);
 
-  AudioSerializer::serialize(components, mEntityDatabase, entity,
-                             mAssetRegistry);
+  AudioSerializer::serialize(components, mEntityDatabase, entity);
   ScriptSerializer::serialize(components, mEntityDatabase, entity,
                               mAssetRegistry);
-  TextSerializer::serialize(components, mEntityDatabase, entity,
-                            mAssetRegistry);
-  InputMapSerializer::serialize(components, mEntityDatabase, entity,
-                                mAssetRegistry);
+  TextSerializer::serialize(components, mEntityDatabase, entity);
+  InputMapSerializer::serialize(components, mEntityDatabase, entity);
   UICanvasSerializer::serialize(components, mEntityDatabase, entity);
 
   return components;

--- a/engine/src/quoll/io/SceneLoader.cpp
+++ b/engine/src/quoll/io/SceneLoader.cpp
@@ -37,20 +37,17 @@ Result<void> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
                                    entityIdCache);
   SpriteSerializer::deserialize(node, mEntityDatabase, entity,
                                 mAssetCache.getRegistry());
-  MeshSerializer::deserialize(node, mEntityDatabase, entity,
-                              mAssetCache.getRegistry());
+  MeshSerializer::deserialize(node, mEntityDatabase, entity, mAssetCache);
   LightSerializer::deserialize(node, mEntityDatabase, entity);
   CameraSerializer::deserialize(node, mEntityDatabase, entity);
-  SkeletonSerializer::deserialize(node, mEntityDatabase, entity,
-                                  mAssetCache.getRegistry());
+  SkeletonSerializer::deserialize(node, mEntityDatabase, entity, mAssetCache);
   EnvironmentLightingSerializer::deserialize(node, mEntityDatabase, entity);
   EnvironmentSkyboxSerializer::deserialize(node, mEntityDatabase, entity,
-                                           mAssetCache.getRegistry());
+                                           mAssetCache);
 
   JointAttachmentSerializer::deserialize(node, mEntityDatabase, entity);
 
-  AnimatorSerializer::deserialize(node, mEntityDatabase, entity,
-                                  mAssetCache.getRegistry());
+  AnimatorSerializer::deserialize(node, mEntityDatabase, entity, mAssetCache);
 
   RigidBodySerializer::deserialize(node, mEntityDatabase, entity);
   CollidableSerializer::deserialize(node, mEntityDatabase, entity);
@@ -59,14 +56,11 @@ Result<void> SceneLoader::loadComponents(const YAML::Node &node, Entity entity,
   SkinnedMeshRendererSerializer::deserialize(node, mEntityDatabase, entity,
                                              mAssetCache);
 
-  AudioSerializer::deserialize(node, mEntityDatabase, entity,
-                               mAssetCache.getRegistry());
+  AudioSerializer::deserialize(node, mEntityDatabase, entity, mAssetCache);
   ScriptSerializer::deserialize(node, mEntityDatabase, entity,
                                 mAssetCache.getRegistry());
-  TextSerializer::deserialize(node, mEntityDatabase, entity,
-                              mAssetCache.getRegistry());
-  InputMapSerializer::deserialize(node, mEntityDatabase, entity,
-                                  mAssetCache.getRegistry());
+  TextSerializer::deserialize(node, mEntityDatabase, entity, mAssetCache);
+  InputMapSerializer::deserialize(node, mEntityDatabase, entity, mAssetCache);
   UICanvasSerializer::deserialize(node, mEntityDatabase, entity);
 
   return Ok();

--- a/engine/src/quoll/renderer/Mesh.h
+++ b/engine/src/quoll/renderer/Mesh.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "quoll/asset/AssetHandle.h"
+#include "quoll/asset/AssetRef.h"
 #include "MeshAsset.h"
 
 namespace quoll {
 
 struct Mesh {
-  AssetHandle<MeshAsset> handle;
+  AssetRef<MeshAsset> handle;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/MeshSerializer.cpp
+++ b/engine/src/quoll/renderer/MeshSerializer.cpp
@@ -5,26 +5,24 @@
 namespace quoll {
 
 void MeshSerializer::serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                               Entity entity, AssetRegistry &assetRegistry) {
+                               Entity entity) {
   if (entityDatabase.has<Mesh>(entity)) {
-    auto handle = entityDatabase.get<Mesh>(entity).handle;
-    if (assetRegistry.has(handle)) {
-      auto uuid = assetRegistry.getMeta(handle).uuid;
-
-      node["mesh"] = uuid;
+    const auto &mesh = entityDatabase.get<Mesh>(entity);
+    if (mesh.handle) {
+      node["mesh"] = mesh.handle.meta().uuid;
     }
   }
 }
 
 void MeshSerializer::deserialize(const YAML::Node &node,
                                  EntityDatabase &entityDatabase, Entity entity,
-                                 AssetRegistry &assetRegistry) {
+                                 AssetCache &assetCache) {
   if (node["mesh"]) {
     auto uuid = node["mesh"].as<Uuid>(Uuid{});
-    auto handle = assetRegistry.findHandleByUuid<MeshAsset>(uuid);
+    auto asset = assetCache.request<MeshAsset>(uuid);
 
-    if (handle) {
-      entityDatabase.set<Mesh>(entity, {handle});
+    if (asset) {
+      entityDatabase.set<Mesh>(entity, {asset});
     }
   }
 }

--- a/engine/src/quoll/renderer/MeshSerializer.h
+++ b/engine/src/quoll/renderer/MeshSerializer.h
@@ -7,11 +7,11 @@ namespace quoll {
 class MeshSerializer {
 public:
   static void serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                        Entity entity, AssetRegistry &assetRegistry);
+                        Entity entity);
 
   static void deserialize(const YAML::Node &node,
                           EntityDatabase &entityDatabase, Entity entity,
-                          AssetRegistry &assetRegistry);
+                          AssetCache &assetCache);
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/SceneRenderer.cpp
+++ b/engine/src/quoll/renderer/SceneRenderer.cpp
@@ -788,35 +788,32 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
   // Meshes
   for (auto [entity, world, mesh, renderer] :
        entityDatabase.view<WorldTransform, Mesh, MeshRenderer>()) {
-    const auto &asset = mAssetRegistry.get(mesh.handle);
-
     std::vector<rhi::DeviceAddress> materials;
     for (auto material : renderer.materials) {
       materials.push_back(material->deviceHandle->getAddress());
     }
 
-    frameData.addMesh(mesh.handle, entity, world.worldTransform, materials);
+    frameData.addMesh(mesh.handle.handle(), entity, world.worldTransform,
+                      materials);
   }
 
   // Skinned Meshes
   for (auto [entity, skeleton, world, mesh, renderer] :
        entityDatabase
            .view<Skeleton, WorldTransform, Mesh, SkinnedMeshRenderer>()) {
-    const auto &asset = mAssetRegistry.get(mesh.handle);
-
     std::vector<rhi::DeviceAddress> materials;
     for (auto material : renderer.materials) {
       materials.push_back(material->deviceHandle->getAddress());
     }
 
-    frameData.addSkinnedMesh(mesh.handle, entity, world.worldTransform,
+    frameData.addSkinnedMesh(mesh.handle.handle(), entity, world.worldTransform,
                              skeleton.jointFinalTransforms, materials);
   }
 
   // Texts
   for (auto [entity, text, world] :
        entityDatabase.view<Text, WorldTransform>()) {
-    const auto &font = mAssetRegistry.get(text.font);
+    const auto &font = text.font.get();
 
     std::vector<SceneRendererFrameData::GlyphData> glyphs(
         text.content.length());
@@ -870,7 +867,7 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
       frameData.setSkyboxColor(environment.color);
     } else if (environment.type == EnvironmentSkyboxType::Texture &&
                environment.texture) {
-      const auto &asset = mAssetRegistry.get(environment.texture);
+      const auto &asset = environment.texture.get();
 
       specularMap = asset.specularMap->deviceHandle;
       irradianceMap = asset.irradianceMap->deviceHandle;

--- a/engine/src/quoll/scene/EnvironmentSkybox.h
+++ b/engine/src/quoll/scene/EnvironmentSkybox.h
@@ -11,7 +11,7 @@ enum class EnvironmentSkyboxType { Color, Texture };
 struct EnvironmentSkybox {
   EnvironmentSkyboxType type = EnvironmentSkyboxType::Color;
 
-  AssetHandle<EnvironmentAsset> texture;
+  AssetRef<EnvironmentAsset> texture;
 
   glm::vec4 color{0.0f, 0.0f, 0.0f, 1.0f};
 };

--- a/engine/src/quoll/scene/EnvironmentSkyboxSerializer.h
+++ b/engine/src/quoll/scene/EnvironmentSkyboxSerializer.h
@@ -7,11 +7,11 @@ namespace quoll {
 class EnvironmentSkyboxSerializer {
 public:
   static void serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                        Entity entity, AssetRegistry &assetRegistry);
+                        Entity entity);
 
   static void deserialize(const YAML::Node &node,
                           EntityDatabase &entityDatabase, Entity entity,
-                          AssetRegistry &assetRegistry);
+                          AssetCache &assetCache);
 };
 
 } // namespace quoll

--- a/engine/src/quoll/skeleton/Skeleton.h
+++ b/engine/src/quoll/skeleton/Skeleton.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "quoll/asset/AssetHandle.h"
+#include "quoll/asset/AssetRef.h"
 #include "Joint.h"
 #include "SkeletonAsset.h"
 
@@ -25,7 +25,7 @@ struct Skeleton {
 
   std::vector<String> jointNames;
 
-  AssetHandle<SkeletonAsset> assetHandle;
+  AssetRef<SkeletonAsset> assetHandle;
 };
 
 struct SkeletonDebug {

--- a/engine/src/quoll/skeleton/SkeletonSerializer.h
+++ b/engine/src/quoll/skeleton/SkeletonSerializer.h
@@ -7,11 +7,11 @@ namespace quoll {
 class SkeletonSerializer {
 public:
   static void serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                        Entity entity, AssetRegistry &assetRegistry);
+                        Entity entity);
 
   static void deserialize(const YAML::Node &node,
                           EntityDatabase &entityDatabase, Entity entity,
-                          AssetRegistry &assetRegistry);
+                          AssetCache &assetCache);
 };
 
 } // namespace quoll

--- a/engine/src/quoll/text/Text.h
+++ b/engine/src/quoll/text/Text.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "quoll/asset/AssetHandle.h"
+#include "quoll/asset/AssetRef.h"
 #include "FontAsset.h"
 
 namespace quoll {
@@ -10,7 +10,7 @@ struct Text {
 
   f32 lineHeight = 1.0f;
 
-  AssetHandle<FontAsset> font;
+  AssetRef<FontAsset> font;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/text/TextSerializer.cpp
+++ b/engine/src/quoll/text/TextSerializer.cpp
@@ -5,34 +5,34 @@
 namespace quoll {
 
 void TextSerializer::serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                               Entity entity, AssetRegistry &assetRegistry) {
+                               Entity entity) {
   if (entityDatabase.has<Text>(entity)) {
     const auto &text = entityDatabase.get<Text>(entity);
 
-    if (!text.content.empty() && assetRegistry.has(text.font)) {
+    if (!text.content.empty() && text.font) {
       node["text"]["content"] = text.content;
       node["text"]["lineHeight"] = text.lineHeight;
-      node["text"]["font"] = assetRegistry.getMeta(text.font).uuid;
+      node["text"]["font"] = text.font.meta().uuid;
     }
   }
 }
 
 void TextSerializer::deserialize(const YAML::Node &node,
                                  EntityDatabase &entityDatabase, Entity entity,
-                                 AssetRegistry &assetRegistry) {
+                                 AssetCache &assetCache) {
   if (node["text"] && node["text"].IsMap()) {
     auto uuid = node["text"]["font"].as<Uuid>(Uuid{});
-    auto handle = assetRegistry.findHandleByUuid<FontAsset>(uuid);
 
-    Text textComponent{};
-    textComponent.font = handle;
+    auto font = assetCache.request<FontAsset>(uuid);
 
-    if (handle) {
+    if (font) {
+      Text textComponent{};
+      textComponent.font = font;
+
       if (node["text"]["content"] && node["text"]["content"].IsScalar()) {
         textComponent.content =
             node["text"]["content"].as<String>(textComponent.content);
       }
-
       textComponent.lineHeight =
           node["text"]["lineHeight"].as<f32>(textComponent.lineHeight);
 

--- a/engine/src/quoll/text/TextSerializer.h
+++ b/engine/src/quoll/text/TextSerializer.h
@@ -7,11 +7,11 @@ namespace quoll {
 class TextSerializer {
 public:
   static void serialize(YAML::Node &node, EntityDatabase &entityDatabase,
-                        Entity entity, AssetRegistry &assetRegistry);
+                        Entity entity);
 
   static void deserialize(const YAML::Node &node,
                           EntityDatabase &entityDatabase, Entity entity,
-                          AssetRegistry &assetRegistry);
+                          AssetCache &assetCache);
 };
 
 } // namespace quoll

--- a/engine/tests/quoll-tests/animation/AnimatorLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/animation/AnimatorLuaTable.test.cpp
@@ -6,6 +6,17 @@
 
 class AnimatorLuaTableTest : public LuaScriptingInterfaceTestBase {
 public:
+  template <typename TAssetData>
+  quoll::AssetRef<TAssetData> createAsset(TAssetData data = {}) {
+    quoll::AssetData<TAssetData> info{};
+    info.type = quoll::AssetCache::getAssetType<TAssetData>();
+    info.uuid = quoll::Uuid::generate();
+    info.data = data;
+
+    assetCache.getRegistry().add(info);
+
+    return assetCache.request<TAssetData>(info.uuid).data();
+  }
 };
 
 TEST_F(AnimatorLuaTableTest, TriggerAddsAnimatorEventComponent) {
@@ -21,12 +32,12 @@ TEST_F(AnimatorLuaTableTest, PropertiesReturnAnimatorDataIfAnimatorExists) {
   animatorAsset.states.push_back({.name = "StateA"});
   animatorAsset.states.push_back({.name = "StateB"});
 
-  auto handle = assetCache.getRegistry().add<quoll::AnimatorAsset>(
-      {.data = animatorAsset});
+  auto asset = createAsset<quoll::AnimatorAsset>(
+      {.states = {{.name = "StateA"}, {.name = "StateB"}}});
 
   auto entity = entityDatabase.create();
   quoll::Animator animator{};
-  animator.asset = handle;
+  animator.asset = asset;
   animator.normalizedTime = 0.4f;
   animator.currentState = 1;
   entityDatabase.set(entity, animator);

--- a/engine/tests/quoll-tests/audio/AudioSystem.test.cpp
+++ b/engine/tests/quoll-tests/audio/AudioSystem.test.cpp
@@ -1,4 +1,5 @@
 #include "quoll/core/Base.h"
+#include "quoll/asset/AssetCache.h"
 #include "quoll/audio/AudioAsset.h"
 #include "quoll/audio/AudioSystem.h"
 #include "quoll/system/SystemView.h"
@@ -49,19 +50,22 @@ private:
 
 class AudioSystemTest : public ::testing::Test {
 public:
-  AudioSystemTest() : audioSystem(assetRegistry) {
+  AudioSystemTest() : audioSystem(assetCache.getRegistry()), assetCache("/") {
     audioSystem.createSystemViewData(view);
   }
 
-  quoll::AssetHandle<quoll::AudioAsset> createFakeAudio() {
-    std::vector<char> bytes;
+  quoll::AssetRef<quoll::AudioAsset> createFakeAudio() {
     quoll::AssetData<quoll::AudioAsset> asset{};
-    asset.data.bytes = bytes;
+    asset.uuid = quoll::Uuid::generate();
+    asset.data.bytes = {};
     asset.data.format = quoll::AudioAssetFormat::Wav;
-    return assetRegistry.add(asset);
+
+    assetCache.getRegistry().add(asset);
+
+    return assetCache.request<quoll::AudioAsset>(asset.uuid).data();
   }
 
-  quoll::AssetRegistry assetRegistry;
+  quoll::AssetCache assetCache;
   quoll::AudioSystem<TestAudioBackend> audioSystem;
   quoll::Scene scene;
   quoll::SystemView view{&scene};

--- a/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
@@ -342,8 +342,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
     const auto &animator = db.get<quoll::Animator>(entity);
     EXPECT_NE(animator.asset, quoll::AssetHandle<quoll::AnimatorAsset>());
     EXPECT_EQ(animator.currentState, i);
-    EXPECT_EQ(assetRegistry.get(animator.asset).initialState,
-              animator.currentState);
+    EXPECT_EQ(animator.asset->initialState, animator.currentState);
     EXPECT_EQ(animator.normalizedTime, 0.0f);
   }
 

--- a/engine/tests/quoll-tests/io/EntitySerializer.test.cpp
+++ b/engine/tests/quoll-tests/io/EntitySerializer.test.cpp
@@ -207,11 +207,9 @@ TEST_F(EntitySerializerTest,
 }
 
 TEST_F(EntitySerializerTest, DoesNotCreateMeshFieldIfMeshAssetIsNotInRegistry) {
-  static constexpr quoll::AssetHandle<quoll::MeshAsset> NonExistentMeshHandle{
-      45};
-
   auto entity = entityDatabase.create();
-  entityDatabase.set<quoll::Mesh>(entity, {NonExistentMeshHandle});
+  entityDatabase.set<quoll::Mesh>(entity,
+                                  {quoll::AssetRef<quoll::MeshAsset>()});
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_FALSE(node["mesh"]);
@@ -221,7 +219,7 @@ TEST_F(EntitySerializerTest, CreatesMeshFieldIfMeshAssetIsInRegistry) {
   auto mesh = createAsset<quoll::MeshAsset>();
 
   auto entity = entityDatabase.create();
-  entityDatabase.set<quoll::Mesh>(entity, {mesh.handle()});
+  entityDatabase.set<quoll::Mesh>(entity, {mesh});
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_TRUE(node["mesh"]);
@@ -351,7 +349,6 @@ TEST_F(EntitySerializerTest,
 
   auto entity = entityDatabase.create();
   quoll::Skeleton component{};
-  component.assetHandle = NonExistentSkeletonHandle;
   entityDatabase.set(entity, component);
 
   auto node = entitySerializer.createComponentsNode(entity);
@@ -363,7 +360,7 @@ TEST_F(EntitySerializerTest, CreatesSkeletonFieldIfSkeletonAssetIsInRegistry) {
 
   auto entity = entityDatabase.create();
   quoll::Skeleton component{};
-  component.assetHandle = skeleton.handle();
+  component.assetHandle = skeleton;
 
   entityDatabase.set(entity, component);
 
@@ -408,7 +405,6 @@ TEST_F(EntitySerializerTest,
 
   auto entity = entityDatabase.create();
   quoll::Animator component{};
-  component.asset = NonExistentAnimatorHandle;
   entityDatabase.set(entity, component);
 
   auto node = entitySerializer.createComponentsNode(entity);
@@ -419,7 +415,7 @@ TEST_F(EntitySerializerTest, CreatesAnimatorWithValidAnimations) {
   auto animator = createAsset<quoll::AnimatorAsset>();
 
   quoll::Animator component{};
-  component.asset = animator.handle();
+  component.asset = animator;
   component.currentState = 0;
 
   auto entity = entityDatabase.create();
@@ -592,10 +588,8 @@ TEST_F(EntitySerializerTest,
 
 TEST_F(EntitySerializerTest,
        DoesNotCreateAudioFieldIfAudioAssetIsNotInRegistry) {
-  static constexpr quoll::AssetHandle<quoll::AudioAsset> NonExistentHandle{45};
-
   auto entity = entityDatabase.create();
-  entityDatabase.set<quoll::AudioSource>(entity, {NonExistentHandle});
+  entityDatabase.set<quoll::AudioSource>(entity, {});
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_FALSE(node["audio"]);
@@ -605,7 +599,7 @@ TEST_F(EntitySerializerTest, CreatesAudioFieldIfAudioAssetIsInRegistry) {
   auto audio = createAsset<quoll::AudioAsset>();
 
   auto entity = entityDatabase.create();
-  entityDatabase.set<quoll::AudioSource>(entity, {audio.handle()});
+  entityDatabase.set<quoll::AudioSource>(entity, {audio});
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_TRUE(node["audio"]);
@@ -702,7 +696,7 @@ TEST_F(EntitySerializerTest, DoesNotCreateTextFieldIfTextContentsAreEmpty) {
   auto entity = entityDatabase.create();
   quoll::Text component{};
   component.content = "";
-  component.font = font.handle();
+  component.font = font;
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_FALSE(node["text"]);
@@ -715,7 +709,6 @@ TEST_F(EntitySerializerTest, DoesNotCreateTextFieldIfFontAssetIsNotInRegistry) {
 
   quoll::Text component{};
   component.content = "Hello world";
-  component.font = NonExistentHandle;
   entityDatabase.set(entity, component);
 
   auto node = entitySerializer.createComponentsNode(entity);
@@ -730,7 +723,7 @@ TEST_F(EntitySerializerTest,
   quoll::Text component{};
   component.content = "Hello world";
   component.lineHeight = 2.0f;
-  component.font = font.handle();
+  component.font = font;
 
   entityDatabase.set(entity, component);
 
@@ -995,13 +988,9 @@ TEST_F(EntitySerializerTest,
 
 TEST_F(EntitySerializerTest,
        DoesNotCreateEnvironmentIfSkyboxIsTextureButAssetDoesNotExist) {
-  static constexpr quoll::AssetHandle<quoll::EnvironmentAsset>
-      NonExistentHandle{45};
-
   auto entity = entityDatabase.create();
 
-  quoll::EnvironmentSkybox component{quoll::EnvironmentSkyboxType::Texture,
-                                     NonExistentHandle};
+  quoll::EnvironmentSkybox component{quoll::EnvironmentSkyboxType::Texture};
   entityDatabase.set(entity, component);
 
   auto node = entitySerializer.createComponentsNode(entity);
@@ -1015,7 +1004,7 @@ TEST_F(EntitySerializerTest,
   auto entity = entityDatabase.create();
 
   quoll::EnvironmentSkybox component{quoll::EnvironmentSkyboxType::Texture,
-                                     environment.handle()};
+                                     environment};
   entityDatabase.set(entity, component);
 
   auto node = entitySerializer.createComponentsNode(entity);
@@ -1030,10 +1019,9 @@ TEST_F(EntitySerializerTest,
        CreatesSkyboxWithColorTypeIfTypeIsColorAndAssetExists) {
   auto entity = entityDatabase.create();
 
-  quoll::EnvironmentSkybox component{
-      quoll::EnvironmentSkyboxType::Color,
-      quoll::AssetHandle<quoll::EnvironmentAsset>(),
-      glm::vec4(0.2f, 0.3f, 0.4f, 0.5f)};
+  quoll::EnvironmentSkybox component{quoll::EnvironmentSkyboxType::Color,
+                                     quoll::AssetRef<quoll::EnvironmentAsset>(),
+                                     glm::vec4(0.2f, 0.3f, 0.4f, 0.5f)};
   entityDatabase.set(entity, component);
 
   auto node = entitySerializer.createComponentsNode(entity);
@@ -1075,8 +1063,7 @@ TEST_F(EntitySerializerTest,
 TEST_F(EntitySerializerTest,
        DoesNotCreateInputMapFieldIfInputMapAssetDoesNotExist) {
   auto entity = entityDatabase.create();
-  entityDatabase.set<quoll::InputMapAssetRef>(
-      entity, {quoll::AssetHandle<quoll::InputMapAsset>{25}});
+  entityDatabase.set<quoll::InputMapAssetRef>(entity, {});
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_FALSE(node["inputMap"]);
@@ -1087,7 +1074,7 @@ TEST_F(EntitySerializerTest,
   auto inputMap = createAsset<quoll::InputMapAsset>();
 
   auto entity = entityDatabase.create();
-  entityDatabase.set<quoll::InputMapAssetRef>(entity, {inputMap.handle(), 0});
+  entityDatabase.set<quoll::InputMapAssetRef>(entity, {inputMap, 0});
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_TRUE(node["inputMap"]);


### PR DESCRIPTION
- Fix a bug with passing input map asset to input map component