### PR TITLE
Separate animator from animator asset

### DIFF
--- a/editor/src/quoll/editor/scene/ui/EntityPanel.h
+++ b/editor/src/quoll/editor/scene/ui/EntityPanel.h
@@ -55,8 +55,8 @@ private:
   void renderSkinnedMeshRenderer(Scene &scene, AssetCache &assetCache,
                                  ActionExecutor &actionExecutor);
 
-  void renderAnimation(WorkspaceState &state, Scene &scene,
-                       AssetCache &assetCache, ActionExecutor &actionExecutor);
+  void renderAnimator(WorkspaceState &state, Scene &scene,
+                      AssetCache &assetCache, ActionExecutor &actionExecutor);
 
   void renderSkeleton(Scene &scene, AssetCache &assetCache,
                       ActionExecutor &actionExecutor);

--- a/editor/tests/quoll/editor-tests/actions/EntityDeleteComponentAction.test.cpp
+++ b/editor/tests/quoll/editor-tests/actions/EntityDeleteComponentAction.test.cpp
@@ -1,5 +1,7 @@
 #include "quoll/core/Base.h"
+#include "quoll/core/Id.h"
 #include "quoll/core/Name.h"
+#include "quoll/scene/LocalTransform.h"
 #include "quoll/editor/actions/EntityDeleteComponentAction.h"
 #include "quoll-tests/Testing.h"
 #include "ActionTestBase.h"
