### PR TITLE
Rename asset variable names in components

### DIFF
--- a/editor/src/quoll/editor/actions/EntityScriptingActions.cpp
+++ b/editor/src/quoll/editor/actions/EntityScriptingActions.cpp
@@ -44,7 +44,7 @@ bool EntitySetScriptVariable::predicate(WorkspaceState &state,
     return false;
   }
 
-  const auto &scriptAsset = scene.entityDatabase.get<LuaScript>(mEntity).handle;
+  const auto &scriptAsset = scene.entityDatabase.get<LuaScript>(mEntity).asset;
   if (!scriptAsset) {
     return false;
   }

--- a/editor/src/quoll/editor/scene/renderer/EditorRenderer.cpp
+++ b/editor/src/quoll/editor/scene/renderer/EditorRenderer.cpp
@@ -501,7 +501,7 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
       frameData.addSpriteOutline(world.worldTransform);
     } else if (entityDatabase.has<Mesh>(state.selectedEntity) &&
                entityDatabase.has<MeshRenderer>(state.selectedEntity)) {
-      const auto &asset = entityDatabase.get<Mesh>(state.selectedEntity).handle;
+      const auto &asset = entityDatabase.get<Mesh>(state.selectedEntity).asset;
 
       const auto &world =
           entityDatabase.get<WorldTransform>(state.selectedEntity);
@@ -510,7 +510,7 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
     } else if (entityDatabase.has<Mesh>(state.selectedEntity) &&
                entityDatabase.has<SkinnedMeshRenderer>(state.selectedEntity) &&
                entityDatabase.has<Skeleton>(state.selectedEntity)) {
-      const auto &asset = entityDatabase.get<Mesh>(state.selectedEntity).handle;
+      const auto &asset = entityDatabase.get<Mesh>(state.selectedEntity).asset;
 
       const auto &world =
           entityDatabase.get<WorldTransform>(state.selectedEntity);

--- a/editor/src/quoll/editor/scene/ui/EntityPanel.cpp
+++ b/editor/src/quoll/editor/scene/ui/EntityPanel.cpp
@@ -633,7 +633,7 @@ void EntityPanel::renderSprite(Scene &scene, AssetCache &assetCache,
 
     if (auto _ = widgets::Section(SectionName.c_str())) {
       const auto &texture =
-          scene.entityDatabase.get<Sprite>(mSelectedEntity).handle;
+          scene.entityDatabase.get<Sprite>(mSelectedEntity).texture;
 
       static constexpr glm::vec2 TextureSize(80.0f, 80.0f);
 
@@ -674,7 +674,7 @@ void EntityPanel::renderMesh(Scene &scene, AssetCache &assetCache,
 
   if (scene.entityDatabase.has<Mesh>(mSelectedEntity)) {
     if (auto _ = widgets::Section(SectionName.c_str())) {
-      auto asset = scene.entityDatabase.get<Mesh>(mSelectedEntity).handle;
+      const auto &asset = scene.entityDatabase.get<Mesh>(mSelectedEntity).asset;
 
       if (auto table = widgets::Table("TableMesh", 2)) {
         table.row("Name", asset.meta().name);
@@ -845,10 +845,8 @@ void EntityPanel::renderSkeleton(Scene &scene, AssetCache &assetCache,
 
     const auto &skeleton = scene.entityDatabase.get<Skeleton>(mSelectedEntity);
 
-    const auto &asset = skeleton.assetHandle;
-
     if (auto table = widgets::Table("TableSkinnedMesh", 2)) {
-      table.row("Name", asset.meta().name);
+      table.row("Name", skeleton.asset.meta().name);
       table.row("Number of joints",
                 static_cast<u32>(skeleton.jointNames.size()));
     }
@@ -1345,7 +1343,7 @@ void EntityPanel::renderAudio(Scene &scene, AssetCache &assetCache,
   if (auto _ = widgets::Section(SectionName.c_str())) {
     const auto &audio = scene.entityDatabase.get<AudioSource>(mSelectedEntity);
 
-    ImGui::Text("Name: %s", audio.source.meta().name.c_str());
+    ImGui::Text("Name: %s", audio.asset.meta().name.c_str());
   }
 
   if (shouldDelete("Audio")) {
@@ -1365,8 +1363,8 @@ void EntityPanel::renderScripting(Scene &scene, AssetCache &assetCache,
 
   if (auto _ = widgets::Section(SectionName.c_str())) {
     auto &script = scene.entityDatabase.get<LuaScript>(mSelectedEntity);
-    const auto &asset = script.handle.get();
-    const auto &name = script.handle.meta().name;
+    const auto &asset = script.asset.get();
+    const auto &name = script.asset.meta().name;
 
     ImGui::Text("Name: %s", name.c_str());
 
@@ -1526,8 +1524,8 @@ void EntityPanel::renderInput(Scene &scene, AssetCache &assetCache,
     auto &component =
         scene.entityDatabase.get<InputMapAssetRef>(mSelectedEntity);
 
-    if (component.handle) {
-      widgets::Button(component.handle.meta().name.c_str(),
+    if (component.asset) {
+      widgets::Button(component.asset.meta().name.c_str(),
                       ImVec2(width, height));
     } else {
       widgets::Button("Drag input map here", ImVec2(width, height));
@@ -1548,14 +1546,14 @@ void EntityPanel::renderInput(Scene &scene, AssetCache &assetCache,
         auto asset = assetCache.request<InputMapAsset>(uuid);
 
         auto newComponent = component;
-        newComponent.handle = asset;
+        newComponent.asset = asset;
         actionExecutor.execute<EntityUpdateComponent<InputMapAssetRef>>(
             mSelectedEntity, component, newComponent);
       }
     }
 
-    if (component.handle) {
-      const auto &asset = component.handle.get();
+    if (component.asset) {
+      const auto &asset = component.asset.get();
 
       const auto *schemeName =
           component.defaultScheme < asset.schemes.size()
@@ -1585,7 +1583,7 @@ void EntityPanel::renderInput(Scene &scene, AssetCache &assetCache,
           scene.entityDatabase.get<InputMap>(mSelectedEntity);
 
       const auto *schemeName =
-          component.handle->schemes.at(inputMap.activeScheme).name.c_str();
+          component.asset->schemes.at(inputMap.activeScheme).name.c_str();
 
       ImGui::Text("Debug");
       ImGui::Text("Active scheme: %s", schemeName);

--- a/editor/tests/quoll/editor-tests/actions/EntityScriptingActions.test.cpp
+++ b/editor/tests/quoll/editor-tests/actions/EntityScriptingActions.test.cpp
@@ -39,7 +39,7 @@ TEST_F(EntitySetScriptVariableActionTest,
   auto entity = state.scene.entityDatabase.create();
 
   quoll::LuaScript script;
-  script.handle = scriptAsset;
+  script.asset = scriptAsset;
   script.variables.insert({"var1", prefab1});
   state.scene.entityDatabase.set(entity, script);
 

--- a/engine/src/quoll/asset/AssetRef.h
+++ b/engine/src/quoll/asset/AssetRef.h
@@ -9,7 +9,8 @@ namespace quoll {
 template <class TAssetData> class AssetRef {
 public:
   constexpr AssetRef() = default;
-  constexpr AssetRef(AssetMap<TAssetData> *map, AssetHandle<TAssetData> handle)
+  constexpr explicit AssetRef(AssetMap<TAssetData> *map,
+                              AssetHandle<TAssetData> handle)
       : mMap(map), mHandle(handle) {}
 
   constexpr operator bool() const { return mHandle; }

--- a/engine/src/quoll/audio/AudioSerializer.cpp
+++ b/engine/src/quoll/audio/AudioSerializer.cpp
@@ -7,7 +7,7 @@ namespace quoll {
 void AudioSerializer::serialize(YAML::Node &node,
                                 EntityDatabase &entityDatabase, Entity entity) {
   if (entityDatabase.has<AudioSource>(entity)) {
-    const auto &asset = entityDatabase.get<AudioSource>(entity).source;
+    const auto &asset = entityDatabase.get<AudioSource>(entity).asset;
     if (asset) {
       node["audio"]["source"] = asset.meta().uuid;
     }

--- a/engine/src/quoll/audio/AudioSource.h
+++ b/engine/src/quoll/audio/AudioSource.h
@@ -6,7 +6,7 @@
 namespace quoll {
 
 struct AudioSource {
-  AssetRef<AudioAsset> source;
+  AssetRef<AudioAsset> asset;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/audio/AudioSystem.h
+++ b/engine/src/quoll/audio/AudioSystem.h
@@ -53,7 +53,7 @@ public:
           continue;
         }
 
-        void *sound = mBackend.playSound(source.source.get());
+        void *sound = mBackend.playSound(source.asset.get());
 
         entityDatabase.set<AudioStatus>(entity, {sound});
       }

--- a/engine/src/quoll/entity/EntitySpawner.cpp
+++ b/engine/src/quoll/entity/EntitySpawner.cpp
@@ -132,7 +132,7 @@ std::vector<Entity> EntitySpawner::spawnPrefab(AssetRef<PrefabAsset> prefab,
     usize numJoints = asset.jointLocalPositions.size();
 
     Skeleton skeleton{};
-    skeleton.assetHandle = pSkeleton.value;
+    skeleton.asset = pSkeleton.value;
     skeleton.numJoints = static_cast<u32>(numJoints);
     skeleton.jointNames.resize(numJoints);
     skeleton.jointParents.resize(numJoints);

--- a/engine/src/quoll/input/InputMap.h
+++ b/engine/src/quoll/input/InputMap.h
@@ -7,7 +7,7 @@
 namespace quoll {
 
 struct InputMapAssetRef {
-  AssetRef<InputMapAsset> handle;
+  AssetRef<InputMapAsset> asset;
 
   usize defaultScheme = 0;
 };

--- a/engine/src/quoll/input/InputMapSerializer.cpp
+++ b/engine/src/quoll/input/InputMapSerializer.cpp
@@ -10,8 +10,8 @@ void InputMapSerializer::serialize(YAML::Node &node,
   if (entityDatabase.has<InputMapAssetRef>(entity)) {
     const auto &component = entityDatabase.get<InputMapAssetRef>(entity);
 
-    if (component.handle) {
-      node["inputMap"]["asset"] = component.handle.meta().uuid;
+    if (component.asset) {
+      node["inputMap"]["asset"] = component.asset.meta().uuid;
       node["inputMap"]["defaultScheme"] = component.defaultScheme;
     }
   }

--- a/engine/src/quoll/input/InputMapSystem.cpp
+++ b/engine/src/quoll/input/InputMapSystem.cpp
@@ -13,9 +13,9 @@ InputMapSystem::InputMapSystem(InputDeviceManager &deviceManager)
 void InputMapSystem::update(SystemView &view) {
   auto &entityDatabase = view.scene->entityDatabase;
   for (auto [entity, ref] : entityDatabase.view<InputMapAssetRef>()) {
-    if (ref.handle && !entityDatabase.has<InputMap>(entity)) {
+    if (ref.asset && !entityDatabase.has<InputMap>(entity)) {
       entityDatabase.set(entity,
-                         createInputMap(ref.handle.get(), ref.defaultScheme));
+                         createInputMap(ref.asset.get(), ref.defaultScheme));
     }
   }
 

--- a/engine/src/quoll/lua-scripting/LuaScript.h
+++ b/engine/src/quoll/lua-scripting/LuaScript.h
@@ -10,7 +10,7 @@
 namespace quoll {
 
 struct LuaScript {
-  AssetRef<LuaScriptAsset> handle;
+  AssetRef<LuaScriptAsset> asset;
 
   bool started = false;
 

--- a/engine/src/quoll/lua-scripting/LuaScriptingSystem.cpp
+++ b/engine/src/quoll/lua-scripting/LuaScriptingSystem.cpp
@@ -29,7 +29,7 @@ void LuaScriptingSystem::start(SystemView &view, PhysicsSystem &physicsSystem,
     }
 
     bool valid = true;
-    auto &script = component.handle.get();
+    auto &script = component.asset.get();
     for (auto &[key, value] : script.variables) {
       auto it = component.variables.find(key);
       if (it == component.variables.end() || !it->second.isType(value.type)) {

--- a/engine/src/quoll/lua-scripting/ScriptSerializer.cpp
+++ b/engine/src/quoll/lua-scripting/ScriptSerializer.cpp
@@ -9,10 +9,10 @@ void ScriptSerializer::serialize(YAML::Node &node,
                                  Entity entity) {
   if (entityDatabase.has<LuaScript>(entity)) {
     const auto &script = entityDatabase.get<LuaScript>(entity);
-    if (script.handle) {
-      const auto &asset = script.handle.get();
+    if (script.asset) {
+      const auto &asset = script.asset.get();
 
-      node["script"]["asset"] = script.handle.meta().uuid;
+      node["script"]["asset"] = script.asset.meta().uuid;
 
       for (auto &[name, value] : script.variables) {
         auto it = asset.variables.find(name);

--- a/engine/src/quoll/renderer/Mesh.h
+++ b/engine/src/quoll/renderer/Mesh.h
@@ -6,7 +6,7 @@
 namespace quoll {
 
 struct Mesh {
-  AssetRef<MeshAsset> handle;
+  AssetRef<MeshAsset> asset;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/MeshSerializer.cpp
+++ b/engine/src/quoll/renderer/MeshSerializer.cpp
@@ -8,8 +8,8 @@ void MeshSerializer::serialize(YAML::Node &node, EntityDatabase &entityDatabase,
                                Entity entity) {
   if (entityDatabase.has<Mesh>(entity)) {
     const auto &mesh = entityDatabase.get<Mesh>(entity);
-    if (mesh.handle) {
-      node["mesh"] = mesh.handle.meta().uuid;
+    if (mesh.asset) {
+      node["mesh"] = mesh.asset.meta().uuid;
     }
   }
 }

--- a/engine/src/quoll/renderer/SceneRenderer.cpp
+++ b/engine/src/quoll/renderer/SceneRenderer.cpp
@@ -781,7 +781,7 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
 
   for (auto [entity, sprite, world] :
        entityDatabase.view<Sprite, WorldTransform>()) {
-    auto handle = sprite.handle->deviceHandle;
+    auto handle = sprite.texture->deviceHandle;
     frameData.addSprite(entity, handle, world.worldTransform);
   }
 
@@ -793,7 +793,7 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
       materials.push_back(material->deviceHandle->getAddress());
     }
 
-    frameData.addMesh(mesh.handle.handle(), entity, world.worldTransform,
+    frameData.addMesh(mesh.asset.handle(), entity, world.worldTransform,
                       materials);
   }
 
@@ -806,7 +806,7 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
       materials.push_back(material->deviceHandle->getAddress());
     }
 
-    frameData.addSkinnedMesh(mesh.handle.handle(), entity, world.worldTransform,
+    frameData.addSkinnedMesh(mesh.asset.handle(), entity, world.worldTransform,
                              skeleton.jointFinalTransforms, materials);
   }
 

--- a/engine/src/quoll/scene/Sprite.h
+++ b/engine/src/quoll/scene/Sprite.h
@@ -6,7 +6,7 @@
 namespace quoll {
 
 struct Sprite {
-  AssetRef<TextureAsset> handle;
+  AssetRef<TextureAsset> texture;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/scene/SpriteSerializer.cpp
+++ b/engine/src/quoll/scene/SpriteSerializer.cpp
@@ -9,7 +9,7 @@ void SpriteSerializer::serialize(YAML::Node &node,
                                  EntityDatabase &entityDatabase,
                                  Entity entity) {
   if (entityDatabase.has<Sprite>(entity)) {
-    auto texture = entityDatabase.get<Sprite>(entity).handle;
+    const auto &texture = entityDatabase.get<Sprite>(entity).texture;
     if (texture) {
       node["sprite"] = texture.meta().uuid;
     }

--- a/engine/src/quoll/skeleton/Skeleton.h
+++ b/engine/src/quoll/skeleton/Skeleton.h
@@ -25,7 +25,7 @@ struct Skeleton {
 
   std::vector<String> jointNames;
 
-  AssetRef<SkeletonAsset> assetHandle;
+  AssetRef<SkeletonAsset> asset;
 };
 
 struct SkeletonDebug {

--- a/engine/src/quoll/skeleton/SkeletonSerializer.cpp
+++ b/engine/src/quoll/skeleton/SkeletonSerializer.cpp
@@ -8,7 +8,7 @@ void SkeletonSerializer::serialize(YAML::Node &node,
                                    EntityDatabase &entityDatabase,
                                    Entity entity) {
   if (entityDatabase.has<Skeleton>(entity)) {
-    const auto &asset = entityDatabase.get<Skeleton>(entity).assetHandle;
+    const auto &asset = entityDatabase.get<Skeleton>(entity).asset;
     if (asset) {
       node["skeleton"] = asset.meta().uuid;
     }
@@ -25,7 +25,7 @@ void SkeletonSerializer::deserialize(const YAML::Node &node,
     if (res) {
       const auto &skeleton = res.data().get();
       Skeleton skeletonComponent{};
-      skeletonComponent.assetHandle = res.data();
+      skeletonComponent.asset = res.data();
       skeletonComponent.jointLocalPositions = skeleton.jointLocalPositions;
       skeletonComponent.jointLocalRotations = skeleton.jointLocalRotations;
       skeletonComponent.jointLocalScales = skeleton.jointLocalScales;

--- a/engine/tests/quoll-tests/animation/AnimatorLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/animation/AnimatorLuaTable.test.cpp
@@ -4,20 +4,7 @@
 #include "quoll-tests/Testing.h"
 #include "quoll-tests/test-utils/ScriptingInterfaceTestBase.h"
 
-class AnimatorLuaTableTest : public LuaScriptingInterfaceTestBase {
-public:
-  template <typename TAssetData>
-  quoll::AssetRef<TAssetData> createAsset(TAssetData data = {}) {
-    quoll::AssetData<TAssetData> info{};
-    info.type = quoll::AssetCache::getAssetType<TAssetData>();
-    info.uuid = quoll::Uuid::generate();
-    info.data = data;
-
-    assetCache.getRegistry().add(info);
-
-    return assetCache.request<TAssetData>(info.uuid).data();
-  }
-};
+using AnimatorLuaTableTest = LuaScriptingInterfaceTestBase;
 
 TEST_F(AnimatorLuaTableTest, TriggerAddsAnimatorEventComponent) {
   auto entity = entityDatabase.create();

--- a/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
@@ -270,7 +270,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
     auto entity = res.at(i);
 
     const auto &mesh = db.get<quoll::Mesh>(entity);
-    EXPECT_EQ(mesh.handle, asset.data.meshes.at(i).value);
+    EXPECT_EQ(mesh.asset, asset.data.meshes.at(i).value);
   }
 
   // Test skinned meshes
@@ -278,7 +278,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
     auto entity = res.at(i);
 
     const auto &mesh = db.get<quoll::Mesh>(entity);
-    EXPECT_EQ(mesh.handle, asset.data.meshes.at(i).value);
+    EXPECT_EQ(mesh.asset, asset.data.meshes.at(i).value);
   }
 
   // Test mesh renderers
@@ -308,7 +308,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
     const auto &skeleton = db.get<quoll::Skeleton>(entity);
 
     // Skeletons vector only has three items
-    EXPECT_EQ(skeleton.assetHandle, asset.data.skeletons.at(i - 2).value);
+    EXPECT_EQ(skeleton.asset, asset.data.skeletons.at(i - 2).value);
   }
 
   // Test animators
@@ -436,17 +436,17 @@ TEST_F(EntitySpawnerTest,
 
 TEST_F(EntitySpawnerTest,
        SpawnSpriteCreatesEntityWithSpriteAndTransformComponents) {
-  auto assetHandle = createAsset<quoll::TextureAsset>(
+  auto asset = createAsset<quoll::TextureAsset>(
       {.deviceHandle = quoll::rhi::TextureHandle{25}}, "my-sprite");
 
   quoll::LocalTransform transform{glm::vec3(0.5f, 0.5f, 0.5f)};
 
-  auto entity = entitySpawner.spawnSprite(assetHandle, transform);
+  auto entity = entitySpawner.spawnSprite(asset, transform);
   EXPECT_TRUE(entityDatabase.exists(entity));
   EXPECT_EQ(entityDatabase.get<quoll::LocalTransform>(entity).localPosition,
             transform.localPosition);
   EXPECT_TRUE(entityDatabase.has<quoll::WorldTransform>(entity));
   EXPECT_TRUE(entityDatabase.has<quoll::Sprite>(entity));
-  EXPECT_EQ(entityDatabase.get<quoll::Sprite>(entity).handle, assetHandle);
+  EXPECT_EQ(entityDatabase.get<quoll::Sprite>(entity).texture, asset);
   EXPECT_EQ(entityDatabase.get<quoll::Name>(entity).name, "my-sprite");
 }

--- a/engine/tests/quoll-tests/entity/EntitySpawnerLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntitySpawnerLuaTable.test.cpp
@@ -92,5 +92,5 @@ TEST_F(EntitySpawnerLuaTableTest,
       glm::vec3{0.0f});
   EXPECT_TRUE(entityDatabase.has<quoll::WorldTransform>(createdEntity));
   EXPECT_TRUE(entityDatabase.has<quoll::Sprite>(createdEntity));
-  EXPECT_EQ(entityDatabase.get<quoll::Sprite>(createdEntity).handle, texture);
+  EXPECT_EQ(entityDatabase.get<quoll::Sprite>(createdEntity).texture, texture);
 }

--- a/engine/tests/quoll-tests/io/EntitySerializer.test.cpp
+++ b/engine/tests/quoll-tests/io/EntitySerializer.test.cpp
@@ -354,7 +354,7 @@ TEST_F(EntitySerializerTest, CreatesSkeletonFieldIfSkeletonAssetIsInRegistry) {
 
   auto entity = entityDatabase.create();
   quoll::Skeleton component{};
-  component.assetHandle = skeleton;
+  component.asset = skeleton;
 
   entityDatabase.set(entity, component);
 

--- a/engine/tests/quoll-tests/io/SceneLoader.test.cpp
+++ b/engine/tests/quoll-tests/io/SceneLoader.test.cpp
@@ -272,7 +272,8 @@ TEST_F(SceneLoaderSpriteTest, CreatesSpriteComponentWithFileDataIfValidField) {
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
   ASSERT_TRUE(entityDatabase.has<quoll::Sprite>(entity));
-  EXPECT_EQ(entityDatabase.get<quoll::Sprite>(entity).handle, texture.handle());
+  EXPECT_EQ(entityDatabase.get<quoll::Sprite>(entity).texture,
+            texture.handle());
 }
 
 using SceneLoaderMeshTest = SceneLoaderTest;
@@ -315,7 +316,7 @@ TEST_F(SceneLoaderMeshTest, CreatesMeshComponentIfValidAssetTypeIsMesh) {
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
   ASSERT_TRUE(entityDatabase.has<quoll::Mesh>(entity));
-  EXPECT_EQ(entityDatabase.get<quoll::Mesh>(entity).handle, mesh1.handle());
+  EXPECT_EQ(entityDatabase.get<quoll::Mesh>(entity).asset, mesh1.handle());
 }
 
 TEST_F(SceneLoaderMeshTest,
@@ -327,7 +328,7 @@ TEST_F(SceneLoaderMeshTest,
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
   ASSERT_TRUE(entityDatabase.has<quoll::Mesh>(entity));
-  EXPECT_EQ(entityDatabase.get<quoll::Mesh>(entity).handle, mesh1.handle());
+  EXPECT_EQ(entityDatabase.get<quoll::Mesh>(entity).asset, mesh1.handle());
 }
 
 using SceneLoaderMeshRendererTest = SceneLoaderTest;
@@ -577,7 +578,7 @@ TEST_F(SceneLoaderSkeletonTest,
   ASSERT_TRUE(entityDatabase.has<quoll::Skeleton>(entity));
 
   const auto &skeleton = entityDatabase.get<quoll::Skeleton>(entity);
-  EXPECT_EQ(skeleton.assetHandle, asset.handle());
+  EXPECT_EQ(skeleton.asset, asset.handle());
 
   EXPECT_EQ(skeleton.numJoints, NumJoints);
   for (u32 i = 0; i < NumJoints; ++i) {
@@ -1566,7 +1567,7 @@ TEST_F(SceneLoaderAudioTest, CreatesAudioComponentWithFileDataIfValidField) {
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
   ASSERT_TRUE(entityDatabase.has<quoll::AudioSource>(entity));
-  EXPECT_EQ(entityDatabase.get<quoll::AudioSource>(entity).source,
+  EXPECT_EQ(entityDatabase.get<quoll::AudioSource>(entity).asset,
             audio.handle());
 }
 
@@ -1613,7 +1614,7 @@ TEST_F(SceneLoaderScriptTest,
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
   ASSERT_TRUE(entityDatabase.has<quoll::LuaScript>(entity));
-  EXPECT_EQ(entityDatabase.get<quoll::LuaScript>(entity).handle,
+  EXPECT_EQ(entityDatabase.get<quoll::LuaScript>(entity).asset,
             script.handle());
 }
 
@@ -1644,7 +1645,7 @@ TEST_F(SceneLoaderScriptTest,
   ASSERT_TRUE(entityDatabase.has<quoll::LuaScript>(entity));
   const auto &component = entityDatabase.get<quoll::LuaScript>(entity);
 
-  EXPECT_EQ(component.handle, script.handle());
+  EXPECT_EQ(component.asset, script.handle());
 
   // Invalid prefab and texture are ignored
   EXPECT_FALSE(component.variables.contains("test_invalid_prefab"));
@@ -2743,7 +2744,7 @@ TEST_F(SceneLoaderInputMapTest, CreatesInputMapComponentIfInputMapAssetExists) {
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
   ASSERT_TRUE(entityDatabase.has<quoll::InputMapAssetRef>(entity));
-  EXPECT_EQ(entityDatabase.get<quoll::InputMapAssetRef>(entity).handle,
+  EXPECT_EQ(entityDatabase.get<quoll::InputMapAssetRef>(entity).asset,
             inputMap.handle());
   EXPECT_EQ(entityDatabase.get<quoll::InputMapAssetRef>(entity).defaultScheme,
             1);

--- a/engine/tests/quoll-tests/scripting/LuaScriptingSystem.test.cpp
+++ b/engine/tests/quoll-tests/scripting/LuaScriptingSystem.test.cpp
@@ -22,18 +22,6 @@ public:
     return cache.request<quoll::LuaScriptAsset>(uuid);
   }
 
-  template <typename TAssetData>
-  quoll::AssetRef<TAssetData> createAsset(TAssetData data = {}) {
-    quoll::AssetData<TAssetData> info{};
-    info.type = quoll::AssetCache::getAssetType<TAssetData>();
-    info.uuid = quoll::Uuid::generate();
-    info.data = data;
-
-    cache.getRegistry().add(info);
-
-    return cache.request<TAssetData>(info.uuid).data();
-  }
-
   quoll::Scene scene;
   quoll::EntityDatabase &entityDatabase = scene.entityDatabase;
   quoll::SystemView view{&scene};

--- a/engine/tests/quoll-tests/test-utils/AssetCacheTestBase.h
+++ b/engine/tests/quoll-tests/test-utils/AssetCacheTestBase.h
@@ -10,6 +10,18 @@ public:
 public:
   AssetCacheTestBase();
 
+  template <typename TAssetData>
+  quoll::AssetRef<TAssetData> createAsset(TAssetData data = {}) {
+    quoll::AssetData<TAssetData> info{};
+    info.type = quoll::AssetCache::getAssetType<TAssetData>();
+    info.uuid = quoll::Uuid::generate();
+    info.data = data;
+
+    cache.getRegistry().add(info);
+
+    return cache.request<TAssetData>(info.uuid).data();
+  }
+
   void SetUp() override;
 
   void TearDown() override;


### PR DESCRIPTION
- Remove unused createAsset functions in tests