### PR TITLE
Separate skeleton instance from skeleton asset components

### DIFF
--- a/editor/src/quoll/editor/actions/EntitySkeletonActions.cpp
+++ b/editor/src/quoll/editor/actions/EntitySkeletonActions.cpp
@@ -31,7 +31,7 @@ EntityToggleSkeletonDebugBones::onExecute(WorkspaceState &state,
 
   scene.entityDatabase.set(mEntity, skeletonDebug);
 
-  return ActionExecutorResult();
+  return {};
 }
 
 bool EntityToggleSkeletonDebugBones::predicate(WorkspaceState &state,
@@ -47,9 +47,16 @@ ActionExecutorResult EntityDeleteSkeleton::onExecute(WorkspaceState &state,
                                                      AssetCache &assetCache) {
   auto &scene = state.scene;
 
-  mOldComponent = scene.entityDatabase.get<Skeleton>(mEntity);
+  mOldComponent = scene.entityDatabase.get<SkeletonAssetRef>(mEntity);
 
-  scene.entityDatabase.remove<Skeleton>(mEntity);
+  if (scene.entityDatabase.has<Skeleton>(mEntity)) {
+    scene.entityDatabase.remove<Skeleton>(mEntity);
+  }
+
+  if (scene.entityDatabase.has<SkeletonCurrentAsset>(mEntity)) {
+    scene.entityDatabase.remove<SkeletonCurrentAsset>(mEntity);
+  }
+  scene.entityDatabase.remove<SkeletonAssetRef>(mEntity);
 
   if (scene.entityDatabase.has<SkeletonDebug>(mEntity)) {
     mOldSkeletonDebug = scene.entityDatabase.get<SkeletonDebug>(mEntity);
@@ -80,7 +87,7 @@ bool EntityDeleteSkeleton::predicate(WorkspaceState &state,
                                      AssetCache &assetCache) {
   auto &scene = state.scene;
 
-  return scene.entityDatabase.has<Skeleton>(mEntity);
+  return scene.entityDatabase.has<SkeletonAssetRef>(mEntity);
 }
 
 } // namespace quoll::editor

--- a/editor/src/quoll/editor/actions/EntitySkeletonActions.h
+++ b/editor/src/quoll/editor/actions/EntitySkeletonActions.h
@@ -32,7 +32,7 @@ public:
 
 private:
   Entity mEntity;
-  Skeleton mOldComponent;
+  SkeletonAssetRef mOldComponent;
   std::optional<SkeletonDebug> mOldSkeletonDebug;
 };
 

--- a/editor/src/quoll/editor/scene/ui/SceneHierarchyPanel.cpp
+++ b/editor/src/quoll/editor/scene/ui/SceneHierarchyPanel.cpp
@@ -49,7 +49,7 @@ static String getNodeName(const String &name, Entity entity,
     return getNameAndIcon(name, fa::Font);
   }
 
-  if (entityDatabase.has<Skeleton>(entity)) {
+  if (entityDatabase.has<SkeletonAssetRef>(entity)) {
     return getNameAndIcon(name, fa::Bone);
   }
 

--- a/engine/src/quoll/asset/AssetRef.h
+++ b/engine/src/quoll/asset/AssetRef.h
@@ -62,7 +62,7 @@ public:
     }
   }
 
