### PR TITLE
Create gpu data of asset during rendering

### DIFF
--- a/editor/src/quoll/editor/asset/AssetLoader.cpp
+++ b/editor/src/quoll/editor/asset/AssetLoader.cpp
@@ -13,8 +13,6 @@ Result<Path> AssetLoader::loadFromPath(const Path &path,
   auto res = mAssetManager.importAsset(path, directory);
 
   if (res) {
-    mAssetManager.getAssetRegistry().syncWithDevice(
-        mAssetManager.getRenderStorage());
     mAssetManager.generatePreview(res, mAssetManager.getRenderStorage());
   }
 

--- a/editor/src/quoll/editor/asset/AssetManager.cpp
+++ b/editor/src/quoll/editor/asset/AssetManager.cpp
@@ -127,13 +127,6 @@ void AssetManager::generatePreview(const Path &sourceAssetPath,
       asset.preview =
           mHDRIImporter.loadFromPathToDevice(sourceAssetPath, renderStorage);
     }
-  } else if (res.first == AssetType::Texture) {
-    auto &asset = mAssetCache.getRegistry().getMeta(
-        static_cast<quoll::AssetHandle<quoll::TextureAsset>>(handle));
-
-    if (!rhi::isHandleValid(asset.preview)) {
-      asset.preview = asset.data.deviceHandle;
-    }
   }
 }
 