@@ -16,11 +18,38 @@ TEST_F(EntityDeleteComponentActionTest,
 }
 
 TEST_F(EntityDeleteComponentActionTest,
+       PredicateReturnsTrueIfEntityHasProvidedComponentButNoOtherComponents) {
+  auto entity = state.scene.entityDatabase.create();
+  state.scene.entityDatabase.set<quoll::Name>(entity, {"Hello"});
+  quoll::editor::EntityDeleteComponent<quoll::Name, quoll::Id> action(entity);
+
+  EXPECT_TRUE(action.predicate(state, assetCache));
+}
+
+TEST_F(EntityDeleteComponentActionTest,
        PredicateReturnsFalseIfEntityDoesNotHaveProvidedComponent) {
   auto entity = state.scene.entityDatabase.create();
   quoll::editor::EntityDeleteComponent<quoll::Name> action(entity);
 
   EXPECT_FALSE(action.predicate(state, assetCache));
+}
+
+TEST_F(
+    EntityDeleteComponentActionTest,
+    PredicateReturnsFalseIfEntityDoesNotHaveProvidedComponentButHasOtherComponents) {
+  auto entity = state.scene.entityDatabase.create();
+  state.scene.entityDatabase.set<quoll::Id>(entity, {});
+  quoll::editor::EntityDeleteComponent<quoll::Name, quoll::Id> action(entity);
+
+  EXPECT_FALSE(action.predicate(state, assetCache));
+}
+
+TEST_F(EntityDeleteComponentActionTest, PredicateReturnsFalse) {
+  auto entity = state.scene.entityDatabase.create();
+  state.scene.entityDatabase.set<quoll::Name>(entity, {"Hello"});
+  quoll::editor::EntityDeleteComponent<quoll::Name, quoll::Id> action(entity);
+
+  EXPECT_TRUE(action.predicate(state, assetCache));
 }
 
 TEST_F(EntityDeleteComponentActionTest, ExecutorDeletesComponentFromEntity) {
@@ -35,6 +64,28 @@ TEST_F(EntityDeleteComponentActionTest, ExecutorDeletesComponentFromEntity) {
   EXPECT_EQ(res.entitiesToSave.size(), 1);
   EXPECT_EQ(res.entitiesToSave.at(0), entity);
   EXPECT_FALSE(state.scene.entityDatabase.has<quoll::Name>(entity));
+}
+
+TEST_F(EntityDeleteComponentActionTest,
+       ExecutorDeletesOtherComponentsFromEntity) {
+  state.scene.entityDatabase.create();
+
+  auto entity = state.scene.entityDatabase.create();
+  state.scene.entityDatabase.set<quoll::Name>(entity, {"Hello"});
+  state.scene.entityDatabase.set<quoll::Id>(entity, {});
+  state.scene.entityDatabase.set<quoll::LocalTransform>(entity, {});
+
+  quoll::editor::EntityDeleteComponent<quoll::Name, quoll::Id,
+                                       quoll::LocalTransform>
+      action(entity);
+
+  auto res = action.onExecute(state, assetCache);
+  EXPECT_TRUE(res.addToHistory);
+  EXPECT_EQ(res.entitiesToSave.size(), 1);
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_FALSE(state.scene.entityDatabase.has<quoll::Name>(entity));
+  EXPECT_FALSE(state.scene.entityDatabase.has<quoll::Id>(entity));
+  EXPECT_FALSE(state.scene.entityDatabase.has<quoll::LocalTransform>(entity));
 }
 
 TEST_F(EntityDeleteComponentActionTest, UndoAddsPreviousComponentToEntity) {
@@ -52,4 +103,30 @@ TEST_F(EntityDeleteComponentActionTest, UndoAddsPreviousComponentToEntity) {
   EXPECT_EQ(res.entitiesToSave.at(0), entity);
   EXPECT_TRUE(state.scene.entityDatabase.has<quoll::Name>(entity));
   EXPECT_EQ(state.scene.entityDatabase.get<quoll::Name>(entity).name, "Hello");
+}
+
+TEST_F(EntityDeleteComponentActionTest,
+       UndoDoesNotAddPreviousOtherComponentsToEntity) {
+  state.scene.entityDatabase.create();
+
+  auto entity = state.scene.entityDatabase.create();
+  state.scene.entityDatabase.set<quoll::Name>(entity, {"Hello"});
+  state.scene.entityDatabase.set<quoll::Id>(entity, {});
+  state.scene.entityDatabase.set<quoll::LocalTransform>(entity, {});
+  quoll::editor::EntityDeleteComponent<quoll::Name, quoll::Id,
+                                       quoll::LocalTransform>
+      action(entity);
+
+  action.onExecute(state, assetCache);
+  EXPECT_FALSE(state.scene.entityDatabase.has<quoll::Name>(entity));
+  EXPECT_FALSE(state.scene.entityDatabase.has<quoll::Id>(entity));
+  EXPECT_FALSE(state.scene.entityDatabase.has<quoll::LocalTransform>(entity));
+
+  auto res = action.onUndo(state, assetCache);
+  EXPECT_EQ(res.entitiesToSave.size(), 1);
+  EXPECT_EQ(res.entitiesToSave.at(0), entity);
+  EXPECT_TRUE(state.scene.entityDatabase.has<quoll::Name>(entity));
+  EXPECT_EQ(state.scene.entityDatabase.get<quoll::Name>(entity).name, "Hello");
+  EXPECT_FALSE(state.scene.entityDatabase.has<quoll::Id>(entity));
+  EXPECT_FALSE(state.scene.entityDatabase.has<quoll::LocalTransform>(entity));
 }

--- a/engine/src/quoll/animation/Animator.h
+++ b/engine/src/quoll/animation/Animator.h
@@ -5,14 +5,14 @@
 
 namespace quoll {
 
-/**
- * Animator component that handles
- * entity specific state machine
- * for controlling animations
- *
- * The animator works with normalized time
- * in range of [0.0, 1.0].
- */
+struct AnimatorAssetRef {
+  AssetRef<AnimatorAsset> asset;
+};
+
+struct AnimatorCurrentAsset {
+  AssetHandle<AnimatorAsset> handle;
+};
+
 struct Animator {
   AssetRef<AnimatorAsset> asset;
 

--- a/engine/src/quoll/animation/AnimatorLuaTable.cpp
+++ b/engine/src/quoll/animation/AnimatorLuaTable.cpp
@@ -40,6 +40,14 @@ void AnimatorLuaTable::trigger(String event) {
 }
 
 void AnimatorLuaTable::deleteThis() {
+  if (mScriptGlobals.entityDatabase.has<AnimatorAssetRef>(mEntity)) {
+    mScriptGlobals.entityDatabase.remove<AnimatorAssetRef>(mEntity);
+  }
+
+  if (mScriptGlobals.entityDatabase.has<AnimatorCurrentAsset>(mEntity)) {
+    mScriptGlobals.entityDatabase.remove<AnimatorCurrentAsset>(mEntity);
+  }
+
   if (mScriptGlobals.entityDatabase.has<Animator>(mEntity)) {
     mScriptGlobals.entityDatabase.remove<Animator>(mEntity);
   }

--- a/engine/src/quoll/animation/AnimatorSerializer.cpp
+++ b/engine/src/quoll/animation/AnimatorSerializer.cpp
@@ -6,10 +6,10 @@ namespace quoll {
 void AnimatorSerializer::serialize(YAML::Node &node,
                                    EntityDatabase &entityDatabase,
                                    Entity entity) {
-  if (entityDatabase.has<Animator>(entity)) {
-    const auto &asset = entityDatabase.get<Animator>(entity).asset;
+  if (entityDatabase.has<AnimatorAssetRef>(entity)) {
+    const auto &asset = entityDatabase.get<AnimatorAssetRef>(entity).asset;
 
-    if (asset) {
+    if (asset.valid()) {
       node["animator"]["asset"] = asset.meta().uuid;
     }
   }
@@ -21,12 +21,10 @@ void AnimatorSerializer::deserialize(const YAML::Node &node,
   if (node["animator"] && node["animator"].IsMap() &&
       node["animator"]["asset"]) {
     auto uuid = node["animator"]["asset"].as<Uuid>(Uuid{});
-    auto asset = assetCache.request<AnimatorAsset>(uuid);
+    auto ref = assetCache.request<AnimatorAsset>(uuid);
 
-    if (asset) {
-      Animator animator;
-      animator.asset = asset;
-      entityDatabase.set(entity, animator);
+    if (ref) {
+      entityDatabase.set(entity, AnimatorAssetRef{ref});
     }
   }
 }

--- a/engine/src/quoll/asset/AssetRef.h
+++ b/engine/src/quoll/asset/AssetRef.h
@@ -77,6 +77,8 @@ public:
 
   constexpr const AssetHandle<TAssetData> &handle() const { return mHandle; }
 
+  constexpr bool valid() const { return mHandle; }
+
 private:
   AssetHandle<TAssetData> mHandle;
   AssetMap<TAssetData> *mMap = nullptr;

--- a/engine/src/quoll/entity/EntityDatabase.cpp
+++ b/engine/src/quoll/entity/EntityDatabase.cpp
@@ -61,6 +61,8 @@ EntityDatabase::EntityDatabase() {
   reg<EnvironmentLightingSkyboxSource>();
   reg<Animator>();
   reg<AnimatorEvent>();
+  reg<AnimatorAssetRef>();
+  reg<AnimatorCurrentAsset>();
   reg<AudioSource>();
   reg<AudioStart>();
   reg<AudioStatus>();

--- a/engine/src/quoll/entity/EntitySpawner.cpp
+++ b/engine/src/quoll/entity/EntitySpawner.cpp
@@ -137,9 +137,7 @@ std::vector<Entity> EntitySpawner::spawnPrefab(AssetRef<PrefabAsset> prefab,
   for (auto &item : asset.animators) {
     auto entity = getOrCreateEntity(item.entity);
 
-    Animator animator{};
-    animator.asset = item.value;
-    animator.currentState = item.value->initialState;
+    AnimatorAssetRef animator{item.value};
     mEntityDatabase.set(entity, animator);
   }
 

--- a/engine/src/quoll/skeleton/SkeletonSerializer.cpp
+++ b/engine/src/quoll/skeleton/SkeletonSerializer.cpp
@@ -9,7 +9,7 @@ void SkeletonSerializer::serialize(YAML::Node &node,
                                    Entity entity) {
   if (entityDatabase.has<SkeletonAssetRef>(entity)) {
     const auto &asset = entityDatabase.get<SkeletonAssetRef>(entity).asset;
-    if (asset) {
+    if (asset.valid()) {
       node["skeleton"] = asset.meta().uuid;
     }
   }

--- a/engine/tests/quoll-tests/Testing.h
+++ b/engine/tests/quoll-tests/Testing.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "quoll/core/Uuid.h"
 #include "quoll/entity/Entity.h"
 
 static const quoll::Path FixturesPath =
@@ -28,6 +29,10 @@ namespace quoll {
 
 static void PrintTo(Entity entity, std::ostream *out) {
   *out << static_cast<u32>(entity);
+}
+
+static void PrintTo(const Uuid &uuid, std::ostream *out) {
+  *out << uuid.toString();
 }
 
 } // namespace quoll

--- a/engine/tests/quoll-tests/animation/AnimatorLuaTable.test.cpp
+++ b/engine/tests/quoll-tests/animation/AnimatorLuaTable.test.cpp
@@ -45,10 +45,14 @@ TEST_F(AnimatorLuaTableTest, DeleteDoesNothingIfComponentDoesNotExist) {
   EXPECT_FALSE(entityDatabase.has<quoll::Animator>(entity));
 }
 
-TEST_F(AnimatorLuaTableTest, DeleteRemovesAnimatorSourceComponentFromEntity) {
+TEST_F(AnimatorLuaTableTest, DeleteRemovesAllAnimatorComponentsFromEntity) {
   auto entity = entityDatabase.create();
+  entityDatabase.set<quoll::AnimatorAssetRef>(entity, {});
+  entityDatabase.set<quoll::AnimatorCurrentAsset>(entity, {});
   entityDatabase.set<quoll::Animator>(entity, {});
 
   call(entity, "animatorDelete");
+  EXPECT_FALSE(entityDatabase.has<quoll::AnimatorAssetRef>(entity));
+  EXPECT_FALSE(entityDatabase.has<quoll::AnimatorCurrentAsset>(entity));
   EXPECT_FALSE(entityDatabase.has<quoll::Animator>(entity));
 }

--- a/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
+++ b/engine/tests/quoll-tests/entity/EntitySpawner.test.cpp
@@ -11,6 +11,7 @@
 #include "quoll/scene/WorldTransform.h"
 #include "quoll/skeleton/Skeleton.h"
 #include "quoll-tests/Testing.h"
+#include "quoll-tests/test-utils/AssetCacheUtils.h"
 
 class EntitySpawnerTest : public ::testing::Test {
 public:
@@ -20,15 +21,7 @@ public:
   template <typename TAssetData>
   quoll::AssetRef<TAssetData> createAsset(TAssetData data = {},
                                           quoll::String name = "") {
-    quoll::AssetMeta meta{};
-    meta.type = quoll::AssetCache::getAssetType<TAssetData>();
-    meta.uuid = quoll::Uuid::generate();
-    meta.name = name;
-
-    auto handle = assetCache.getRegistry().allocate<TAssetData>(meta);
-    assetCache.getRegistry().store(handle, data);
-
-    return assetCache.request<TAssetData>(meta.uuid).data();
+    return createAssetInCache(assetCache, data, name);
   }
 
   quoll::AssetCache assetCache;
@@ -314,11 +307,8 @@ TEST_F(EntitySpawnerTest, SpawnPrefabCreatesEntitiesFromPrefab) {
   // Test animators
   for (u32 i = 2; i < 5; ++i) {
     auto entity = res.at(i);
-    const auto &animator = db.get<quoll::Animator>(entity);
+    const auto &animator = db.get<quoll::AnimatorAssetRef>(entity);
     EXPECT_TRUE(animator.asset);
-    EXPECT_EQ(animator.currentState, i);
-    EXPECT_EQ(animator.asset->initialState, animator.currentState);
-    EXPECT_EQ(animator.normalizedTime, 0.0f);
   }
 
   for (u32 i = 1; i < 3; ++i) {

--- a/engine/tests/quoll-tests/io/EntitySerializer.test.cpp
+++ b/engine/tests/quoll-tests/io/EntitySerializer.test.cpp
@@ -387,21 +387,18 @@ TEST_F(EntitySerializerTest, CreatesJointAttachmentFieldWithJointId) {
 
 // Animator
 TEST_F(EntitySerializerTest,
-       DoesNotCreateAnimatorFieldIfAnimatorAssetIsNotInRegistry) {
+       DoesNotCreateAnimatorFieldIfAnimatorAssetIsNotValid) {
   auto entity = entityDatabase.create();
-  quoll::Animator component{};
+  quoll::AnimatorAssetRef component{};
   entityDatabase.set(entity, component);
 
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_FALSE(node["animator"]);
 }
 
-TEST_F(EntitySerializerTest, CreatesAnimatorWithValidAnimations) {
-  auto animator = createAsset<quoll::AnimatorAsset>();
-
-  quoll::Animator component{};
-  component.asset = animator;
-  component.currentState = 0;
+TEST_F(EntitySerializerTest, CreatesAnimatorIfAssetIsValid) {
+  auto asset = createAsset<quoll::AnimatorAsset>();
+  quoll::AnimatorAssetRef component{asset};
 
   auto entity = entityDatabase.create();
   entityDatabase.set(entity, component);
@@ -409,7 +406,7 @@ TEST_F(EntitySerializerTest, CreatesAnimatorWithValidAnimations) {
   auto node = entitySerializer.createComponentsNode(entity);
   EXPECT_TRUE(node["animator"]);
   EXPECT_EQ(node["animator"]["asset"].as<quoll::Uuid>(quoll::Uuid{}),
-            animator.meta().uuid);
+            asset.meta().uuid);
 }
 
 // Directional light

--- a/engine/tests/quoll-tests/io/SceneLoader.test.cpp
+++ b/engine/tests/quoll-tests/io/SceneLoader.test.cpp
@@ -640,7 +640,7 @@ TEST_F(SceneLoaderAnimatorTest,
   auto [node, entity] = createNode();
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
-  EXPECT_FALSE(entityDatabase.has<quoll::Animator>(entity));
+  EXPECT_FALSE(entityDatabase.has<quoll::AnimatorAssetRef>(entity));
 }
 
 TEST_F(SceneLoaderAnimatorTest,
@@ -653,7 +653,7 @@ TEST_F(SceneLoaderAnimatorTest,
     auto [node, entity] = createNode();
     node["animator"] = invalidNode;
     sceneLoader.loadComponents(node, entity, entityIdCache);
-    EXPECT_FALSE(entityDatabase.has<quoll::Animator>(entity));
+    EXPECT_FALSE(entityDatabase.has<quoll::AnimatorAssetRef>(entity));
   }
 }
 
@@ -668,7 +668,7 @@ TEST_F(SceneLoaderAnimatorTest,
     auto [node, entity] = createNode();
     node["animator"]["asset"] = invalidNode;
     sceneLoader.loadComponents(node, entity, entityIdCache);
-    EXPECT_FALSE(entityDatabase.has<quoll::Animator>(entity));
+    EXPECT_FALSE(entityDatabase.has<quoll::AnimatorAssetRef>(entity));
   }
 }
 
@@ -680,12 +680,10 @@ TEST_F(SceneLoaderAnimatorTest, CreatesAnimatorComponentIfAllFieldsAreValid) {
 
   sceneLoader.loadComponents(node, entity, entityIdCache);
 
-  ASSERT_TRUE(entityDatabase.has<quoll::Animator>(entity));
+  ASSERT_TRUE(entityDatabase.has<quoll::AnimatorAssetRef>(entity));
 
-  const auto &component = entityDatabase.get<quoll::Animator>(entity);
+  const auto &component = entityDatabase.get<quoll::AnimatorAssetRef>(entity);
   EXPECT_EQ(component.asset, animator1.handle());
-  EXPECT_EQ(component.currentState, std::numeric_limits<usize>::max());
-  EXPECT_EQ(component.normalizedTime, 0.0f);
 }
 
 using SceneLoaderLightTest = SceneLoaderTest;


### PR DESCRIPTION
- Create animator asset ref and animator current asset components
- Create animator components from animator asset ref component
- Add `valid` checker to asset ref to check if the handle is valid
- Allow passing multiple auxilary components to EntityDeleteComponent
- Modify UI of Animator component in Entity panel
- Remove animator from global drag and drop in entity panel
- Use animator asset ref in entity spawner, serializer, and editor