### PR TITLE
Only load assets that are needed for the scene

### DIFF
--- a/editor/src/quoll/editor/actions/ProjectActions.cpp
+++ b/editor/src/quoll/editor/actions/ProjectActions.cpp
@@ -12,7 +12,7 @@ ActionExecutorResult ExportAsGame::onExecute(WorkspaceState &state,
                                              AssetCache &assetCache) {
   auto path = platform::FileDialog::getFilePathFromCreateDialog({});
 
-  mAssetManager.reloadAssets();
+  mAssetManager.syncAssets();
 
   GameExporter exporter;
   exporter.exportGame(state.project, path);

--- a/editor/src/quoll/editor/asset/AssetLoader.cpp
+++ b/editor/src/quoll/editor/asset/AssetLoader.cpp
@@ -1,6 +1,7 @@
 #include "quoll/core/Base.h"
 #include "quoll/platform/tools/FileDialog.h"
 #include "AssetLoader.h"
+#include "AssetManager.h"
 #include "GLTFImporter.h"
 
 namespace quoll::editor {

--- a/editor/src/quoll/editor/asset/AssetLoader.h
+++ b/editor/src/quoll/editor/asset/AssetLoader.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "AssetManager.h"
+#include "quoll/asset/Result.h"
 
 namespace quoll::editor {
+
+class AssetManager;
 
 class AssetLoader {
 public:

--- a/editor/src/quoll/editor/asset/AssetManager.h
+++ b/editor/src/quoll/editor/asset/AssetManager.h
@@ -59,6 +59,17 @@ public:
   static const std::vector<String> EnvironmentExtensions;
 
 public:
+  struct SourceInfo {
+    Uuid uuid;
+
+    String name;
+
+    AssetType type;
+
+    bool hasContents;
+  };
+
+public:
   AssetManager(const Path &assetsPath, const Path &assetsCachePath,
                RenderStorage &renderStorage, bool optimize,
                bool createDefaultObjects);
@@ -70,13 +81,15 @@ public:
 
   inline const Path &getAssetsPath() const { return mAssetsPath; }
 
-  Result<void> reloadAssets();
-
-  Result<void> validateAndPreloadAssets(RenderStorage &renderStorage);
+  Result<void> syncAssets();
 
   inline AssetCache &getCache() { return mAssetCache; }
 
   rhi::TextureHandle generatePreview(const Uuid &uuid);
+
+  const SourceInfo &getSourceInfo(const Path &path);
+
+  const std::vector<SourceInfo> &getSourceContentInfos(const Path &path);
 
   Uuid findRootAssetUuid(const Path &sourceAssetPath);
 
@@ -164,6 +177,8 @@ private:
 
   std::unordered_map<Path, Uuid> mSourceToRootUuids;
   std::unordered_map<Uuid, Path> mUuidToSources;
+  std::unordered_map<Path, SourceInfo> mSourceInfos;
+  std::unordered_map<Path, std::vector<SourceInfo>> mSourceContentInfos;
   std::unordered_map<Uuid, rhi::TextureHandle> mPreviews;
 };
 

--- a/editor/src/quoll/editor/scene/ui/AssetBrowser.h
+++ b/editor/src/quoll/editor/scene/ui/AssetBrowser.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "quoll/editor/ui/AssetLoadStatusDialog.h"
-#include "quoll/editor/ui/IconRegistry.h"
 #include "quoll/editor/ui/MaterialViewer.h"
 
 namespace quoll::editor {
@@ -11,16 +10,17 @@ class AssetManager;
 class ActionExecutor;
 
 class AssetBrowser {
+  enum class PathType { Directory, ComplexAsset, SimpleAsset };
+
   struct Entry {
+    PathType pathType;
     Path path;
     Uuid uuid;
     String name;
     String truncatedName;
     f32 textWidth = 0.0f;
-    bool isDirectory = false;
     rhi::TextureHandle preview = rhi::TextureHandle::Null;
     AssetType assetType = AssetType::None;
-    u32 asset = 0;
     bool isEditable = false;
   };
 
@@ -39,13 +39,11 @@ private:
 
   void fetchAssetDirectory(Path path, AssetManager &assetManager);
 
-  void fetchPrefab(AssetHandle<PrefabAsset> handle, AssetManager &assetManager);
+  void fetchAssetContents(Path path, AssetManager &assetManager);
 
   void setDefaultProps(Entry &entry, AssetManager &assetManager);
 
-  void setCurrentFetch(std::variant<Path, AssetHandle<PrefabAsset>> fetch);
-
-  const Path &getCurrentFetchPath() const;
+  void setCurrentFetch(Path path, PathType pathType);
 
 private:
   Entry mStagingEntry;
@@ -53,11 +51,11 @@ private:
   bool mInitialFocusSet = false;
 
   bool mNeedsRefresh = true;
-  std::variant<Path, AssetHandle<PrefabAsset>> mCurrentFetch;
 
   std::vector<Entry> mEntries;
-  Path mCurrentDirectory;
-  Path mPrefabDirectory;
+  Path mCurrentPath;
+  PathType mCurrentPathType;
+
   usize mSelected = std::numeric_limits<usize>::max();
 
   AssetLoadStatusDialog mStatusDialog{"AssetLoadStatus"};

--- a/editor/src/quoll/editor/screens/EditorScreen.cpp
+++ b/editor/src/quoll/editor/screens/EditorScreen.cpp
@@ -62,19 +62,7 @@ void EditorScreen::start(const Project &rawProject) {
 
   presenter.updateFramebuffers(mDevice->getSwapchain());
 
-  auto sceneUuid = assetManager.findRootAssetUuid(project.assetsPath /
-                                                  "scenes" / "main.scene");
-
-  auto res = assetManager.validateAndPreloadAssets(renderStorage);
-
-  project.startingScene = sceneUuid;
-
-  auto sceneAsset = assetManager.getCache().request<SceneAsset>(sceneUuid);
-  QuollAssert(sceneAsset, "Scene asset does not exist");
-  if (!sceneAsset) {
-    return;
-  }
-
+  auto res = assetManager.syncAssets();
   AssetLoadStatusDialog loadStatusDialog("Loaded with warnings");
 
   if (res.hasWarnings()) {
@@ -84,6 +72,16 @@ void EditorScreen::start(const Project &rawProject) {
 
     loadStatusDialog.setMessages(res.warnings());
     loadStatusDialog.show();
+  }
+
+  auto sceneUuid = assetManager.findRootAssetUuid(project.assetsPath /
+                                                  "scenes" / "main.scene");
+  project.startingScene = sceneUuid;
+
+  auto sceneAsset = assetManager.getCache().request<SceneAsset>(sceneUuid);
+  QuollAssert(sceneAsset, "Scene asset does not exist");
+  if (!sceneAsset) {
+    return;
   }
 
   Theme::apply();

--- a/editor/tests/quoll/editor-tests/asset/AssetManager.test.cpp
+++ b/editor/tests/quoll/editor-tests/asset/AssetManager.test.cpp
@@ -57,7 +57,9 @@ std::vector<std::tuple<quoll::String, quoll::String>>
 mapExtensions(const std::vector<quoll::String> &extensions, T &&fn) {
   std::vector<std::tuple<quoll::String, quoll::String>> temp(extensions.size());
   std::transform(extensions.begin(), extensions.end(), temp.begin(),
-                 [&fn](auto str) { return std::tuple{str, fn(str)}; });
+                 [&fn](auto str) {
+                   return std::tuple{str, fn(str)};
+                 });
   return temp;
 }
 
@@ -99,7 +101,7 @@ TEST_F(AssetManagerTest, CreatesInputMapFileAndLoadsIt) {
   EXPECT_TRUE(fs::exists(InnerPathInAssets / "test.inputmap"));
 }
 
-TEST_F(AssetManagerTest, ReloadingAssetIfChangedDoesNotCreateFileWithNewUUID) {
+TEST_F(AssetManagerTest, ReloadsAssetIfChangedDoesNotCreateFileWithNewUUID) {
   fs::create_directories(InnerPathInAssets);
 
   auto animatorPath = InnerPathInAssets / "test.animator";
@@ -121,9 +123,8 @@ TEST_F(AssetManagerTest, ReloadingAssetIfChangedDoesNotCreateFileWithNewUUID) {
   EXPECT_EQ(engineUuidBefore, engineUuidAfter);
 }
 
-TEST_F(
-    AssetManagerTest,
-    ValidateAndPreloadDoesNotCreateFileWithNewUUIDIfFileContentsHaveChanged) {
+TEST_F(AssetManagerTest,
+       SyncDoesNotCreateFileWithNewUUIDIfFileContentsHaveChanged) {
   fs::create_directories(InnerPathInAssets);
 
   auto animatorPath = InnerPathInAssets / "test.animator";
@@ -138,22 +139,21 @@ TEST_F(
       (manager.getCache().getAssetsPath() / engineUuidBefore.toString())
           .replace_extension("asset"));
 
-  manager.validateAndPreloadAssets(renderStorage);
+  manager.syncAssets();
 
   auto engineUuidAfter = manager.findRootAssetUuid(sourcePath);
   EXPECT_TRUE(engineUuidAfter.isValid());
   EXPECT_EQ(engineUuidBefore, engineUuidAfter);
 }
 
-TEST_F(AssetManagerTest,
-       ValidateAndPreloadDeletesCacheFileIfAssetFileDoesNotExist) {
+TEST_F(AssetManagerTest, SyncDeletesCacheFileIfAssetFileDoesNotExist) {
   auto texturePath = CachePath / "test.asset";
 
   createEmptyFile(texturePath);
 
   EXPECT_TRUE(fs::exists(texturePath));
 
-  manager.validateAndPreloadAssets(renderStorage);
+  manager.syncAssets();
 
   EXPECT_FALSE(fs::exists(texturePath));
 }

--- a/engine/src/quoll/asset/AssetCache.cpp
+++ b/engine/src/quoll/asset/AssetCache.cpp
@@ -14,29 +14,6 @@ AssetCache::AssetCache(const Path &assetsPath, bool createDefaultObjects)
   }
 }
 
-Result<void> AssetCache::preloadAssets() {
-  QUOLL_PROFILE_EVENT("AssetCache::preloadAssets");
-  std::vector<String> warnings;
-
-  for (const auto &entry :
-       std::filesystem::recursive_directory_iterator(mAssetsPath)) {
-    if (!entry.is_regular_file() || entry.path().extension() == ".assetmeta") {
-      continue;
-    }
-
-    auto res = loadAsset(entry.path());
-
-    if (!res) {
-      warnings.push_back(res.error());
-    } else {
-      warnings.insert(warnings.end(), res.warnings().begin(),
-                      res.warnings().end());
-    }
-  }
-
-  return {warnings};
-}
-
 AssetMeta AssetCache::getAssetMeta(const Uuid &uuid) const {
   AssetMeta meta{};
   auto typePath =

--- a/engine/src/quoll/asset/AssetCache.h
+++ b/engine/src/quoll/asset/AssetCache.h
@@ -182,8 +182,6 @@ public:
 
   inline const Path &getAssetsPath() const { return mAssetsPath; }
 
-  Result<void> preloadAssets();
-
   AssetMeta getAssetMeta(const Uuid &uuid) const;
 
   Path getPathFromUuid(const Uuid &uuid) const;

--- a/runtime/src/runtime/Runtime.cpp
+++ b/runtime/src/runtime/Runtime.cpp
@@ -63,8 +63,6 @@ void Runtime::start() {
   SceneRenderer sceneRenderer(assetCache.getRegistry(), renderStorage,
                               rendererAssetRegistry);
 
-  auto res = assetCache.preloadAssets();
-
   FPSCounter fpsCounter;
   MainLoop mainLoop(window, fpsCounter);
 


### PR DESCRIPTION
- Use UUIDs and metadata to get asset type and preview from Asset browser
- Allow checking contents of any complex asset from asset browser
- Remove preload methods from asset manager
- Rename reload asset method to sync assets in asset manager
- Fix error when creating a new project that was caused by scene not being available