### PR TITLE
Manage asset previews in editor

### DIFF
--- a/editor/src/quoll/editor/asset/AssetLoader.cpp
+++ b/editor/src/quoll/editor/asset/AssetLoader.cpp
@@ -10,13 +10,7 @@ AssetLoader::AssetLoader(AssetManager &assetManager)
 
 Result<Path> AssetLoader::loadFromPath(const Path &path,
                                        const Path &directory) {
-  auto res = mAssetManager.importAsset(path, directory);
-
-  if (res) {
-    mAssetManager.generatePreview(res, mAssetManager.getRenderStorage());
-  }
-
-  return res;
+  return mAssetManager.importAsset(path, directory);
 }
 
 Result<void> AssetLoader::loadFromFileDialog(const Path &directory) {

--- a/editor/src/quoll/editor/asset/AssetManager.h
+++ b/editor/src/quoll/editor/asset/AssetManager.h
@@ -70,13 +70,13 @@ public:
 
   inline const Path &getAssetsPath() const { return mAssetsPath; }
 
-  inline const Path &getCachePath() const {
-    return mAssetCache.getAssetsPath();
-  }
+  Result<void> reloadAssets();
+
+  Result<void> validateAndPreloadAssets(RenderStorage &renderStorage);
 
   inline AssetCache &getCache() { return mAssetCache; }
 
-  void generatePreview(const Path &path, RenderStorage &renderStorage);
+  rhi::TextureHandle generatePreview(const Uuid &uuid);
 
   Uuid findRootAssetUuid(const Path &sourceAssetPath);
 
@@ -88,13 +88,7 @@ public:
 
   Result<Path> createInputMap(const Path &assetPath);
 
-  Result<void> reloadAssets();
-
-  Result<void> validateAndPreloadAssets(RenderStorage &renderStorage);
-
   Result<UUIDMap> loadSourceIfChanged(const Path &sourceAssetPath);
-
-  inline RenderStorage &getRenderStorage() { return mRenderStorage; }
 
   static AssetType getAssetTypeFromExtension(const Path &path);
 
@@ -168,7 +162,9 @@ private:
 
   HDRIImporter mHDRIImporter;
 
-  std::unordered_map<String, Uuid> mAssetCacheMap;
+  std::unordered_map<Path, Uuid> mSourceToRootUuids;
+  std::unordered_map<Uuid, Path> mUuidToSources;
+  std::unordered_map<Uuid, rhi::TextureHandle> mPreviews;
 };
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/scene/SceneEditorWorkspace.cpp
+++ b/editor/src/quoll/editor/scene/SceneEditorWorkspace.cpp
@@ -108,8 +108,7 @@ void SceneEditorWorkspace::updateFrameData(rhi::RenderCommandList &commandList,
   mSceneRenderer.updateFrameData(scene.entityDatabase, mState.activeCamera,
                                  frameIndex);
   mEditorRenderer.updateFrameData(scene.entityDatabase, mState.activeCamera,
-                                  mState, mAssetManager.getAssetRegistry(),
-                                  frameIndex);
+                                  mState, frameIndex);
 
   if (mMousePickingGraph.isSelectionPerformedInFrame(frameIndex)) {
     auto entity = mMousePickingGraph.getSelectedEntity();

--- a/editor/src/quoll/editor/scene/SceneSimulatorWorkspace.cpp
+++ b/editor/src/quoll/editor/scene/SceneSimulatorWorkspace.cpp
@@ -96,8 +96,7 @@ void SceneSimulatorWorkspace::updateFrameData(
   mSceneRenderer.updateFrameData(mState.scene.entityDatabase,
                                  mState.activeCamera, frameIndex);
   mEditorRenderer.updateFrameData(mState.scene.entityDatabase,
-                                  mState.activeCamera, mState,
-                                  mAssetManager.getAssetRegistry(), frameIndex);
+                                  mState.activeCamera, mState, frameIndex);
 
   if (mMousePickingGraph.isSelectionPerformedInFrame(frameIndex)) {
     auto entity = mMousePickingGraph.getSelectedEntity();

--- a/editor/src/quoll/editor/scene/renderer/EditorRenderer.cpp
+++ b/editor/src/quoll/editor/scene/renderer/EditorRenderer.cpp
@@ -488,7 +488,6 @@ void EditorRenderer::attach(RenderGraph &graph,
 
 void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
                                      Entity camera, WorkspaceState &state,
-                                     AssetRegistry &assetRegistry,
                                      u32 frameIndex) {
   auto &frameData = mFrameData.at(frameIndex);
 

--- a/editor/src/quoll/editor/scene/renderer/EditorRenderer.h
+++ b/editor/src/quoll/editor/scene/renderer/EditorRenderer.h
@@ -23,8 +23,7 @@ public:
               const RendererOptions &options);
 
   void updateFrameData(EntityDatabase &entityDatabase, Entity camera,
-                       WorkspaceState &state, AssetRegistry &assetRegistry,
-                       u32 frameIndex);
+                       WorkspaceState &state, u32 frameIndex);
 
 private:
   void renderSpriteOutlines(rhi::RenderCommandList &commandList,

--- a/editor/src/quoll/editor/scene/renderer/MousePickingGraph.cpp
+++ b/editor/src/quoll/editor/scene/renderer/MousePickingGraph.cpp
@@ -9,10 +9,9 @@ namespace quoll::editor {
 
 MousePickingGraph::MousePickingGraph(
     const std::array<SceneRendererFrameData, 2> &frameData,
-    AssetRegistry &assetRegistry, RenderStorage &renderStorage,
-    RendererAssetRegistry &rendererAssetRegistry)
+    RenderStorage &renderStorage, RendererAssetRegistry &rendererAssetRegistry)
     : mRenderStorage(renderStorage), mFrameData(frameData),
-      mAssetRegistry(assetRegistry), mRenderGraph("MousePicking"),
+      mRenderGraph("MousePicking"),
       mRendererAssetRegistry(rendererAssetRegistry),
       mBindlessParams{
           BindlessDrawParameters(renderStorage.getDevice()

--- a/editor/src/quoll/editor/scene/renderer/MousePickingGraph.h
+++ b/editor/src/quoll/editor/scene/renderer/MousePickingGraph.h
@@ -20,7 +20,7 @@ class MousePickingGraph {
 
 public:
   MousePickingGraph(const std::array<SceneRendererFrameData, 2> &frameData,
-                    AssetRegistry &assetRegistry, RenderStorage &renderStorage,
+                    RenderStorage &renderStorage,
                     RendererAssetRegistry &rendererAssetRegistry);
 
   void execute(rhi::RenderCommandList &commandList, const glm::vec2 &mousePos,
@@ -50,8 +50,6 @@ private:
 
   std::array<MousePickingFrameData, rhi::RenderDevice::NumFrames>
       mMousePickingFrameData;
-
-  AssetRegistry &mAssetRegistry;
 
   rhi::Buffer mSpriteEntitiesBuffer;
   rhi::Buffer mMeshEntitiesBuffer;

--- a/editor/src/quoll/editor/scene/ui/AssetBrowser.h
+++ b/editor/src/quoll/editor/scene/ui/AssetBrowser.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#include "quoll/editor/actions/ActionExecutor.h"
-#include "quoll/editor/asset/AssetLoader.h"
 #include "quoll/editor/ui/AssetLoadStatusDialog.h"
 #include "quoll/editor/ui/IconRegistry.h"
 #include "quoll/editor/ui/MaterialViewer.h"
 
 namespace quoll::editor {
+
+struct WorkspaceState;
+class AssetManager;
+class ActionExecutor;
 
 class AssetBrowser {
   struct Entry {
@@ -16,7 +18,6 @@ class AssetBrowser {
     String truncatedName;
     f32 textWidth = 0.0f;
     bool isDirectory = false;
-    EditorIcon icon = EditorIcon::Unknown;
     rhi::TextureHandle preview = rhi::TextureHandle::Null;
     AssetType assetType = AssetType::None;
     u32 asset = 0;
@@ -40,7 +41,7 @@ private:
 
   void fetchPrefab(AssetHandle<PrefabAsset> handle, AssetManager &assetManager);
 
-  void setDefaultProps(Entry &entry, AssetRegistry &assetRegistry);
+  void setDefaultProps(Entry &entry, AssetManager &assetManager);
 
   void setCurrentFetch(std::variant<Path, AssetHandle<PrefabAsset>> fetch);
 

--- a/editor/src/quoll/editor/scene/ui/EntityPanel.h
+++ b/editor/src/quoll/editor/scene/ui/EntityPanel.h
@@ -17,13 +17,14 @@
 #include "quoll/editor/actions/EntityScriptingActions.h"
 #include "quoll/editor/actions/EntityTransformActions.h"
 #include "quoll/editor/actions/EntityUpdateComponentAction.h"
+#include "quoll/editor/asset/AssetManager.h"
 #include "quoll/editor/workspace/WorkspaceState.h"
 
 namespace quoll::editor {
 
 class EntityPanel {
 public:
-  void renderContent(WorkspaceState &state, AssetCache &assetCache,
+  void renderContent(WorkspaceState &state, AssetManager &assetManager,
                      ActionExecutor &actionExecutor);
 
 private:
@@ -75,7 +76,7 @@ private:
   void renderScripting(Scene &scene, AssetCache &assetCache,
                        ActionExecutor &actionExecutor);
 
-  void renderSkybox(Scene &scene, AssetCache &assetCache,
+  void renderSkybox(Scene &scene, AssetManager &assetManager,
                     ActionExecutor &actionExecutor);
 
   void renderInput(Scene &scene, AssetCache &assetCache,

--- a/editor/src/quoll/editor/scene/ui/Inspector.cpp
+++ b/editor/src/quoll/editor/scene/ui/Inspector.cpp
@@ -4,20 +4,21 @@
 #include "quoll/editor/ui/StyleStack.h"
 #include "quoll/editor/ui/Theme.h"
 #include "quoll/editor/ui/Widgets.h"
+#include "EntityPanel.h"
 #include "Inspector.h"
 
 namespace quoll::editor {
 
 Inspector::Inspector() {
   mTabs.push_back({"Entity", fa::Wrench,
-                   [this](WorkspaceState &state, AssetCache &assetCache,
+                   [this](WorkspaceState &state, AssetManager &assetManager,
                           ActionExecutor &actionExecutor) {
-                     mEntityPanel.renderContent(state, assetCache,
+                     mEntityPanel.renderContent(state, assetManager,
                                                 actionExecutor);
                    }});
 }
 
-void Inspector::render(WorkspaceState &state, AssetCache &assetCache,
+void Inspector::render(WorkspaceState &state, AssetManager &assetManager,
                        ActionExecutor &actionExecutor) {
   StyleStack stack;
   stack.pushStyle(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
@@ -78,7 +79,7 @@ void Inspector::render(WorkspaceState &state, AssetCache &assetCache,
         stack.pushStyle(ImGuiStyleVar_ChildRounding,
                         Theme::getStyles().childRounding);
 
-        mTabs.at(mSelectedIndex).renderFn(state, assetCache, actionExecutor);
+        mTabs.at(mSelectedIndex).renderFn(state, assetManager, actionExecutor);
       }
       ImGui::EndChild();
     }

--- a/editor/src/quoll/editor/scene/ui/Inspector.h
+++ b/editor/src/quoll/editor/scene/ui/Inspector.h
@@ -1,23 +1,24 @@
 #pragma once
 
-#include "quoll/asset/AssetCache.h"
-#include "EntityPanel.h"
-
 namespace quoll::editor {
+
+class AssetManager;
+class ActionExecutor;
+struct WorkspaceState;
 
 class Inspector {
 private:
   struct Tab {
     String name;
     String icon;
-    std::function<void(WorkspaceState &, AssetCache &, ActionExecutor &)>
+    std::function<void(WorkspaceState &, AssetManager &, ActionExecutor &)>
         renderFn;
   };
 
 public:
   Inspector();
 
-  void render(WorkspaceState &state, AssetCache &assetCache,
+  void render(WorkspaceState &state, AssetManager &assetManager,
               ActionExecutor &actionExecutor);
 
 private:

--- a/editor/src/quoll/editor/scene/ui/SceneEditorUI.cpp
+++ b/editor/src/quoll/editor/scene/ui/SceneEditorUI.cpp
@@ -90,7 +90,7 @@ void SceneEditorUI::render(WorkspaceState &state, AssetManager &assetManager,
                 editorCamera, workspaceManager);
 
   mSceneHierarchyPanel.render(state, actionExecutor);
-  mInspector.render(state, assetManager.getCache(), actionExecutor);
+  mInspector.render(state, assetManager, actionExecutor);
 
   mAssetBrowser.render(state, assetManager, actionExecutor);
 }

--- a/editor/src/quoll/editor/scene/ui/SceneSimulatorUI.cpp
+++ b/editor/src/quoll/editor/scene/ui/SceneSimulatorUI.cpp
@@ -68,7 +68,7 @@ void SceneSimulatorUI::render(WorkspaceState &state, AssetManager &assetManager,
   renderToolbar(state, actionExecutor);
 
   mSceneHierarchyPanel.render(state, actionExecutor);
-  mInspector.render(state, assetManager.getCache(), actionExecutor);
+  mInspector.render(state, assetManager, actionExecutor);
 
   mAssetBrowser.render(state, assetManager, actionExecutor);
 }

--- a/editor/src/quoll/editor/screens/EditorScreen.cpp
+++ b/editor/src/quoll/editor/screens/EditorScreen.cpp
@@ -119,8 +119,7 @@ void EditorScreen::start(const Project &rawProject) {
                             scenePassGroup.finalColor};
   });
 
-  MousePickingGraph mousePicking(sceneRenderer.getFrameData(),
-                                 assetManager.getAssetRegistry(), renderStorage,
+  MousePickingGraph mousePicking(sceneRenderer.getFrameData(), renderStorage,
                                  rendererAssetRegistry);
 
   mousePicking.setFramebufferSize(mWindow.getFramebufferSize());

--- a/editor/tests/quoll/editor-tests/asset/AssetManager.test.cpp
+++ b/editor/tests/quoll/editor-tests/asset/AssetManager.test.cpp
@@ -57,9 +57,7 @@ std::vector<std::tuple<quoll::String, quoll::String>>
 mapExtensions(const std::vector<quoll::String> &extensions, T &&fn) {
   std::vector<std::tuple<quoll::String, quoll::String>> temp(extensions.size());
   std::transform(extensions.begin(), extensions.end(), temp.begin(),
-                 [&fn](auto str) {
-                   return std::tuple{str, fn(str)};
-                 });
+                 [&fn](auto str) { return std::tuple{str, fn(str)}; });
   return temp;
 }
 
@@ -73,7 +71,8 @@ mapExtensions(const std::vector<quoll::String> &extensions, T &&fn) {
 TEST_F(AssetManagerTest, SetsProvidedAssetsAndCachePathsOnConstruct) {
   EXPECT_EQ(manager.getAssetsPath(),
             std::filesystem::current_path() / "assets");
-  EXPECT_EQ(manager.getCachePath(), std::filesystem::current_path() / "cache");
+  EXPECT_EQ(manager.getCache().getAssetsPath(),
+            std::filesystem::current_path() / "cache");
 }
 
 TEST_F(AssetManagerTest, CreatesScriptFileAndLoadsIt) {
@@ -112,7 +111,7 @@ TEST_F(AssetManagerTest, ReloadingAssetIfChangedDoesNotCreateFileWithNewUUID) {
   EXPECT_TRUE(engineUuidBefore.isValid());
 
   std::filesystem::remove(
-      (manager.getCachePath() / (engineUuidBefore.toString()))
+      (manager.getCache().getAssetsPath() / (engineUuidBefore.toString()))
           .replace_extension("asset"));
 
   manager.loadSourceIfChanged(sourcePath);
@@ -135,8 +134,9 @@ TEST_F(
   auto engineUuidBefore = manager.findRootAssetUuid(sourcePath);
   EXPECT_TRUE(engineUuidBefore.isValid());
 
-  std::filesystem::remove((manager.getCachePath() / engineUuidBefore.toString())
-                              .replace_extension("asset"));
+  std::filesystem::remove(
+      (manager.getCache().getAssetsPath() / engineUuidBefore.toString())
+          .replace_extension("asset"));
 
   manager.validateAndPreloadAssets(renderStorage);
 

--- a/engine/src/quoll/asset/AssetData.h
+++ b/engine/src/quoll/asset/AssetData.h
@@ -13,8 +13,6 @@ template <class TData> struct AssetData {
   Uuid uuid;
 
   String name;
-
-  rhi::TextureHandle preview = rhi::TextureHandle::Null;
 };
 
 } // namespace quoll

--- a/engine/src/quoll/core/Uuid.h
+++ b/engine/src/quoll/core/Uuid.h
@@ -28,3 +28,9 @@ private:
 };
 
 } // namespace quoll
+
+template <> struct std::hash<quoll::Uuid> {
+  size_t operator()(const auto &data) const {
+    return std::hash<quoll::String>{}(data.toString());
+  }
+};


### PR DESCRIPTION
- Create preview cache in editor
- Change API to generate previews using Uuid
- Generate previews on the fly instead of during preloading
- Remove unused asset registry parameter from various classes
- Remove unused functions from asset manager
- Add hash method for Uuid