-  constexpr operator bool() const { return mHandle; }
+  constexpr operator bool() const { return mHandle && mMap->hasData(mHandle); }
   constexpr const TAssetData *operator->() const { return &get(); }
 
   constexpr const TAssetData &get() const {

--- a/engine/src/quoll/entity/EntityDatabase.cpp
+++ b/engine/src/quoll/entity/EntityDatabase.cpp
@@ -65,8 +65,10 @@ EntityDatabase::EntityDatabase() {
   reg<AudioStart>();
   reg<AudioStatus>();
   reg<Skeleton>();
-  reg<JointAttachment>();
+  reg<SkeletonAssetRef>();
+  reg<SkeletonCurrentAsset>();
   reg<SkeletonDebug>();
+  reg<JointAttachment>();
   reg<RigidBody>();
   reg<Collidable>();
   reg<PhysxInstance>();

--- a/engine/src/quoll/entity/EntitySpawner.cpp
+++ b/engine/src/quoll/entity/EntitySpawner.cpp
@@ -131,29 +131,7 @@ std::vector<Entity> EntitySpawner::spawnPrefab(AssetRef<PrefabAsset> prefab,
 
     usize numJoints = asset.jointLocalPositions.size();
 
-    Skeleton skeleton{};
-    skeleton.asset = pSkeleton.value;
-    skeleton.numJoints = static_cast<u32>(numJoints);
-    skeleton.jointNames.resize(numJoints);
-    skeleton.jointParents.resize(numJoints);
-    skeleton.jointLocalPositions.resize(numJoints);
-    skeleton.jointLocalRotations.resize(numJoints);
-    skeleton.jointLocalScales.resize(numJoints);
-    skeleton.jointInverseBindMatrices.resize(numJoints);
-    skeleton.jointWorldTransforms.resize(numJoints, glm::mat4{1.0f});
-    skeleton.jointFinalTransforms.resize(numJoints, glm::mat4{1.0f});
-
-    for (usize i = 0; i < numJoints; ++i) {
-      skeleton.jointNames.at(i) = asset.jointNames.at(i);
-      skeleton.jointParents.at(i) = asset.jointParents.at(i);
-      skeleton.jointLocalPositions.at(i) = asset.jointLocalPositions.at(i);
-      skeleton.jointLocalRotations.at(i) = asset.jointLocalRotations.at(i);
-      skeleton.jointLocalScales.at(i) = asset.jointLocalScales.at(i);
-      skeleton.jointInverseBindMatrices.at(i) =
-          asset.jointInverseBindMatrices.at(i);
-    }
-
-    mEntityDatabase.set(entity, skeleton);
+    mEntityDatabase.set(entity, SkeletonAssetRef{pSkeleton.value});
   }
 
   for (auto &item : asset.animators) {

--- a/engine/src/quoll/skeleton/Skeleton.h
+++ b/engine/src/quoll/skeleton/Skeleton.h
@@ -6,6 +6,14 @@
 
 namespace quoll {
 
+struct SkeletonAssetRef {
+  AssetRef<SkeletonAsset> asset;
+};
+
+struct SkeletonCurrentAsset {
+  AssetHandle<SkeletonAsset> handle;
+};
+
 struct Skeleton {
   u32 numJoints = 0;
 
@@ -24,8 +32,6 @@ struct Skeleton {
   std::vector<glm::mat4> jointFinalTransforms;
 
   std::vector<String> jointNames;
-
-  AssetRef<SkeletonAsset> asset;
 };
 
 struct SkeletonDebug {

--- a/engine/src/quoll/skeleton/SkeletonSerializer.cpp
+++ b/engine/src/quoll/skeleton/SkeletonSerializer.cpp
@@ -7,8 +7,8 @@ namespace quoll {
 void SkeletonSerializer::serialize(YAML::Node &node,
                                    EntityDatabase &entityDatabase,
                                    Entity entity) {
-  if (entityDatabase.has<Skeleton>(entity)) {
-    const auto &asset = entityDatabase.get<Skeleton>(entity).asset;
+  if (entityDatabase.has<SkeletonAssetRef>(entity)) {
+    const auto &asset = entityDatabase.get<SkeletonAssetRef>(entity).asset;
     if (asset) {
       node["skeleton"] = asset.meta().uuid;
     }
@@ -23,24 +23,7 @@ void SkeletonSerializer::deserialize(const YAML::Node &node,
 
     auto res = assetCache.request<SkeletonAsset>(uuid);
     if (res) {
-      const auto &skeleton = res.data().get();
-      Skeleton skeletonComponent{};
-      skeletonComponent.asset = res.data();
-      skeletonComponent.jointLocalPositions = skeleton.jointLocalPositions;
-      skeletonComponent.jointLocalRotations = skeleton.jointLocalRotations;
-      skeletonComponent.jointLocalScales = skeleton.jointLocalScales;
-      skeletonComponent.jointParents = skeleton.jointParents;
-      skeletonComponent.jointInverseBindMatrices =
-          skeleton.jointInverseBindMatrices;
-      skeletonComponent.jointNames = skeleton.jointNames;
-      skeletonComponent.numJoints =
-          static_cast<u32>(skeleton.jointLocalPositions.size());
-      skeletonComponent.jointFinalTransforms.resize(skeletonComponent.numJoints,
-                                                    glm::mat4{1.0f});
-      skeletonComponent.jointWorldTransforms.resize(skeletonComponent.numJoints,
-                                                    glm::mat4{1.0f});
-
-      entityDatabase.set(entity, skeletonComponent);
+      entityDatabase.set(entity, SkeletonAssetRef{res.data()});
     }
   }
 }

--- a/engine/src/quoll/skeleton/SkeletonUpdater.h
+++ b/engine/src/quoll/skeleton/SkeletonUpdater.h
@@ -7,11 +7,6 @@ struct SystemView;
 class SkeletonUpdater {
 public:
   void update(SystemView &view);
-
-private:
-  void updateSkeletons(SystemView &view);
-
-  void updateDebugBones(SystemView &view);
 };
 
 } // namespace quoll

--- a/engine/tests/quoll-tests/asset/AssetRef.test.cpp
+++ b/engine/tests/quoll-tests/asset/AssetRef.test.cpp
@@ -37,6 +37,13 @@ TEST_F(AssetRefTest, DefaultConstructorSetsHandleToNull) {
   EXPECT_FALSE(ref);
   EXPECT_EQ(ref.handle(), quoll::AssetHandle<Data>());
 }
+
+TEST_F(AssetRefTest, ValidReturnsFalseIfAssetIsAllocatedButIsEmpty) {
+  auto handle = map.allocate({.uuid = quoll::Uuid::generate()});
+  quoll::AssetRef<Data> ref(map, handle);
+  EXPECT_FALSE(ref);
+}
+
 TEST_F(AssetRefTest, ConstructorIncrementsRefCount) {
   auto handle = allocateAndStore({});
 

--- a/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
@@ -305,7 +305,7 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   for (u32 i = 2; i < 5; ++i) {
     auto entity = res.at(i);
 
-    const auto &skeleton = db.get<quoll::Skeleton>(entity);
+    const auto &skeleton = db.get<quoll::SkeletonAssetRef>(entity);
 
     // Skeletons vector only has three items
     EXPECT_EQ(skeleton.asset, asset.data.skeletons.at(i - 2).value);

--- a/engine/tests/quoll-tests/io/EntitySerializer.test.cpp
+++ b/engine/tests/quoll-tests/io/EntitySerializer.test.cpp
@@ -334,20 +334,20 @@ TEST_F(EntitySerializerTest,
 }
 
 TEST_F(EntitySerializerTest,
-       DoesNotCreateSkeletonFieldIfSkeletonAssetIsNotInRegistry) {
+       DoesNotCreateSkeletonFieldIfSkeletonAssetDoesNotExist) {
   auto entity = entityDatabase.create();
-  quoll::Skeleton component{};
+  quoll::SkeletonAssetRef component{};
   entityDatabase.set(entity, component);
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_FALSE(node["skeleton"]);
 }
 
-TEST_F(EntitySerializerTest, CreatesSkeletonFieldIfSkeletonAssetIsInRegistry) {
+TEST_F(EntitySerializerTest, CreatesSkeletonFieldIfSkeletonAssetExists) {
   auto skeleton = createAsset<quoll::SkeletonAsset>();
 
   auto entity = entityDatabase.create();
-  quoll::Skeleton component{};
+  quoll::SkeletonAssetRef component{};
   component.asset = skeleton;
 
   entityDatabase.set(entity, component);

--- a/engine/tests/quoll-tests/io/SceneLoader.test.cpp
+++ b/engine/tests/quoll-tests/io/SceneLoader.test.cpp
@@ -516,7 +516,7 @@ TEST_F(SceneLoaderSkeletonTest,
   auto [node, entity] = createNode();
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
-  EXPECT_FALSE(entityDatabase.has<quoll::Skeleton>(entity));
+  EXPECT_FALSE(entityDatabase.has<quoll::SkeletonAssetRef>(entity));
 }
 
 TEST_F(SceneLoaderSkeletonTest,
@@ -530,7 +530,7 @@ TEST_F(SceneLoaderSkeletonTest,
     auto [node, entity] = createNode();
     node["skeleton"] = invalidNode;
     sceneLoader.loadComponents(node, entity, entityIdCache);
-    EXPECT_FALSE(entityDatabase.has<quoll::Skeleton>(entity));
+    EXPECT_FALSE(entityDatabase.has<quoll::SkeletonAssetRef>(entity));
   }
 }
 
@@ -540,7 +540,7 @@ TEST_F(SceneLoaderSkeletonTest,
   node["skeleton"] = "bye";
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
-  EXPECT_FALSE(entityDatabase.has<quoll::Skeleton>(entity));
+  EXPECT_FALSE(entityDatabase.has<quoll::SkeletonAssetRef>(entity));
 }
 
 TEST_F(SceneLoaderSkeletonTest,
@@ -566,28 +566,10 @@ TEST_F(SceneLoaderSkeletonTest,
   node["skeleton"] = asset.meta().uuid;
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
-  ASSERT_TRUE(entityDatabase.has<quoll::Skeleton>(entity));
+  ASSERT_TRUE(entityDatabase.has<quoll::SkeletonAssetRef>(entity));
 
-  const auto &skeleton = entityDatabase.get<quoll::Skeleton>(entity);
+  const auto &skeleton = entityDatabase.get<quoll::SkeletonAssetRef>(entity);
   EXPECT_EQ(skeleton.asset, asset.handle());
-
-  EXPECT_EQ(skeleton.numJoints, NumJoints);
-  for (u32 i = 0; i < NumJoints; ++i) {
-    f32 fi = static_cast<f32>(i);
-
-    EXPECT_EQ(skeleton.jointLocalPositions.at(i),
-              asset->jointLocalPositions.at(i));
-    EXPECT_EQ(skeleton.jointLocalRotations.at(i),
-              asset->jointLocalRotations.at(i));
-    EXPECT_EQ(skeleton.jointLocalScales.at(i), asset->jointLocalScales.at(i));
-    EXPECT_EQ(skeleton.jointParents.at(i), asset->jointParents.at(i));
-    EXPECT_EQ(skeleton.jointInverseBindMatrices.at(i),
-              asset->jointInverseBindMatrices.at(i));
-    EXPECT_EQ(skeleton.jointNames.at(i), asset->jointNames.at(i));
-
-    EXPECT_EQ(skeleton.jointFinalTransforms.at(i), glm::mat4{1.0f});
-    EXPECT_EQ(skeleton.jointWorldTransforms.at(i), glm::mat4{1.0f});
-  }
 }
 
 using SceneLoaderJointAttachmentTest = SceneLoaderTest;
@@ -610,7 +592,7 @@ TEST_F(SceneLoaderJointAttachmentTest,
     auto [node, entity] = createNode();
     node["jointAttachment"] = invalidNode;
     sceneLoader.loadComponents(node, entity, entityIdCache);
-    EXPECT_FALSE(entityDatabase.has<quoll::Skeleton>(entity));
+    EXPECT_FALSE(entityDatabase.has<quoll::SkeletonAssetRef>(entity));
   }
 }
 

--- a/engine/tests/quoll-tests/test-utils/AssetCacheUtils.h
+++ b/engine/tests/quoll-tests/test-utils/AssetCacheUtils.h
@@ -3,6 +3,20 @@
 #include "quoll/asset/AssetCache.h"
 
 template <typename TAssetData>
+quoll::AssetRef<TAssetData>
+createAssetInCacheWithoutData(quoll::AssetCache &cache,
+                              quoll::String name = "") {
+  quoll::AssetMeta meta{};
+  meta.type = quoll::AssetCache::getAssetType<TAssetData>();
+  meta.uuid = quoll::Uuid::generate();
+  meta.name = name;
+
+  auto handle = cache.getRegistry().allocate<TAssetData>(meta);
+
+  return cache.request<TAssetData>(meta.uuid).data();
+}
+
+template <typename TAssetData>
 quoll::AssetRef<TAssetData> createAssetInCache(quoll::AssetCache &cache,
                                                TAssetData data = {},
                                                quoll::String name = "") {


### PR DESCRIPTION
- Create skeleton asset ref component
- Create skeleton instances from assets in skeleton system
- Use the skeleton asset ref component as the main source of truth when creating/deleting skeletons
- Allow adding skeletons to entities from editor
- Reference count assets that have no data
- Check if asset data is loaded in asset ref boolean operator