### PR TITLE
Allow creating empty audio, sprite, and mesh components

### DIFF
--- a/editor/src/quoll/editor/scene/renderer/EditorRenderer.cpp
+++ b/editor/src/quoll/editor/scene/renderer/EditorRenderer.cpp
@@ -496,34 +496,39 @@ void EditorRenderer::updateFrameData(EntityDatabase &entityDatabase,
 
   if (entityDatabase.exists(state.selectedEntity)) {
     if (entityDatabase.has<Sprite>(state.selectedEntity)) {
-      const auto &world =
-          entityDatabase.get<WorldTransform>(state.selectedEntity);
-      frameData.addSpriteOutline(world.worldTransform);
+      const auto &asset =
+          entityDatabase.get<Sprite>(state.selectedEntity).texture;
+
+      if (asset) {
+        const auto &world =
+            entityDatabase.get<WorldTransform>(state.selectedEntity);
+        frameData.addSpriteOutline(world.worldTransform);
+      }
     } else if (entityDatabase.has<Mesh>(state.selectedEntity) &&
                entityDatabase.has<MeshRenderer>(state.selectedEntity)) {
       const auto &asset = entityDatabase.get<Mesh>(state.selectedEntity).asset;
 
-      const auto &world =
-          entityDatabase.get<WorldTransform>(state.selectedEntity);
-
-      const auto &meshDrawData = mRendererAssetRegistry.get(asset);
-
-      frameData.addMeshOutline(meshDrawData, world.worldTransform);
+      if (asset) {
+        const auto &world =
+            entityDatabase.get<WorldTransform>(state.selectedEntity);
+        const auto &meshDrawData = mRendererAssetRegistry.get(asset);
+        frameData.addMeshOutline(meshDrawData, world.worldTransform);
+      }
     } else if (entityDatabase.has<Mesh>(state.selectedEntity) &&
                entityDatabase.has<SkinnedMeshRenderer>(state.selectedEntity) &&
                entityDatabase.has<Skeleton>(state.selectedEntity)) {
       const auto &asset = entityDatabase.get<Mesh>(state.selectedEntity).asset;
 
-      const auto &world =
-          entityDatabase.get<WorldTransform>(state.selectedEntity);
-
-      const auto &skeleton = entityDatabase.get<Skeleton>(state.selectedEntity)
-                                 .jointFinalTransforms;
-
-      const auto &meshDrawData = mRendererAssetRegistry.get(asset);
-
-      frameData.addSkinnedMeshOutline(meshDrawData, skeleton,
-                                      world.worldTransform);
+      if (asset) {
+        const auto &world =
+            entityDatabase.get<WorldTransform>(state.selectedEntity);
+        const auto &skeleton =
+            entityDatabase.get<Skeleton>(state.selectedEntity)
+                .jointFinalTransforms;
+        const auto &meshDrawData = mRendererAssetRegistry.get(asset);
+        frameData.addSkinnedMeshOutline(meshDrawData, skeleton,
+                                        world.worldTransform);
+      }
     } else if (entityDatabase.has<Text>(state.selectedEntity)) {
       const auto &text = entityDatabase.get<Text>(state.selectedEntity);
       const auto &font = text.font.get();

--- a/engine/src/quoll/audio/AudioSystem.h
+++ b/engine/src/quoll/audio/AudioSystem.h
@@ -49,6 +49,10 @@ public:
       QUOLL_PROFILE_EVENT("Start audios");
       for (auto [entity, source, play] :
            entityDatabase.view<AudioSource, AudioStart>()) {
+        if (!source.asset) {
+          continue;
+        }
+
         if (entityDatabase.has<AudioStatus>(entity)) {
           continue;
         }

--- a/engine/src/quoll/renderer/SceneRenderer.cpp
+++ b/engine/src/quoll/renderer/SceneRenderer.cpp
@@ -785,13 +785,18 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
 
   for (auto [entity, sprite, world] :
        entityDatabase.view<Sprite, WorldTransform>()) {
-    auto handle = mRendererAssetRegistry.get(sprite.texture);
-    frameData.addSprite(entity, handle, world.worldTransform);
+    if (sprite.texture) {
+      auto handle = mRendererAssetRegistry.get(sprite.texture);
+      frameData.addSprite(entity, handle, world.worldTransform);
+    }
   }
 
   // Meshes
   for (auto [entity, world, mesh, renderer] :
        entityDatabase.view<WorldTransform, Mesh, MeshRenderer>()) {
+    if (!mesh.asset)
+      continue;
+
     std::vector<rhi::DeviceAddress> materials;
     for (auto material : renderer.materials) {
       materials.push_back(mRendererAssetRegistry.get(material)->getAddress());
@@ -806,6 +811,9 @@ void SceneRenderer::updateFrameData(EntityDatabase &entityDatabase,
   for (auto [entity, skeleton, world, mesh, renderer] :
        entityDatabase
            .view<Skeleton, WorldTransform, Mesh, SkinnedMeshRenderer>()) {
+    if (!mesh.asset)
+      continue;
+
     std::vector<rhi::DeviceAddress> materials;
     for (const auto &material : renderer.materials) {
       materials.push_back(mRendererAssetRegistry.get(material)->getAddress());

--- a/engine/tests/quoll-tests/audio/AudioSystem.test.cpp
+++ b/engine/tests/quoll-tests/audio/AudioSystem.test.cpp
@@ -83,13 +83,24 @@ TEST_F(AudioSystemTest,
   EXPECT_FALSE(entityDatabase.has<quoll::AudioStatus>(e1));
 }
 
+TEST_F(AudioSystemTest, DoesNothingIfAudioSourceAssetHasNoData) {
+  auto ref = createAssetInCacheWithoutData<quoll::AudioAsset>(assetCache);
+  auto e1 = entityDatabase.create();
+
+  entityDatabase.set<quoll::AudioSource>(e1, {ref});
+  entityDatabase.set<quoll::AudioStart>(e1, {});
+  audioSystem.output(view);
+
+  EXPECT_FALSE(entityDatabase.has<quoll::AudioStatus>(e1));
+}
+
 TEST_F(AudioSystemTest,
        DoesNothingIfThereAreNoEntitiesWithAudioStartComponents) {
-  auto handle = createFakeAudio();
+  auto ref = createFakeAudio();
 
   auto e1 = entityDatabase.create();
 
-  entityDatabase.set<quoll::AudioSource>(e1, {handle});
+  entityDatabase.set<quoll::AudioSource>(e1, {ref});
   audioSystem.output(view);
 
   EXPECT_FALSE(entityDatabase.has<quoll::AudioStatus>(e1));


### PR DESCRIPTION
- Remove audio, sprite, and mesh from the drag and drop
- Add drag and drop to each component section
- Do not start audio if asset is not loaded
- Do not render mesh if asset is not loaded
- Do not render sprite if asset is not loaded