@@ -273,7 +266,7 @@ AssetManager::validateAndPreloadAssets(RenderStorage &renderStorage) {
   QUOLL_PROFILE_EVENT("AssetManager::validateAndPreloadAssets");
   auto reloadRes = reloadAssets();
 
-  auto res = mAssetCache.preloadAssets(renderStorage);
+  auto res = mAssetCache.preloadAssets();
   auto warnings = res.warnings();
 
   if (!res)

--- a/editor/src/quoll/editor/asset/AssetManager.h
+++ b/editor/src/quoll/editor/asset/AssetManager.h
@@ -6,6 +6,12 @@
 #include "ImageLoader.h"
 #include "UUIDMap.h"
 
+namespace quoll {
+
+class RenderStorage;
+
+} // namespace quoll
+
 namespace quoll::editor {
 
 /**

--- a/editor/src/quoll/editor/asset/HDRIImporter.h
+++ b/editor/src/quoll/editor/asset/HDRIImporter.h
@@ -4,6 +4,12 @@
 #include "quoll/rhi/Descriptor.h"
 #include "UUIDMap.h"
 
+namespace quoll {
+
+class RenderStorage;
+
+} // namespace quoll
+
 namespace quoll::editor {
 
 class HDRIImporter {

--- a/editor/src/quoll/editor/asset/ImageLoader.h
+++ b/editor/src/quoll/editor/asset/ImageLoader.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include "quoll/asset/Result.h"
-#include "quoll/rhi/RenderDevice.h"
+
+namespace quoll {
+
+class RenderStorage;
+
+} // namespace quoll
 
 namespace quoll::editor {
 

--- a/editor/src/quoll/editor/scene/renderer/EditorRenderer.cpp
+++ b/editor/src/quoll/editor/scene/renderer/EditorRenderer.cpp
@@ -4,6 +4,7 @@
 #include "quoll/asset/AssetRegistry.h"
 #include "quoll/renderer/Mesh.h"
 #include "quoll/renderer/MeshVertexLayout.h"
+#include "quoll/renderer/RendererAssetRegistry.h"
 #include "quoll/scene/Sprite.h"
 #include "quoll/skeleton/Skeleton.h"
 #include "quoll/text/Text.h"
@@ -13,11 +14,11 @@
 namespace quoll::editor {
 
 EditorRenderer::EditorRenderer(RenderStorage &renderStorage,
-                               rhi::RenderDevice *device)
+                               RendererAssetRegistry &rendererAssetRegistry)
     : mRenderStorage(renderStorage),
       mFrameData{EditorRendererFrameData(renderStorage),
                  EditorRendererFrameData(renderStorage)},
-      mDevice(device) {
+      mRendererAssetRegistry(rendererAssetRegistry) {
 
   createCollidableShapes();
 
@@ -506,7 +507,9 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
       const auto &world =
           entityDatabase.get<WorldTransform>(state.selectedEntity);
 
-      frameData.addMeshOutline(asset.get(), world.worldTransform);
+      const auto &meshDrawData = mRendererAssetRegistry.get(asset);
+
+      frameData.addMeshOutline(meshDrawData, world.worldTransform);
     } else if (entityDatabase.has<Mesh>(state.selectedEntity) &&
                entityDatabase.has<SkinnedMeshRenderer>(state.selectedEntity) &&
                entityDatabase.has<Skeleton>(state.selectedEntity)) {
@@ -518,7 +521,9 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
       const auto &skeleton = entityDatabase.get<Skeleton>(state.selectedEntity)
                                  .jointFinalTransforms;
 
-      frameData.addSkinnedMeshOutline(asset.get(), skeleton,
+      const auto &meshDrawData = mRendererAssetRegistry.get(asset);
+
+      frameData.addSkinnedMeshOutline(meshDrawData, skeleton,
                                       world.worldTransform);
     } else if (entityDatabase.has<Text>(state.selectedEntity)) {
       const auto &text = entityDatabase.get<Text>(state.selectedEntity);
@@ -551,7 +556,8 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
         advanceX += fontGlyph.advanceX;
       }
 
-      frameData.addTextOutline(font.deviceHandle, glyphs, world.worldTransform);
+      frameData.addTextOutline(mRendererAssetRegistry.get(text.font), glyphs,
+                               world.worldTransform);
     }
   }
 

--- a/editor/src/quoll/editor/scene/renderer/EditorRenderer.h
+++ b/editor/src/quoll/editor/scene/renderer/EditorRenderer.h
@@ -16,7 +16,8 @@ class EditorRenderer {
   };
 
 public:
-  EditorRenderer(RenderStorage &renderStorage, rhi::RenderDevice *device);
+  EditorRenderer(RenderStorage &renderStorage,
+                 RendererAssetRegistry &rendererAssetRegistry);
 
   void attach(RenderGraph &graph, const SceneRenderPassData &scenePassData,
               const RendererOptions &options);
@@ -44,7 +45,6 @@ private:
   void createCollidableShapes();
 
 private:
-  rhi::RenderDevice *mDevice;
   Entity mSelectedEntity = Entity::Null;
 
   CollidableShapeDraw mCollidableCube;
@@ -52,6 +52,7 @@ private:
   CollidableShapeDraw mCollidableCapsule;
 
   RenderStorage &mRenderStorage;
+  RendererAssetRegistry &mRendererAssetRegistry;
   std::array<EditorRendererFrameData, rhi::RenderDevice::NumFrames> mFrameData;
 
   rhi::SamplerHandle mTextOutlineSampler = rhi::SamplerHandle::Null;

--- a/editor/src/quoll/editor/scene/renderer/EditorRendererFrameData.cpp
+++ b/editor/src/quoll/editor/scene/renderer/EditorRendererFrameData.cpp
@@ -1,4 +1,5 @@
 #include "quoll/core/Base.h"
+#include "quoll/renderer/MeshDrawData.h"
 #include "quoll/renderer/MeshRenderUtils.h"
 #include "EditorRendererFrameData.h"
 
@@ -133,35 +134,33 @@ void EditorRendererFrameData::addTextOutline(
   mOutlineTextEnd++;
 }
 
-void EditorRendererFrameData::addMeshOutline(const MeshAsset &mesh,
+void EditorRendererFrameData::addMeshOutline(const MeshDrawData &drawData,
                                              const glm::mat4 &worldTransform) {
   MeshOutline outline{};
-  outline.indexBuffer = mesh.indexBuffer;
+  outline.indexBuffer = drawData.indexBuffer;
   {
-    auto data = MeshRenderUtils::getGeometryBuffers(mesh);
+    auto data = MeshRenderUtils::getGeometryBuffers(&drawData);
     outline.vertexBuffers = std::vector(data.begin(), data.end());
   }
   {
-    auto data = MeshRenderUtils::getGeometryBufferOffsets(mesh);
+    auto data = MeshRenderUtils::getGeometryBufferOffsets(&drawData);
     outline.vertexBufferOffsets = std::vector(data.begin(), data.end());
   }
 
-  outline.indexCounts.resize(mesh.geometries.size());
-  outline.indexOffsets.resize(mesh.geometries.size());
-  outline.vertexOffsets.resize(mesh.geometries.size());
+  outline.indexCounts.resize(drawData.geometries.size());
+  outline.indexOffsets.resize(drawData.geometries.size());
+  outline.vertexOffsets.resize(drawData.geometries.size());
 
   mOutlineTransforms.push_back(worldTransform);
 
   u32 lastIndexOffset = 0;
   u32 lastVertexOffset = 0;
   for (usize i = 0; i < outline.indexCounts.size(); ++i) {
-    outline.indexCounts.at(i) =
-        static_cast<u32>(mesh.geometries.at(i).indices.size());
+    outline.indexCounts.at(i) = drawData.geometries.at(i).numIndices;
     outline.indexOffsets.at(i) = static_cast<u32>(lastIndexOffset);
     outline.vertexOffsets.at(i) = lastVertexOffset;
     lastIndexOffset += outline.indexCounts.at(i);
-    lastVertexOffset +=
-        static_cast<u32>(mesh.geometries.at(i).positions.size());
+    lastVertexOffset += drawData.geometries.at(i).numVertices;
   }
 
   mMeshOutlines.push_back(outline);
@@ -169,35 +168,33 @@ void EditorRendererFrameData::addMeshOutline(const MeshAsset &mesh,
 }
 
 void EditorRendererFrameData::addSkinnedMeshOutline(
-    const MeshAsset &mesh, const std::vector<glm::mat4> &skeleton,
+    const MeshDrawData &drawData, const std::vector<glm::mat4> &skeleton,
     const glm::mat4 &worldTransform) {
   MeshOutline outline{};
-  outline.indexBuffer = mesh.indexBuffer;
+  outline.indexBuffer = drawData.indexBuffer;
   {
-    auto data = MeshRenderUtils::getSkinnedGeometryBuffers(mesh);
+    auto data = MeshRenderUtils::getSkinnedGeometryBuffers(&drawData);
     outline.vertexBuffers = std::vector(data.begin(), data.end());
   }
   {
-    auto data = MeshRenderUtils::getSkinnedGeometryBufferOffsets(mesh);
+    auto data = MeshRenderUtils::getSkinnedGeometryBufferOffsets(&drawData);
     outline.vertexBufferOffsets = std::vector(data.begin(), data.end());
   }
 
-  outline.indexCounts.resize(mesh.geometries.size());
-  outline.indexOffsets.resize(mesh.geometries.size());
-  outline.vertexOffsets.resize(mesh.geometries.size());
+  outline.indexCounts.resize(drawData.geometries.size());
+  outline.indexOffsets.resize(drawData.geometries.size());
+  outline.vertexOffsets.resize(drawData.geometries.size());
 
   mOutlineTransforms.push_back(worldTransform);
 
   u32 lastIndexOffset = 0;
   u32 lastVertexOffset = 0;
   for (usize i = 0; i < outline.indexCounts.size(); ++i) {
-    outline.indexCounts.at(i) =
-        static_cast<u32>(mesh.geometries.at(i).indices.size());
+    outline.indexCounts.at(i) = drawData.geometries.at(i).numIndices;
     outline.indexOffsets.at(i) = static_cast<u32>(lastIndexOffset);
     outline.vertexOffsets.at(i) = lastVertexOffset;
     lastIndexOffset += outline.indexCounts.at(i);
-    lastVertexOffset +=
-        static_cast<u32>(mesh.geometries.at(i).positions.size());
+    lastVertexOffset += drawData.geometries.at(i).numVertices;
   }
 
   mMeshOutlines.push_back(outline);

--- a/editor/src/quoll/editor/scene/renderer/EditorRendererFrameData.h
+++ b/editor/src/quoll/editor/scene/renderer/EditorRendererFrameData.h
@@ -4,6 +4,7 @@
 #include "quoll/entity/EntityDatabase.h"
 #include "quoll/physics/Collidable.h"
 #include "quoll/renderer/BindlessDrawParameters.h"
+#include "quoll/renderer/MeshDrawData.h"
 #include "quoll/renderer/RenderStorage.h"
 #include "quoll/renderer/SceneRendererFrameData.h"
 #include "quoll/rhi/RenderDevice.h"
@@ -80,9 +81,10 @@ public:
                  const std::vector<SceneRendererFrameData::GlyphData> &glyphs,
                  const glm::mat4 &worldTransform);
 
-  void addMeshOutline(const MeshAsset &mesh, const glm::mat4 &worldTransform);
+  void addMeshOutline(const MeshDrawData &drawData,
+                      const glm::mat4 &worldTransform);
 
-  void addSkinnedMeshOutline(const MeshAsset &mesh,
+  void addSkinnedMeshOutline(const MeshDrawData &drawData,
                              const std::vector<glm::mat4> &skeleton,
                              const glm::mat4 &worldTransform);
 

--- a/editor/src/quoll/editor/scene/renderer/MousePickingGraph.h
+++ b/editor/src/quoll/editor/scene/renderer/MousePickingGraph.h
@@ -5,6 +5,12 @@
 #include "quoll/renderer/SceneRendererFrameData.h"
 #include "quoll/window/Window.h"
 
+namespace quoll {
+
+class RendererAssetRegistry;
+
+} // namespace quoll
+
 namespace quoll::editor {
 
 class MousePickingGraph {
@@ -14,7 +20,8 @@ class MousePickingGraph {
 
 public:
   MousePickingGraph(const std::array<SceneRendererFrameData, 2> &frameData,
-                    AssetRegistry &assetRegistry, RenderStorage &renderStorage);
+                    AssetRegistry &assetRegistry, RenderStorage &renderStorage,
+                    RendererAssetRegistry &rendererAssetRegistry);
 
   void execute(rhi::RenderCommandList &commandList, const glm::vec2 &mousePos,
                u32 frameIndex);
@@ -34,6 +41,7 @@ private:
 
 private:
   RenderStorage &mRenderStorage;
+  RendererAssetRegistry &mRendererAssetRegistry;
   RenderGraph mRenderGraph;
   const std::array<SceneRendererFrameData, rhi::RenderDevice::NumFrames>
       &mFrameData;

--- a/editor/src/quoll/editor/scene/ui/AssetBrowser.cpp
+++ b/editor/src/quoll/editor/scene/ui/AssetBrowser.cpp
@@ -541,12 +541,9 @@ void AssetBrowser::setDefaultProps(Entry &entry, AssetRegistry &assetRegistry) {
   // Icon and preview
   entry.icon = entry.isDirectory ? EditorIcon::Directory
                                  : getIconFromAssetType(entry.assetType);
+  entry.preview = IconRegistry::getIcon(entry.icon);
 
-  if (entry.assetType == AssetType::Texture) {
-    entry.preview =
-        assetRegistry.get(static_cast<AssetHandle<TextureAsset>>(entry.asset))
-            .deviceHandle;
-  } else if (entry.assetType == AssetType::Environment) {
+  if (entry.assetType == AssetType::Environment) {
     entry.preview =
         assetRegistry
             .getMeta(static_cast<AssetHandle<EnvironmentAsset>>(entry.asset))

--- a/editor/src/quoll/editor/scene/ui/AssetBrowser.h
+++ b/editor/src/quoll/editor/scene/ui/AssetBrowser.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "quoll/asset/AssetCache.h"
 #include "quoll/editor/actions/ActionExecutor.h"
 #include "quoll/editor/asset/AssetLoader.h"
 #include "quoll/editor/ui/AssetLoadStatusDialog.h"

--- a/editor/src/quoll/editor/scene/ui/EntityPanel.cpp
+++ b/editor/src/quoll/editor/scene/ui/EntityPanel.cpp
@@ -640,7 +640,7 @@ void EntityPanel::renderSprite(Scene &scene, AssetCache &assetCache,
       if (auto table = widgets::Table("TableSprite", 2)) {
         table.row("Texture", texture.meta().name);
         table.column("Preview");
-        table.column(texture->deviceHandle, TextureSize);
+        table.column(texture, TextureSize);
       }
     }
 

--- a/editor/src/quoll/editor/scene/ui/SceneEditorUI.h
+++ b/editor/src/quoll/editor/scene/ui/SceneEditorUI.h
@@ -6,7 +6,6 @@
 #include "quoll/renderer/Renderer.h"
 #include "quoll/renderer/SceneRenderer.h"
 #include "quoll/scene/CameraAspectRatioUpdater.h"
-#include "quoll/ui/UICanvasUpdater.h"
 #include "quoll/editor/ui/IconRegistry.h"
 #include "quoll/editor/ui/StatusBar.h"
 #include "quoll/editor/workspace/WorkspaceManager.h"

--- a/editor/src/quoll/editor/scene/ui/SceneSimulatorUI.h
+++ b/editor/src/quoll/editor/scene/ui/SceneSimulatorUI.h
@@ -6,7 +6,6 @@
 #include "quoll/renderer/Renderer.h"
 #include "quoll/renderer/SceneRenderer.h"
 #include "quoll/scene/CameraAspectRatioUpdater.h"
-#include "quoll/ui/UICanvasUpdater.h"
 #include "quoll/editor/ui/IconRegistry.h"
 #include "quoll/editor/ui/StatusBar.h"
 #include "quoll/editor/workspace/WorkspaceManager.h"

--- a/editor/src/quoll/editor/screens/ProjectSelectorScreen.cpp
+++ b/editor/src/quoll/editor/screens/ProjectSelectorScreen.cpp
@@ -8,6 +8,7 @@
 #include "quoll/renderer/Presenter.h"
 #include "quoll/renderer/RenderStorage.h"
 #include "quoll/renderer/Renderer.h"
+#include "quoll/renderer/RendererAssetRegistry.h"
 #include "quoll/editor/ui/FontAwesome.h"
 #include "quoll/editor/ui/MainMenuBar.h"
 #include "quoll/editor/ui/StyleStack.h"
@@ -32,7 +33,8 @@ std::optional<Project> ProjectSelectorScreen::start() {
 
   Renderer renderer(renderStorage, initialOptions);
 
-  ImguiRenderer imguiRenderer(mWindow, renderStorage);
+  quoll::RendererAssetRegistry rendererAssetRegistry(renderStorage);
+  ImguiRenderer imguiRenderer(mWindow, renderStorage, rendererAssetRegistry);
   Presenter presenter(renderStorage);
 
   ProjectManager projectManager;

--- a/editor/src/quoll/editor/ui/MaterialViewer.cpp
+++ b/editor/src/quoll/editor/ui/MaterialViewer.cpp
@@ -11,7 +11,7 @@ static void renderTextureIfExists(widgets::Table &table, const String &label,
 
   if (texture) {
     table.column(label);
-    table.column(texture->deviceHandle, TextureSize);
+    table.column(texture, TextureSize);
   }
 }
 

--- a/editor/src/quoll/editor/ui/MaterialViewer.h
+++ b/editor/src/quoll/editor/ui/MaterialViewer.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "quoll/asset/AssetCache.h"
+#include "quoll/asset/AssetRef.h"
+#include "quoll/renderer/MaterialAsset.h"
 
 namespace quoll::editor {
 

--- a/editor/src/quoll/editor/ui/Widgets.cpp
+++ b/editor/src/quoll/editor/ui/Widgets.cpp
@@ -164,6 +164,11 @@ void Table::column(rhi::TextureHandle handle, const glm::vec2 &size) {
   imgui::image(handle, ImVec2(size.x, size.y));
 }
 
+void Table::column(const AssetRef<TextureAsset> &asset, const glm::vec2 &size) {
+  ImGui::TableNextColumn();
+  imgui::image(asset, ImVec2(size.x, size.y));
+}
+
 Input::Input(String label, glm::vec3 &value, bool autoChange) {
   if (autoChange) {
     auto temp = value;

--- a/editor/src/quoll/editor/ui/Widgets.h
+++ b/editor/src/quoll/editor/ui/Widgets.h
@@ -95,6 +95,8 @@ public:
 
   void column(rhi::TextureHandle handle, const glm::vec2 &size);
 
+  void column(const AssetRef<TextureAsset> &asset, const glm::vec2 &size);
+
   template <class... TColumns> void row(const TColumns &...columns) {
     ImGui::TableNextRow();
 

--- a/engine/src/quoll/asset/AssetCache.cpp
+++ b/engine/src/quoll/asset/AssetCache.cpp
@@ -14,7 +14,7 @@ AssetCache::AssetCache(const Path &assetsPath, bool createDefaultObjects)
   }
 }
 
-Result<void> AssetCache::preloadAssets(RenderStorage &renderStorage) {
+Result<void> AssetCache::preloadAssets() {
   QUOLL_PROFILE_EVENT("AssetCache::preloadAssets");
   std::vector<String> warnings;
 
@@ -33,8 +33,6 @@ Result<void> AssetCache::preloadAssets(RenderStorage &renderStorage) {
                       res.warnings().end());
     }
   }
-
-  mRegistry.syncWithDevice(renderStorage);
 
   return {warnings};
 }

--- a/engine/src/quoll/asset/AssetCache.h
+++ b/engine/src/quoll/asset/AssetCache.h
@@ -11,9 +11,8 @@ namespace quoll {
 /**
  * Asset cache
  *
- * Loads and creates engine optimized
- * assets for usage within engine
- * functionality
+ * Loads and creates engine optimized assets
+ * for usage within engine functionality
  */
 class AssetCache {
 public:
@@ -183,7 +182,7 @@ public:
 
   inline const Path &getAssetsPath() const { return mAssetsPath; }
 
-  Result<void> preloadAssets(RenderStorage &renderStorage);
+  Result<void> preloadAssets();
 
   AssetMeta getAssetMeta(const Uuid &uuid) const;
 

--- a/engine/src/quoll/asset/AssetRegistry.h
+++ b/engine/src/quoll/asset/AssetRegistry.h
@@ -20,8 +20,6 @@
 
 namespace quoll {
 
-class RenderStorage;
-
 /**
  * Registry of all the loaded assets
  *
@@ -44,7 +42,7 @@ class AssetRegistry : NoCopyMove {
   using SceneMap = AssetMap<SceneAsset>;
 
   struct DefaultObjects {
-    AssetHandle<MeshAsset> cube;
+    AssetRef<MeshAsset> cube;
     AssetRef<MaterialAsset> defaultMaterial;
     AssetRef<FontAsset> defaultFont;
   };
@@ -59,8 +57,6 @@ public:
   inline const DefaultObjects &getDefaultObjects() const {
     return mDefaultObjects;
   }
-
-  void syncWithDevice(RenderStorage &renderStorage);
 
   std::pair<AssetType, u32> getAssetByUuid(const Uuid &uuid);
 

--- a/engine/src/quoll/imgui/ImguiRenderer.cpp
+++ b/engine/src/quoll/imgui/ImguiRenderer.cpp
@@ -3,6 +3,7 @@
 #include "quoll/renderer/RenderStorage.h"
 #include "quoll/renderer/TextureUtils.h"
 #include "ImguiRenderer.h"
+#include "ImguiUtils.h"
 #include <imgui_impl_glfw.h>
 #include <implot.h>
 
@@ -20,8 +21,10 @@ static inline u64 getAlignedBufferSize(u64 size) {
 
 namespace quoll {
 
-ImguiRenderer::ImguiRenderer(Window &window, RenderStorage &renderStorage)
-    : mRenderStorage(renderStorage), mDevice(renderStorage.getDevice()) {
+ImguiRenderer::ImguiRenderer(Window &window, RenderStorage &renderStorage,
+                             RendererAssetRegistry &rendererAssetRegistry)
+    : mRenderStorage(renderStorage), mDevice(renderStorage.getDevice()),
+      mRendererAssetRegistry(rendererAssetRegistry) {
   ImGui::CreateContext();
   ImGui::StyleColorsDark();
   ImGui_ImplGlfw_InitForVulkan(window.getInstance(), true);
@@ -127,6 +130,7 @@ ImguiRenderPassData ImguiRenderer::attach(RenderGraph &graph,
 void ImguiRenderer::beginRendering() {
   ImGui_ImplGlfw_NewFrame();
   ImGui::NewFrame();
+  imgui::setImguiAssetRegistry(mRendererAssetRegistry);
 }
 
 void ImguiRenderer::endRendering() { ImGui::Render(); }

--- a/engine/src/quoll/imgui/ImguiRenderer.h
+++ b/engine/src/quoll/imgui/ImguiRenderer.h
@@ -10,6 +10,7 @@
 namespace quoll {
 
 class RenderStorage;
+class RendererAssetRegistry;
 
 struct ImguiRenderPassData {
   RenderGraphPass &pass;
@@ -35,7 +36,8 @@ class ImguiRenderer : NoCopyMove {
   static constexpr const glm::vec4 DefaultClearColor{0.0f, 0.0f, 0.0f, 1.0f};
 
 public:
-  ImguiRenderer(Window &window, RenderStorage &renderStorage);
+  ImguiRenderer(Window &window, RenderStorage &renderStorage,
+                RendererAssetRegistry &rendererAssetRegistry);
 
   ~ImguiRenderer();
 
@@ -62,6 +64,7 @@ private:
 
 private:
   RenderStorage &mRenderStorage;
+  RendererAssetRegistry &mRendererAssetRegistry;
   rhi::TextureHandle mFontTexture = rhi::TextureHandle::Null;
 
   std::array<FrameData, rhi::RenderDevice::NumFrames> mFrameData;

--- a/engine/src/quoll/imgui/ImguiUtils.cpp
+++ b/engine/src/quoll/imgui/ImguiUtils.cpp
@@ -1,4 +1,5 @@
 #include "quoll/core/Base.h"
+#include "quoll/renderer/RendererAssetRegistry.h"
 #include "ImguiUtils.h"
 
 constexpr ImVec2 operator+(const ImVec2 &a, const ImVec2 &b) {
@@ -17,8 +18,36 @@ constexpr ImVec2 &operator+=(ImVec2 &a, const ImVec2 &b) {
 
 namespace quoll::imgui {
 
+static RendererAssetRegistry *ImguiAssetRegistry = nullptr;
+
 inline ImTextureID getImguiTexture(quoll::rhi::TextureHandle handle) {
   return reinterpret_cast<ImTextureID>(static_cast<uptr>(handle));
+}
+
+void setImguiAssetRegistry(RendererAssetRegistry &rendererAssetRegistry) {
+  ImguiAssetRegistry = &rendererAssetRegistry;
+}
+
+void image(const AssetRef<TextureAsset> &asset, const ImVec2 &size,
+           const ImVec2 &uv0, const ImVec2 &uv1, ImGuiID id,
+           const ImVec4 &tint_col, const ImVec4 &border_col) {
+  QuollAssert(ImguiAssetRegistry != nullptr,
+              "Asset registry is null. Make sure to call "
+              "`imgui::setImguiAssetRegistry`");
+
+  image(ImguiAssetRegistry->get(asset), size, uv0, uv1, id, tint_col,
+        border_col);
+}
+
+bool imageButton(const AssetRef<TextureAsset> &asset, const ImVec2 &size,
+                 const ImVec2 &uv0, const ImVec2 &uv1, int frame_padding,
+                 const ImVec4 &bg_col, const ImVec4 &tint_col) {
+  QuollAssert(ImguiAssetRegistry != nullptr,
+              "Asset registry is null. Make sure to call "
+              "`imgui::setImguiAssetRegistry`");
+
+  return imageButton(ImguiAssetRegistry->get(asset), size, uv0, uv1,
+                     frame_padding, bg_col, tint_col);
 }
 
 void image(quoll::rhi::TextureHandle handle, const ImVec2 &size,

--- a/engine/src/quoll/imgui/ImguiUtils.h
+++ b/engine/src/quoll/imgui/ImguiUtils.h
@@ -1,9 +1,30 @@
 #pragma once
 
+#include "quoll/asset/AssetRef.h"
 #include "quoll/imgui/Imgui.h"
+#include "quoll/renderer/TextureAsset.h"
 #include "quoll/rhi/RenderHandle.h"
 
+namespace quoll {
+
+class RendererAssetRegistry;
+
+}
+
 namespace quoll::imgui {
+
+void setImguiAssetRegistry(RendererAssetRegistry &rendererAssetRegistry);
+
+void image(const AssetRef<TextureAsset> &asset, const ImVec2 &size,
+           const ImVec2 &uv0 = ImVec2(0, 0), const ImVec2 &uv1 = ImVec2(1, 1),
+           ImGuiID id = 0, const ImVec4 &tint_col = ImVec4(1, 1, 1, 1),
+           const ImVec4 &border_col = ImVec4(0, 0, 0, 0));
+
+bool imageButton(const AssetRef<TextureAsset> &asset, const ImVec2 &size,
+                 const ImVec2 &uv0 = ImVec2(0, 0),
+                 const ImVec2 &uv1 = ImVec2(1, 1), int frame_padding = -1,
+                 const ImVec4 &bg_col = ImVec4(0, 0, 0, 0),
+                 const ImVec4 &tint_col = ImVec4(1, 1, 1, 1));
 
 void image(quoll::rhi::TextureHandle handle, const ImVec2 &size,
            const ImVec2 &uv0 = ImVec2(0, 0), const ImVec2 &uv1 = ImVec2(1, 1),

--- a/engine/src/quoll/loop/MainEngineModules.h
+++ b/engine/src/quoll/loop/MainEngineModules.h
@@ -50,7 +50,7 @@ private:
   EntityDeleter mEntityDeleter;
   SkeletonUpdater mSkeletonUpdater;
   SceneUpdater mSceneUpdater;
-  AnimationSystem mAnimationSystem;
+  AnimationSystem mAnimationSystem{};
   LuaScriptingSystem mScriptingSystem;
   PhysicsSystem mPhysicsSystem;
   AudioSystem<DefaultAudioBackend> mAudioSystem;

--- a/engine/src/quoll/renderer/MaterialAsset.h
+++ b/engine/src/quoll/renderer/MaterialAsset.h
@@ -5,8 +5,6 @@
 
 namespace quoll {
 
-class Material;
-
 struct MaterialAsset {
   AssetRef<TextureAsset> baseColorTexture;
 
@@ -39,8 +37,6 @@ struct MaterialAsset {
   i8 emissiveTextureCoord = -1;
 
   glm::vec3 emissiveFactor{};
-
-  SharedPtr<Material> deviceHandle;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/MeshAsset.h
+++ b/engine/src/quoll/renderer/MeshAsset.h
@@ -24,12 +24,6 @@ struct BaseGeometryAsset {
 
 struct MeshAsset {
   std::vector<BaseGeometryAsset> geometries;
-
-  std::vector<rhi::BufferHandle> vertexBuffers;
-
-  std::vector<u64> vertexBufferOffsets;
-
-  rhi::BufferHandle indexBuffer = rhi::BufferHandle::Null;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/MeshDrawData.h
+++ b/engine/src/quoll/renderer/MeshDrawData.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "quoll/rhi/RenderHandle.h"
+
+namespace quoll {
+
+struct MeshGeometryInfo {
+  u32 numVertices = 0;
+  u32 numIndices = 0;
+};
+
+struct MeshDrawData {
+  std::vector<rhi::BufferHandle> vertexBuffers;
+  std::vector<u64> vertexBufferOffsets;
+  rhi::BufferHandle indexBuffer = rhi::BufferHandle::Null;
+
+  std::vector<MeshGeometryInfo> geometries;
+};
+
+} // namespace quoll

--- a/engine/src/quoll/renderer/MeshRenderUtils.cpp
+++ b/engine/src/quoll/renderer/MeshRenderUtils.cpp
@@ -8,28 +8,27 @@ static constexpr usize JointsIndex = 5;
 static constexpr usize WeightsIndex = 6;
 
 std::array<rhi::BufferHandle, 1>
-MeshRenderUtils::getGeometryBuffers(const MeshAsset &mesh) {
-
-  return std::array{mesh.vertexBuffers.at(PositionsIndex)};
+MeshRenderUtils::getGeometryBuffers(const MeshDrawData *drawData) {
+  return std::array{drawData->vertexBuffers.at(PositionsIndex)};
 }
 
 std::array<u64, 1>
-MeshRenderUtils::getGeometryBufferOffsets(const MeshAsset &mesh) {
-  return std::array{mesh.vertexBufferOffsets.at(PositionsIndex)};
+MeshRenderUtils::getGeometryBufferOffsets(const MeshDrawData *drawData) {
+  return std::array{drawData->vertexBufferOffsets.at(PositionsIndex)};
 }
 
 std::array<rhi::BufferHandle, MeshRenderUtils::SkinGeometryContributors>
-MeshRenderUtils::getSkinnedGeometryBuffers(const MeshAsset &mesh) {
-  return std::array{mesh.vertexBuffers.at(PositionsIndex),
-                    mesh.vertexBuffers.at(JointsIndex),
-                    mesh.vertexBuffers.at(WeightsIndex)};
+MeshRenderUtils::getSkinnedGeometryBuffers(const MeshDrawData *drawData) {
+  return std::array{drawData->vertexBuffers.at(PositionsIndex),
+                    drawData->vertexBuffers.at(JointsIndex),
+                    drawData->vertexBuffers.at(WeightsIndex)};
 }
 
 std::array<u64, MeshRenderUtils::SkinGeometryContributors>
-MeshRenderUtils::getSkinnedGeometryBufferOffsets(const MeshAsset &mesh) {
-  return std::array{mesh.vertexBufferOffsets.at(PositionsIndex),
-                    mesh.vertexBufferOffsets.at(JointsIndex),
-                    mesh.vertexBufferOffsets.at(WeightsIndex)};
+MeshRenderUtils::getSkinnedGeometryBufferOffsets(const MeshDrawData *drawData) {
+  return std::array{drawData->vertexBufferOffsets.at(PositionsIndex),
+                    drawData->vertexBufferOffsets.at(JointsIndex),
+                    drawData->vertexBufferOffsets.at(WeightsIndex)};
 }
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/MeshRenderUtils.h
+++ b/engine/src/quoll/renderer/MeshRenderUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MeshAsset.h"
+#include "MeshDrawData.h"
 
 namespace quoll {
 
@@ -16,41 +16,30 @@ public:
    *
    * Provides minimal buffer to render the mesh
    * with no shading
-   *
-   * @param mesh Mesh asset data
-   * @return Buffers
    */
   static std::array<rhi::BufferHandle, 1>
-  getGeometryBuffers(const MeshAsset &mesh);
+  getGeometryBuffers(const MeshDrawData *drawData);
 
   /**
    * @brief Get buffer offsets required for mesh geometry
-   *
-   * @param mesh Mesh asset data
-   * @return Offsets
    */
-  static std::array<u64, 1> getGeometryBufferOffsets(const MeshAsset &mesh);
+  static std::array<u64, 1>
+  getGeometryBufferOffsets(const MeshDrawData *drawData);
 
   /**
    * @brief Get buffers required for skinned mesh geometry
    *
    * Provides minimal buffer to render
    * the skinned mesh with no shading
-   *
-   * @param mesh Mesh asset data
-   * @return Buffers
    */
   static std::array<rhi::BufferHandle, SkinGeometryContributors>
-  getSkinnedGeometryBuffers(const MeshAsset &mesh);
+  getSkinnedGeometryBuffers(const MeshDrawData *drawData);
 
   /**
    * @brief Get buffer offsets required for skinned mesh geometry
-   *
-   * @param mesh Mesh asset data
-   * @return Offsets
    */
   static std::array<u64, SkinGeometryContributors>
-  getSkinnedGeometryBufferOffsets(const MeshAsset &mesh);
+  getSkinnedGeometryBufferOffsets(const MeshDrawData *drawData);
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/RendererAssetRegistry.cpp
+++ b/engine/src/quoll/renderer/RendererAssetRegistry.cpp
@@ -1,0 +1,207 @@
+#include "quoll/core/Base.h"
+#include "quoll/rhi/TextureDescription.h"
+#include "MaterialPBR.h"
+#include "RenderStorage.h"
+#include "RendererAssetRegistry.h"
+#include "TextureUtils.h"
+
+namespace quoll {
+
+RendererAssetRegistry::RendererAssetRegistry(RenderStorage &storage)
+    : mStorage(storage) {}
+
+rhi::TextureHandle
+RendererAssetRegistry::get(const AssetRef<TextureAsset> &asset) {
+  auto it = mTextures.find(asset.handle());
+  if (it != mTextures.end()) {
+    return it->second;
+  }
+
+  const auto &texture = asset.get();
+
+  rhi::TextureDescription description{};
+  description.width = texture.width;
+  description.mipLevelCount = static_cast<u32>(texture.levels.size());
+  description.layerCount = texture.layers;
+  description.height = texture.height;
+  description.usage = rhi::TextureUsage::Color |
+                      rhi::TextureUsage::TransferDestination |
+                      rhi::TextureUsage::Sampled;
+  description.type = texture.type == TextureAssetType::Cubemap
+                         ? rhi::TextureType::Cubemap
+                         : rhi::TextureType::Standard;
+  description.format = texture.format;
+  description.debugName = asset.meta().name;
+
+  auto handle = mStorage.createTexture(description);
+  TextureUtils::copyDataToTexture(
+      mStorage.getDevice(), texture.data.data(), handle,
+      rhi::ImageLayout::ShaderReadOnlyOptimal, texture.layers, texture.levels);
+
+  mTextures.insert_or_assign(asset.handle(), handle);
+
+  return handle;
+}
+
+Material *RendererAssetRegistry::get(const AssetRef<MaterialAsset> &asset) {
+  auto it = mMaterials.find(asset.handle());
+  if (it != mMaterials.end()) {
+    return it->second.get();
+  }
+
+  auto getTextureFromRegistry = [this](const AssetRef<TextureAsset> &texture) {
+    return texture ? get(texture) : rhi::TextureHandle::Null;
+  };
+
+  const auto &material = asset.get();
+  quoll::MaterialPBR::Properties properties{};
+
+  properties.baseColorFactor = material.baseColorFactor;
+  properties.baseColorTexture =
+      getTextureFromRegistry(material.baseColorTexture);
+  properties.baseColorTextureCoord = material.baseColorTextureCoord;
+
+  properties.metallicFactor = material.metallicFactor;
+  properties.metallicRoughnessTexture =
+      getTextureFromRegistry(material.metallicRoughnessTexture);
+  properties.metallicRoughnessTextureCoord =
+      material.metallicRoughnessTextureCoord;
+  properties.roughnessFactor = material.roughnessFactor;
+
+  properties.normalScale = material.normalScale;
+  properties.normalTexture = getTextureFromRegistry(material.normalTexture);
+
+  properties.normalTextureCoord = material.normalTextureCoord;
+
+  properties.occlusionStrength = material.occlusionStrength;
+  properties.occlusionTexture =
+      getTextureFromRegistry(material.occlusionTexture);
+  properties.occlusionTextureCoord = material.occlusionTextureCoord;
+
+  properties.emissiveFactor = material.emissiveFactor;
+  properties.emissiveTexture = getTextureFromRegistry(material.emissiveTexture);
+  properties.emissiveTextureCoord = material.emissiveTextureCoord;
+
+  auto *deviceObject = new MaterialPBR(asset.meta().name, properties, mStorage);
+
+  mMaterials.insert_or_assign(asset.handle(),
+                              std::unique_ptr<Material>(deviceObject));
+
+  return deviceObject;
+}
+
+const MeshDrawData &
+RendererAssetRegistry::get(const AssetRef<MeshAsset> &asset) {
+  auto it = mMeshBuffers.find(asset.handle());
+  if (it != mMeshBuffers.end()) {
+    return it->second;
+  }
+
+  const auto &mesh = asset.get();
+
+  usize ibSize = 0;
+  for (auto &g : mesh.geometries) {
+    ibSize += g.indices.size() * sizeof(u32);
+  }
+
+  MeshDrawData drawData{};
+
+  for (auto &g : mesh.geometries) {
+    drawData.geometries.push_back(
+        {.numVertices = static_cast<u32>(g.positions.size()),
+         .numIndices = static_cast<u32>(g.indices.size())});
+  }
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define CreateBuffer(FieldName, Type)                                          \
+  {                                                                            \
+    usize vbSize = 0;                                                          \
+    for (auto &g : mesh.geometries) {                                          \
+      usize vertexSize = g.FieldName.size();                                   \
+      vbSize += vertexSize * sizeof(Type);                                     \
+    }                                                                          \
+                                                                               \
+    if (vbSize > 0) {                                                          \
+      rhi::BufferDescription description;                                      \
+      description.usage = rhi::BufferUsage::Vertex;                            \
+      description.size = vbSize;                                               \
+      description.data = nullptr;                                              \
+      description.debugName = asset.meta().name + " " #FieldName;              \
+      auto buffer = mStorage.createBuffer(description);                        \
+      auto *data = static_cast<Type *>(buffer.map());                          \
+      drawData.vertexBufferOffsets.push_back(0);                               \
+      usize offset = 0;                                                        \
+      for (auto &g : mesh.geometries) {                                        \
+        memcpy(data + offset, g.FieldName.data(),                              \
+               g.FieldName.size() * sizeof(Type));                             \
+        offset += g.FieldName.size();                                          \
+      }                                                                        \
+      buffer.unmap();                                                          \
+      drawData.vertexBuffers.push_back(buffer.getHandle());                    \
+    }                                                                          \
+  }
+
+  CreateBuffer(positions, glm::vec3);
+  CreateBuffer(normals, glm::vec3);
+  CreateBuffer(tangents, glm::vec4);
+  CreateBuffer(texCoords0, glm::vec2);
+  CreateBuffer(texCoords1, glm::vec2);
+  CreateBuffer(joints, glm::uvec4);
+  CreateBuffer(weights, glm::vec4);
+
+  {
+    rhi::BufferDescription description;
+    description.usage = rhi::BufferUsage::Index;
+    description.size = ibSize;
+    description.data = nullptr;
+    description.debugName = asset.meta().name + " indices";
+
+    auto buffer = mStorage.createBuffer(description);
+
+    auto *data = static_cast<u32 *>(buffer.map());
+    usize offset = 0;
+    for (auto &g : mesh.geometries) {
+      memcpy(data + offset, g.indices.data(), g.indices.size() * sizeof(u32));
+      offset += g.indices.size();
+    }
+
+    buffer.unmap();
+
+    drawData.indexBuffer = buffer.getHandle();
+  }
+
+  mMeshBuffers.insert_or_assign(asset.handle(), std::move(drawData));
+
+  return mMeshBuffers.at(asset.handle());
+}
+
+rhi::TextureHandle
+RendererAssetRegistry::get(const AssetRef<FontAsset> &asset) {
+  auto it = mFontAtlases.find(asset.handle());
+  if (it != mFontAtlases.end()) {
+    return it->second;
+  }
+
+  const auto &font = asset.get();
+
+  rhi::TextureDescription description{};
+  description.width = font.atlasDimensions.x;
+  description.height = font.atlasDimensions.y;
+  description.usage = rhi::TextureUsage::Color |
+                      rhi::TextureUsage::TransferDestination |
+                      rhi::TextureUsage::Sampled;
+  description.format = rhi::Format::Rgba8Unorm;
+  description.debugName = asset.meta().name;
+
+  auto handle = mStorage.createTexture(description);
+  mFontAtlases.insert_or_assign(asset.handle(), handle);
+
+  TextureUtils::copyDataToTexture(
+      mStorage.getDevice(), font.atlasBytes.data(), handle,
+      rhi::ImageLayout::ShaderReadOnlyOptimal, 1,
+      {{0, font.size, font.atlasDimensions.x, font.atlasDimensions.y}});
+
+  return handle;
+}
+
+} // namespace quoll

--- a/engine/src/quoll/renderer/RendererAssetRegistry.h
+++ b/engine/src/quoll/renderer/RendererAssetRegistry.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "quoll/asset/AssetRef.h"
+#include "quoll/text/FontAsset.h"
+#include "Material.h"
+#include "MaterialAsset.h"
+#include "MeshAsset.h"
+#include "MeshDrawData.h"
+#include "TextureAsset.h"
+
+namespace quoll {
+
+class RenderStorage;
+
+class RendererAssetRegistry {
+public:
+  RendererAssetRegistry(RenderStorage &storage);
+
+  rhi::TextureHandle get(const AssetRef<TextureAsset> &asset);
+
+  Material *get(const AssetRef<MaterialAsset> &asset);
+
+  const MeshDrawData &get(const AssetRef<MeshAsset> &asset);
+
+  rhi::TextureHandle get(const AssetRef<FontAsset> &asset);
+
+private:
+  RenderStorage &mStorage;
+
+  std::unordered_map<AssetHandle<TextureAsset>, rhi::TextureHandle> mTextures;
+  std::unordered_map<AssetHandle<MaterialAsset>, std::unique_ptr<Material>>
+      mMaterials;
+  std::unordered_map<AssetHandle<MeshAsset>, MeshDrawData> mMeshBuffers;
+  std::unordered_map<AssetHandle<FontAsset>, rhi::TextureHandle> mFontAtlases;
+};
+
+} // namespace quoll

--- a/engine/src/quoll/renderer/SceneRenderer.h
+++ b/engine/src/quoll/renderer/SceneRenderer.h
@@ -9,6 +9,8 @@ namespace quoll {
 
 class AssetRegistry;
 class RenderStorage;
+class RendererAssetRegistry;
+struct MeshDrawData;
 
 struct SceneRenderPassData {
   RenderGraphResource<rhi::TextureHandle> sceneColor;
@@ -26,7 +28,8 @@ class SceneRenderer {
   static constexpr glm::vec4 DefaultClearColor{0.0f, 0.0f, 0.0f, 1.0f};
 
 public:
-  SceneRenderer(AssetRegistry &assetRegistry, RenderStorage &renderStorage);
+  SceneRenderer(AssetRegistry &assetRegistry, RenderStorage &renderStorage,
+                RendererAssetRegistry &rendererAssetRegistry);
 
   void setClearColor(const glm::vec4 &clearColor);
 
@@ -50,8 +53,9 @@ private:
                      rhi::PipelineHandle pipeline, u32 frameIndex);
 
   void renderGeometries(rhi::RenderCommandList &commandList,
-                        rhi::PipelineHandle pipeline, const MeshAsset &mesh,
-                        u32 instanceStart, u32 numInstances);
+                        rhi::PipelineHandle pipeline,
+                        const MeshDrawData *drawData, u32 instanceStart,
+                        u32 numInstances);
 
   void renderShadowsMesh(rhi::RenderCommandList &commandList,
                          rhi::PipelineHandle pipeline, u32 frameIndex);
@@ -61,7 +65,7 @@ private:
 
   void renderShadowsGeometries(rhi::RenderCommandList &commandList,
                                rhi::PipelineHandle pipeline,
-                               const MeshAsset &mesh, u32 instanceStart,
+                               const MeshDrawData *drawData, u32 instanceStart,
                                u32 numInstances);
 
   void renderText(rhi::RenderCommandList &commandList,
@@ -75,6 +79,8 @@ private:
   glm::vec4 mClearColor{DefaultClearColor};
   AssetRegistry &mAssetRegistry;
   RenderStorage &mRenderStorage;
+  RendererAssetRegistry &mRendererAssetRegistry;
+
   std::array<SceneRendererFrameData, rhi::RenderDevice::NumFrames> mFrameData;
 
   rhi::SamplerHandle mBloomSampler;

--- a/engine/src/quoll/renderer/SceneRendererFrameData.cpp
+++ b/engine/src/quoll/renderer/SceneRendererFrameData.cpp
@@ -229,8 +229,8 @@ void SceneRendererFrameData::setDefaultMaterial(rhi::DeviceAddress material) {
 }
 
 void SceneRendererFrameData::addMesh(
-    AssetHandle<MeshAsset> handle, quoll::Entity entity,
-    const glm::mat4 &transform,
+    AssetHandle<MeshAsset> handle, const MeshDrawData &meshDrawData,
+    quoll::Entity entity, const glm::mat4 &transform,
     const std::vector<rhi::DeviceAddress> &materials) {
   u32 start = static_cast<u32>(mFlatMaterials.size());
   for (const auto &material : materials) {
@@ -247,10 +247,12 @@ void SceneRendererFrameData::addMesh(
   mMeshGroups.at(handle).entities.push_back(entity);
   mMeshGroups.at(handle).transforms.push_back(transform);
   mMeshGroups.at(handle).materialRanges.push_back({start, end});
+  mMeshGroups.at(handle).drawData = &meshDrawData;
 }
 
 void SceneRendererFrameData::addSkinnedMesh(
-    AssetHandle<MeshAsset> handle, Entity entity, const glm::mat4 &transform,
+    AssetHandle<MeshAsset> handle, const MeshDrawData &meshDrawData,
+    Entity entity, const glm::mat4 &transform,
     const std::vector<glm::mat4> &skeleton,
     const std::vector<rhi::DeviceAddress> &materials) {
   u32 start = static_cast<u32>(mFlatMaterials.size());
@@ -269,6 +271,7 @@ void SceneRendererFrameData::addSkinnedMesh(
   group.entities.push_back(entity);
   group.transforms.push_back(transform);
   group.materialRanges.push_back({start, end});
+  group.drawData = &meshDrawData;
 
   usize currentOffset = group.lastSkeleton * MaxNumJoints;
   usize newSize = currentOffset + MaxNumJoints;

--- a/engine/src/quoll/renderer/SceneRendererFrameData.h
+++ b/engine/src/quoll/renderer/SceneRendererFrameData.h
@@ -13,6 +13,7 @@
 #include "quoll/scene/PointLight.h"
 #include "quoll/scene/WorldTransform.h"
 #include "MeshAsset.h"
+#include "MeshDrawData.h"
 
 namespace quoll {
 
@@ -155,6 +156,8 @@ public:
     std::vector<MaterialRange> materialRanges;
 
     std::vector<Entity> entities;
+
+    const MeshDrawData *drawData = nullptr;
   };
 
   struct SkinnedMeshData : public MeshData {
@@ -215,11 +218,12 @@ public:
 
   void setDefaultMaterial(rhi::DeviceAddress material);
 
-  void addMesh(AssetHandle<MeshAsset> handle, quoll::Entity entity,
-               const glm::mat4 &transform,
+  void addMesh(AssetHandle<MeshAsset> handle, const MeshDrawData &meshBuffers,
+               quoll::Entity entity, const glm::mat4 &transform,
                const std::vector<rhi::DeviceAddress> &materials);
 
-  void addSkinnedMesh(AssetHandle<MeshAsset> handle, Entity entity,
+  void addSkinnedMesh(AssetHandle<MeshAsset> handle,
+                      const MeshDrawData &meshBuffers, Entity entity,
                       const glm::mat4 &transform,
                       const std::vector<glm::mat4> &skeleton,
                       const std::vector<rhi::DeviceAddress> &materials);

--- a/engine/src/quoll/renderer/TextureAsset.h
+++ b/engine/src/quoll/renderer/TextureAsset.h
@@ -33,8 +33,6 @@ struct TextureAsset {
   std::vector<u8> data;
 
   std::vector<TextureAssetMipLevel> levels;
-
-  rhi::TextureHandle deviceHandle = rhi::TextureHandle::Null;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/renderer/TextureUtils.cpp
+++ b/engine/src/quoll/renderer/TextureUtils.cpp
@@ -4,8 +4,9 @@
 namespace quoll {
 
 void TextureUtils::copyDataToTexture(
-    rhi::RenderDevice *device, void *source, rhi::TextureHandle destination,
-    rhi::ImageLayout destinationLayout, u32 destinationLayers,
+    rhi::RenderDevice *device, const void *source,
+    rhi::TextureHandle destination, rhi::ImageLayout destinationLayout,
+    u32 destinationLayers,
     const std::vector<TextureAssetMipLevel> &destinationLevels) {
 
   rhi::BufferDescription stagingBufferDesc{};

--- a/engine/src/quoll/renderer/TextureUtils.h
+++ b/engine/src/quoll/renderer/TextureUtils.h
@@ -8,7 +8,7 @@ namespace quoll {
 class TextureUtils {
 public:
   static void
-  copyDataToTexture(rhi::RenderDevice *device, void *source,
+  copyDataToTexture(rhi::RenderDevice *device, const void *source,
                     rhi::TextureHandle destination,
                     rhi::ImageLayout destinationLayout, u32 destinationLayers,
                     const std::vector<TextureAssetMipLevel> &destinationLevels);

--- a/engine/src/quoll/text/FontAsset.h
+++ b/engine/src/quoll/text/FontAsset.h
@@ -22,8 +22,6 @@ struct FontAsset {
 
   f32 fontScale = 1.0f;
 
-  rhi::TextureHandle deviceHandle = rhi::TextureHandle::Null;
-
   usize size = 0;
 };
 

--- a/engine/src/quoll/ui/UICanvasUpdater.cpp
+++ b/engine/src/quoll/ui/UICanvasUpdater.cpp
@@ -18,8 +18,7 @@ void renderView(UIComponent component, YGNodeRef node) {
 
   if (auto *image = std::get_if<UIImage>(&component)) {
     if (image->texture) {
-      auto texture = image->texture->deviceHandle;
-      imgui::image(texture, ImVec2(ImageSize, ImageSize));
+      imgui::image(image->texture, ImVec2(ImageSize, ImageSize));
     }
   } else if (auto *text = std::get_if<UIText>(&component)) {
     ImGui::Text("%s", text->content.c_str());

--- a/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
@@ -436,8 +436,7 @@ TEST_F(EntitySpawnerTest,
 
 TEST_F(EntitySpawnerTest,
        SpawnSpriteCreatesEntityWithSpriteAndTransformComponents) {
-  auto asset = createAsset<quoll::TextureAsset>(
-      {.deviceHandle = quoll::rhi::TextureHandle{25}}, "my-sprite");
+  auto asset = createAsset<quoll::TextureAsset>({}, "my-sprite");
 
   quoll::LocalTransform transform{glm::vec3(0.5f, 0.5f, 0.5f)};
 

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -12,6 +12,7 @@
 #include "quoll/renderer/Presenter.h"
 #include "quoll/renderer/RenderStorage.h"
 #include "quoll/renderer/Renderer.h"
+#include "quoll/renderer/RendererAssetRegistry.h"
 #include "quoll/renderer/SceneRenderer.h"
 #include "quoll/scene/Scene.h"
 #include "quoll/window/Window.h"
@@ -43,11 +44,12 @@ void Runtime::start() {
   MetricsCollector metricsCollector;
 
   RenderStorage renderStorage(device, metricsCollector);
+  RendererAssetRegistry rendererAssetRegistry(renderStorage);
 
   RendererOptions initialOptions{};
   initialOptions.framebufferSize = {Width, Height};
   Renderer renderer(renderStorage, initialOptions);
-  ImguiRenderer imguiRenderer(window, renderStorage);
+  ImguiRenderer imguiRenderer(window, renderStorage, rendererAssetRegistry);
 
   {
     static constexpr f32 FontSize = 18.0f;
@@ -58,9 +60,10 @@ void Runtime::start() {
     imguiRenderer.buildFonts();
   }
 
-  SceneRenderer sceneRenderer(assetCache.getRegistry(), renderStorage);
+  SceneRenderer sceneRenderer(assetCache.getRegistry(), renderStorage,
+                              rendererAssetRegistry);
 
-  auto res = assetCache.preloadAssets(renderStorage);
+  auto res = assetCache.preloadAssets();
 
   FPSCounter fpsCounter;
   MainLoop mainLoop(window, fpsCounter);


### PR DESCRIPTION
- Remove `syncWithDevice` function from asset registry
- Add new renderer asset registry that creates the gpu data based on asset data
- Provide renderer asset registry to Imgui as separate context
- Get rid of device handles in assets