### PR TITLE
Render box component

### DIFF
--- a/engine/lib/quoll/profiler/ImguiDebugLayer.cpp
+++ b/engine/lib/quoll/profiler/ImguiDebugLayer.cpp
@@ -7,8 +7,16 @@
 
 namespace quoll {
 
-static constexpr auto DemoQui = qui::component([]() -> qui::Element {
-  return qui::Text("Red text").color(qui::Color::Red);
+static constexpr auto DemoQui = qui::component([]() {
+  static const f32 BorderRadius = 5.0f;
+  static const f32 Padding = 5.0f;
+
+  return qui::Box(qui::Text("Red text on a yellow background")
+                      .color(qui::Color::Red))
+      .padding(qui::EdgeInsets(Padding))
+      .background(qui::Color::Yellow)
+      .width(100.0f)
+      .borderRadius(BorderRadius);
 });
 
 ImguiDebugLayer::ImguiDebugLayer(

--- a/engine/lib/quoll/qui/native/Box.h
+++ b/engine/lib/quoll/qui/native/Box.h
@@ -52,7 +52,7 @@ public:
 
 private:
   Value<Element> mChild;
-  Value<Color> mBackground;
+  Value<Color> mBackground{Color::Transparent};
   Value<EdgeInsets> mPadding;
   Value<f32> mWidth{0};
   Value<f32> mHeight{0};

--- a/engine/lib/quoll/qui/native/BoxView.h
+++ b/engine/lib/quoll/qui/native/BoxView.h
@@ -25,14 +25,19 @@ public:
   constexpr f32 getWidth() { return mWidth; }
   constexpr f32 getHeight() { return mHeight; }
   constexpr f32 getBorderRadius() { return mBorderRadius; }
+  constexpr glm::vec2 getPosition() { return mPosition; }
+  constexpr glm::vec2 getSize() { return mSize; }
 
 private:
   View *mChild = nullptr;
-  Color mBackground;
+  Color mBackground{Color::Transparent};
   EdgeInsets mPadding;
   f32 mWidth{0};
   f32 mHeight{0};
   f32 mBorderRadius{0};
+
+  glm::vec2 mPosition;
+  glm::vec2 mSize;
 };
 
 } // namespace qui

--- a/engine/lib/quoll/qui/properties/Color.cpp
+++ b/engine/lib/quoll/qui/properties/Color.cpp
@@ -8,5 +8,7 @@ const Color Color::Black = Color(0.0f, 0.0f, 0.0f, 1.0f);
 const Color Color::Red = Color(1.0f, 0.0f, 0.0f, 1.0f);
 const Color Color::Green = Color(1.0f, 0.0f, 0.0f, 1.0f);
 const Color Color::Blue = Color(1.0f, 0.0f, 0.0f, 1.0f);
+const Color Color::Yellow = Color(1.0f, 1.0f, 0.0f, 1.0f);
+const Color Color::Transparent = Color(0.0f, 0.0f, 0.0f, 0.0f);
 
 } // namespace qui

--- a/engine/lib/quoll/qui/properties/Color.h
+++ b/engine/lib/quoll/qui/properties/Color.h
@@ -12,6 +12,8 @@ public:
   static const Color Red;
   static const Color Green;
   static const Color Blue;
+  static const Color Yellow;
+  static const Color Transparent;
 
 public:
   constexpr Color() = default;

--- a/engine/lib/quoll/qui/reactive/Value.h
+++ b/engine/lib/quoll/qui/reactive/Value.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../component/Element.h"
 #include "Computation.h"
 #include "Signal.h"
 
@@ -31,6 +32,10 @@ public:
   constexpr Value(const char *data)
   requires std::same_as<TData, quoll::String>
       : mData(quoll::String(data)) {}
+
+  template <std::derived_from<Component> TComp>
+  requires std::same_as<TData, Element>
+  constexpr Value(TComp comp) : mData(Element(comp)) {}
 
   constexpr Value(Signal<TData> signal) : mData(signal.getNode()) {}
 

--- a/engine/tests/quoll-tests/qui/native/Box.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Box.test.cpp
@@ -29,7 +29,7 @@ public:
 };
 
 TEST_F(QuiBoxTest, CreatesBoxWithElements) {
-  qui::Element el = qui::Box(qui::Element(TestComponent(10)));
+  qui::Element el = qui::Box(TestComponent(10));
 
   auto *box = static_cast<qui::Box *>(el.getComponent());
 
@@ -37,14 +37,21 @@ TEST_F(QuiBoxTest, CreatesBoxWithElements) {
   EXPECT_EQ(test1->value, 10);
 
   EXPECT_EQ(box->getPadding(), qui::EdgeInsets(0.0f));
-  EXPECT_EQ(box->getBackground(), qui::Color::Black);
+  EXPECT_EQ(box->getBackground(), qui::Color::Transparent);
   EXPECT_EQ(box->getWidth(), 0.0f);
   EXPECT_EQ(box->getHeight(), 0.0f);
   EXPECT_EQ(box->getBorderRadius(), 0.0f);
+
+  auto *view = static_cast<qui::BoxView *>(box->getView());
+  EXPECT_EQ(view->getChild(), nullptr);
+  EXPECT_EQ(view->getPadding(), qui::EdgeInsets(0.0f));
+  EXPECT_EQ(view->getBackground(), qui::Color::Transparent);
+  EXPECT_EQ(view->getWidth(), 0.0f);
+  EXPECT_EQ(view->getHeight(), 0.0f);
 }
 
 TEST_F(QuiBoxTest, CreatesBoxWithAllProps) {
-  qui::Element el = qui::Box(qui::Element(TestComponent(10)))
+  qui::Element el = qui::Box(TestComponent(10))
                         .background(qui::Color::Red)
                         .padding(qui::EdgeInsets(3.5f))
                         .borderRadius(5.0f)
@@ -65,13 +72,13 @@ TEST_F(QuiBoxTest, CreatesBoxWithAllProps) {
   auto *view = static_cast<qui::BoxView *>(box->getView());
   EXPECT_EQ(view->getChild(), nullptr);
   EXPECT_EQ(view->getPadding(), qui::EdgeInsets(0.0f));
-  EXPECT_EQ(view->getBackground(), qui::Color::Black);
+  EXPECT_EQ(view->getBackground(), qui::Color::Transparent);
   EXPECT_EQ(view->getWidth(), 0.0f);
   EXPECT_EQ(view->getHeight(), 0.0f);
 }
 
 TEST_F(QuiBoxTest, BuildingBoxUpdatesView) {
-  qui::Element el = qui::Box(qui::Element(TestComponent(10)))
+  qui::Element el = qui::Box(TestComponent(10))
                         .background(qui::Color::Red)
                         .padding(qui::EdgeInsets(3.5f))
                         .borderRadius(5.0f)
@@ -100,7 +107,7 @@ TEST_F(QuiBoxTest, UpdatingBoxPropertiesAfterBuildUpdatesTheView) {
   auto borderRadius = scope.signal(5.0f);
   auto width = scope.signal(10.0f);
   auto height = scope.signal(20.0f);
-  auto child = scope.signal(qui::Element(TestComponent(10)));
+  auto child = scope.signal<qui::Element>(TestComponent(10));
 
   qui::Element el = qui::Box(child)
                         .background(background)

--- a/engine/tests/quoll-tests/qui/native/Custom.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Custom.test.cpp
@@ -33,7 +33,7 @@ private:
 };
 
 TEST_F(QuiCustomComponentTest, ComponentWithoutPropsCreatesElementOnCall) {
-  auto Test = qui::component([]() -> qui::Element { return Person("John"); });
+  auto Test = qui::component([]() { return Person("John"); });
 
   auto element = Test();
 
@@ -45,10 +45,8 @@ TEST_F(QuiCustomComponentTest, ComponentWithoutPropsCreatesElementOnCall) {
 }
 
 TEST_F(QuiCustomComponentTest, ComponentWithPropsCreatesElementOnCall) {
-  auto Test =
-      qui::component([](qui::Value<quoll::String> name) -> qui::Element {
-        return Person(name);
-      });
+  auto Test = qui::component(
+      [](qui::Value<quoll::String> name) { return Person(name); });
 
   auto element = Test("John");
 
@@ -60,7 +58,7 @@ TEST_F(QuiCustomComponentTest, ComponentWithPropsCreatesElementOnCall) {
 }
 
 TEST_F(QuiCustomComponentTest, ComponentWithScopeCreatesElementOnCall) {
-  auto Test = qui::component([](qui::Scope &scope) -> qui::Element {
+  auto Test = qui::component([](qui::Scope &scope) {
     auto name = scope.signal("John");
     return Person(name);
   });
@@ -75,8 +73,8 @@ TEST_F(QuiCustomComponentTest, ComponentWithScopeCreatesElementOnCall) {
 }
 
 TEST_F(QuiCustomComponentTest, ComponentWithScopeAndPropsCreatesElementOnCall) {
-  auto Test = qui::component(
-      [](qui::Scope &scope, qui::Value<quoll::String> name) -> qui::Element {
+  auto Test =
+      qui::component([](qui::Scope &scope, qui::Value<quoll::String> name) {
         auto fullName = scope.computation([name] { return name() + " Doe"; });
 
         return Person(fullName);
@@ -92,7 +90,7 @@ TEST_F(QuiCustomComponentTest, ComponentWithScopeAndPropsCreatesElementOnCall) {
 }
 
 TEST_F(QuiCustomComponentTest, BuildingComponnetBuildsTheResult) {
-  auto Test = qui::component([]() -> qui::Element { return Person("John"); });
+  auto Test = qui::component([]() { return Person("John"); });
 
   auto element = Test();
 
@@ -106,7 +104,7 @@ TEST_F(QuiCustomComponentTest, BuildingComponnetBuildsTheResult) {
 }
 
 TEST_F(QuiCustomComponentTest, GettingViewReturnsViewOfResult) {
-  auto Test = qui::component([]() -> qui::Element { return Person("John"); });
+  auto Test = qui::component([]() { return Person("John"); });
 
   auto element = Test();
 


### PR DESCRIPTION
- Render box with border radius if background color is not transparent
- Fix box view layouting to accommodate for padding
- Clip box child during rendering to avoid overflow
- Wrap text around box with padding, border radius, and background color in imgui debug layer
- Add more color constants