### PR TITLE
Add hit test to views

### DIFF
--- a/engine/lib/quoll/qui/Qui.cpp
+++ b/engine/lib/quoll/qui/Qui.cpp
@@ -6,7 +6,9 @@ namespace qui {
 
 Tree Qui::createTree(Element &&element) {
   Tree tree{.root = std::move(element)};
-  tree.root.build();
+
+  BuildContext context{};
+  tree.root.build(context);
 
   return tree;
 }

--- a/engine/lib/quoll/qui/component/BuildContext.h
+++ b/engine/lib/quoll/qui/component/BuildContext.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace qui {
+
+struct BuildContext {};
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/Component.h
+++ b/engine/lib/quoll/qui/component/Component.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "BuildContext.h"
 #include "View.h"
 
 namespace qui {
@@ -8,7 +9,7 @@ class Component {
 public:
   virtual ~Component() = default;
 
-  virtual void build() = 0;
+  virtual void build(BuildContext &context) = 0;
 
   virtual View *getView() = 0;
 };

--- a/engine/lib/quoll/qui/component/Element.cpp
+++ b/engine/lib/quoll/qui/component/Element.cpp
@@ -3,9 +3,9 @@
 
 namespace qui {
 
-void Element::build() {
+void Element::build(BuildContext &context) {
   if (!mBuilt) {
-    mComponent->build();
+    mComponent->build(context);
     mBuilt = true;
   }
 }

--- a/engine/lib/quoll/qui/component/Element.h
+++ b/engine/lib/quoll/qui/component/Element.h
@@ -16,7 +16,7 @@ public:
   template <std::derived_from<Component> Comp>
   Element(const Comp &component) : mComponent(new Comp(component)){};
 
-  inline View *getView() { return mComponent->getView(); }
+  constexpr View *getView() { return mComponent->getView(); }
 
   inline bool operator==(const Element &other) const {
     return mComponent == other.mComponent;
@@ -26,7 +26,7 @@ public:
 
   inline const Component *getComponent() const { return mComponent.get(); }
 
-  void build();
+  void build(BuildContext &context);
 
 private:
   quoll::SharedPtr<Component> mComponent = nullptr;

--- a/engine/lib/quoll/qui/component/View.h
+++ b/engine/lib/quoll/qui/component/View.h
@@ -45,6 +45,8 @@ public:
   virtual constexpr void render() {}
 
   virtual LayoutOutput layout(const LayoutInput &input) = 0;
+
+  virtual constexpr bool hitTest(const glm::vec2 &point) { return false; }
 };
 
 } // namespace qui

--- a/engine/lib/quoll/qui/native/Box.cpp
+++ b/engine/lib/quoll/qui/native/Box.cpp
@@ -30,10 +30,10 @@ Box &Box::borderRadius(Value<f32> radius) {
   return *this;
 }
 
-void Box::build() {
-  auto observeChild = [this] {
+void Box::build(BuildContext &context) {
+  auto observeChild = [this, &context] {
     if (mChild()) {
-      mChild().build();
+      mChild().build(context);
       mView.setChild(mChild().getView());
     }
   };

--- a/engine/lib/quoll/qui/native/Box.h
+++ b/engine/lib/quoll/qui/native/Box.h
@@ -38,7 +38,7 @@ public:
 
   Box &borderRadius(Value<f32> radius);
 
-  void build() override;
+  void build(BuildContext &context) override;
 
   constexpr View *getView() { return &mView; }
 

--- a/engine/lib/quoll/qui/native/BoxView.cpp
+++ b/engine/lib/quoll/qui/native/BoxView.cpp
@@ -78,4 +78,9 @@ LayoutOutput BoxView::layout(const LayoutInput &input) {
   return {mSize};
 }
 
+bool BoxView::hitTest(const glm::vec2 &point) {
+  return point.x >= mPosition.x && point.x <= mPosition.x + mSize.x &&
+         point.y >= mPosition.y && point.y <= mPosition.y + mSize.y;
+}
+
 } // namespace qui

--- a/engine/lib/quoll/qui/native/BoxView.h
+++ b/engine/lib/quoll/qui/native/BoxView.h
@@ -17,6 +17,7 @@ public:
 
   void render() override;
   LayoutOutput layout(const LayoutInput &input) override;
+  bool hitTest(const glm::vec2 &point) override;
 
 public:
   constexpr auto *getChild() { return mChild; }

--- a/engine/lib/quoll/qui/native/Custom.cpp
+++ b/engine/lib/quoll/qui/native/Custom.cpp
@@ -3,7 +3,7 @@
 
 namespace qui {
 
-void Custom::build() { mResult.build(); }
+void Custom::build(BuildContext &context) { mResult.build(context); }
 
 View *Custom::getView() { return mResult.getView(); }
 

--- a/engine/lib/quoll/qui/native/Custom.h
+++ b/engine/lib/quoll/qui/native/Custom.h
@@ -25,7 +25,7 @@ public:
     }
   }
 
-  void build() override;
+  void build(BuildContext &context) override;
 
   View *getView() override;
 

--- a/engine/lib/quoll/qui/native/Flex.cpp
+++ b/engine/lib/quoll/qui/native/Flex.cpp
@@ -30,12 +30,12 @@ Flex &Flex::spacing(Value<glm::vec2> spacing) {
   return *this;
 }
 
-void Flex::build() {
-  auto observeChildren = [this] {
+void Flex::build(BuildContext &context) {
+  auto observeChildren = [this, &context] {
     auto &children = mChildren();
     std::vector<View *> viewChildren(children.size());
     for (usize i = 0; i < children.size(); ++i) {
-      children.at(i).build();
+      children.at(i).build(context);
       viewChildren.at(i) = children.at(i).getView();
     }
 

--- a/engine/lib/quoll/qui/native/Flex.h
+++ b/engine/lib/quoll/qui/native/Flex.h
@@ -16,7 +16,7 @@ public:
   Flex &grow(Value<f32> grow);
   Flex &spacing(Value<glm::vec2> spacing);
 
-  void build() override;
+  void build(BuildContext &context) override;
 
   View *getView() override { return &mView; }
 

--- a/engine/lib/quoll/qui/native/FlexView.cpp
+++ b/engine/lib/quoll/qui/native/FlexView.cpp
@@ -165,4 +165,9 @@ LayoutOutput FlexView::layout(const LayoutInput &input) {
   return {mSize};
 }
 
+bool FlexView::hitTest(const glm::vec2 &point) {
+  return point.x >= mPosition.x && point.x <= mPosition.x + mSize.x &&
+         point.y >= mPosition.y && point.y <= mPosition.y + mSize.y;
+}
+
 } // namespace qui

--- a/engine/lib/quoll/qui/native/FlexView.h
+++ b/engine/lib/quoll/qui/native/FlexView.h
@@ -20,6 +20,8 @@ public:
 
   LayoutOutput layout(const LayoutInput &input) override;
 
+  bool hitTest(const glm::vec2 &point) override;
+
 public:
   constexpr auto getDirection() const { return mDirection; }
   constexpr auto getWrap() const { return mWrap; }

--- a/engine/lib/quoll/qui/native/Text.cpp
+++ b/engine/lib/quoll/qui/native/Text.cpp
@@ -10,7 +10,7 @@ Text &Text::color(Value<Color> color) {
   return *this;
 }
 
-void Text::build() {
+void Text::build(BuildContext &context) {
   auto observeText = [this] { mView.setText(mText()); };
   auto observeColor = [this] { mView.setColor(mColor()); };
 

--- a/engine/lib/quoll/qui/native/Text.h
+++ b/engine/lib/quoll/qui/native/Text.h
@@ -15,7 +15,7 @@ public:
 
   Text &color(Value<Color> color);
 
-  void build() override;
+  void build(BuildContext &context) override;
 
   constexpr View *getView() override { return &mView; }
 

--- a/engine/lib/quoll/qui/native/TextView.cpp
+++ b/engine/lib/quoll/qui/native/TextView.cpp
@@ -25,4 +25,9 @@ LayoutOutput TextView::layout(const LayoutInput &input) {
   return LayoutOutput{mTextSize};
 }
 
+bool TextView::hitTest(const glm::vec2 &point) {
+  return point.x >= mPosition.x && point.x <= mPosition.x + mTextSize.x &&
+         point.y >= mPosition.y && point.y <= mPosition.y + mTextSize.y;
+}
+
 } // namespace qui

--- a/engine/lib/quoll/qui/native/TextView.h
+++ b/engine/lib/quoll/qui/native/TextView.h
@@ -12,6 +12,7 @@ public:
 
   void render() override;
   LayoutOutput layout(const LayoutInput &input) override;
+  bool hitTest(const glm::vec2 &point) override;
 
 public:
   constexpr const auto &getText() { return mText; }

--- a/engine/tests/quoll-tests/qui/native/Box.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Box.test.cpp
@@ -1,10 +1,10 @@
 #include "quoll/core/Base.h"
 #include "quoll/qui/native/Box.h"
 #include "quoll/qui/reactive/Scope.h"
-#include "quoll-tests/Testing.h"
 #include "MockComponent.h"
+#include "QuiComponentTest.h"
 
-class QuiBoxTest : public ::testing::Test {
+class QuiBoxTest : public QuiComponentTest {
 public:
 };
 
@@ -67,7 +67,7 @@ TEST_F(QuiBoxTest, BuildingBoxUpdatesView) {
                         .width(10.0f)
                         .height(20.0f);
 
-  el.build();
+  el.build(buildContext);
 
   auto *view = static_cast<qui::BoxView *>(el.getView());
 
@@ -98,7 +98,7 @@ TEST_F(QuiBoxTest, UpdatingBoxPropertiesAfterBuildUpdatesTheView) {
                         .height(height);
 
   auto *box = static_cast<const qui::Box *>(el.getComponent());
-  el.build();
+  el.build(buildContext);
 
   auto *view = static_cast<qui::BoxView *>(el.getView());
 

--- a/engine/tests/quoll-tests/qui/native/BoxView.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/BoxView.test.cpp
@@ -323,3 +323,36 @@ TEST_F(QuiBoxViewTest, RenderCallsChildRender) {
 
   EXPECT_EQ(child.rendered, 1);
 }
+
+TEST_F(QuiBoxViewTest, HitTestReturnsTrueIfPointIsWithinViewBounds) {
+  view.setWidth(50.0f);
+  view.setHeight(100.0f);
+  view.setChild(&child);
+  auto output = view.layout({.position = {40.0f, 50.0f}});
+
+  EXPECT_TRUE(view.hitTest({40.0f, 50.0f}));
+  EXPECT_TRUE(view.hitTest({40.0f, 150.0f}));
+  EXPECT_TRUE(view.hitTest({90.0f, 50.0f}));
+  EXPECT_TRUE(view.hitTest({90.0f, 150.0f}));
+  EXPECT_TRUE(view.hitTest({80.0f, 120.0f}));
+}
+
+TEST_F(QuiBoxViewTest, HitTestReturnsFalseIfPointIsOutsideOfViewBounds) {
+  view.setWidth(50.0f);
+  view.setHeight(100.0f);
+  view.setChild(&child);
+  auto output = view.layout({.position = {40.0f, 50.0f}});
+
+  EXPECT_FALSE(view.hitTest({40.0f, 49.0f}));
+  EXPECT_FALSE(view.hitTest({40.0f, 151.0f}));
+  EXPECT_FALSE(view.hitTest({90.0f, 49.0f}));
+  EXPECT_FALSE(view.hitTest({09.0f, 151.0f}));
+
+  EXPECT_FALSE(view.hitTest({39.0f, 50.0f}));
+  EXPECT_FALSE(view.hitTest({91.0f, 50.0f}));
+  EXPECT_FALSE(view.hitTest({39.0f, 150.0f}));
+  EXPECT_FALSE(view.hitTest({91.0f, 150.0f}));
+
+  EXPECT_FALSE(view.hitTest({20.0f, 10.0f}));
+  EXPECT_FALSE(view.hitTest({120.0f, 160.0f}));
+}

--- a/engine/tests/quoll-tests/qui/native/Custom.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Custom.test.cpp
@@ -1,35 +1,27 @@
 #include "quoll/core/Base.h"
 #include "quoll/qui/native/Custom.h"
 #include "quoll/qui/reactive/Value.h"
-#include "quoll-tests/Testing.h"
+#include "MockView.h"
+#include "QuiComponentTest.h"
 
-class QuiCustomComponentTest : public ::testing::Test {};
-
-class PersonView : public qui::View {
-public:
-  int data = 20;
-
-  qui::LayoutOutput layout(const qui::LayoutInput &input) override {
-    return qui::LayoutOutput{};
-  }
-};
+class QuiCustomComponentTest : public QuiComponentTest {};
 
 class Person : public qui::Component {
 public:
-  Person(qui::Value<quoll::String> name) : mName(name) {}
+  Person(qui::Value<quoll::String> name) : mName(name) { mView.value = 20; }
 
-  void build() override { mAge = 20; }
+  void build(qui::BuildContext &context) override { mAge = 20; }
 
   constexpr quoll::String getName() const { return mName(); }
 
   constexpr uint32_t getAge() const { return mAge; }
 
-  qui::View *getView() override { return &mPersonView; }
+  qui::View *getView() override { return &mView; }
 
 private:
   qui::Value<quoll::String> mName;
   uint32_t mAge = 0;
-  PersonView mPersonView;
+  MockView mView;
 };
 
 TEST_F(QuiCustomComponentTest, ComponentWithoutPropsCreatesElementOnCall) {
@@ -98,7 +90,7 @@ TEST_F(QuiCustomComponentTest, BuildingComponnetBuildsTheResult) {
 
   auto element = Test();
 
-  element.build();
+  element.build(buildContext);
 
   auto *component = dynamic_cast<const qui::Custom *>(element.getComponent());
   auto *person =
@@ -113,8 +105,8 @@ TEST_F(QuiCustomComponentTest, GettingViewReturnsViewOfResult) {
 
   auto element = Test();
 
-  auto *view = dynamic_cast<PersonView *>(element.getView());
+  auto *view = dynamic_cast<MockView *>(element.getView());
 
   ASSERT_NE(view, nullptr);
-  EXPECT_EQ(view->data, 20);
+  EXPECT_EQ(view->value, 20);
 }

--- a/engine/tests/quoll-tests/qui/native/Element.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Element.test.cpp
@@ -1,9 +1,9 @@
 #include "quoll/core/Base.h"
 #include "quoll/qui/component/Element.h"
-#include "quoll-tests/Testing.h"
 #include "MockComponent.h"
+#include "QuiComponentTest.h"
 
-class QuiElementTest : public ::testing::Test {
+class QuiElementTest : public QuiComponentTest {
 public:
 };
 
@@ -20,7 +20,7 @@ TEST_F(QuiElementTest, BuildingElementBuildsComponent) {
   qui::Element element = MockComponent(20);
   auto *component = dynamic_cast<const MockComponent *>(element.getComponent());
 
-  element.build();
+  element.build(buildContext);
 
   EXPECT_EQ(component->value, 20);
   EXPECT_EQ(dynamic_cast<MockView *>(element.getView())->value, 20);
@@ -31,9 +31,9 @@ TEST_F(QuiElementTest, RebuildingElementDoesNotBuildComponentAgain) {
   qui::Element element = MockComponent(20);
   auto *component = dynamic_cast<const MockComponent *>(element.getComponent());
 
-  element.build();
-  element.build();
-  element.build();
+  element.build(buildContext);
+  element.build(buildContext);
+  element.build(buildContext);
 
   EXPECT_EQ(component->value, 20);
   EXPECT_EQ(dynamic_cast<MockView *>(element.getView())->value, 20);

--- a/engine/tests/quoll-tests/qui/native/Flex.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Flex.test.cpp
@@ -1,10 +1,10 @@
 #include "quoll/core/Base.h"
 #include "quoll/qui/native/Flex.h"
 #include "quoll/qui/reactive/Scope.h"
-#include "quoll-tests/Testing.h"
 #include "MockComponent.h"
+#include "QuiComponentTest.h"
 
-class QuiFlexTest : public ::testing::Test {
+class QuiFlexTest : public QuiComponentTest {
 public:
 };
 
@@ -79,7 +79,7 @@ TEST_F(QuiFlexTest, BuildingFlexUpdatesView) {
                         .grow(3.0f)
                         .spacing(glm::vec2{2.0f, 5.0f});
 
-  el.build();
+  el.build(buildContext);
   auto *view = static_cast<qui::FlexView *>(el.getView());
 
   EXPECT_EQ(view->getChildren().size(), 2);
@@ -113,7 +113,7 @@ TEST_F(QuiFlexTest, UpdatingFlexPropertiesAfterBuildUpdatesTheView) {
                         .grow(grow)
                         .spacing(spacing);
 
-  el.build();
+  el.build(buildContext);
 
   auto *view = static_cast<qui::FlexView *>(el.getView());
 

--- a/engine/tests/quoll-tests/qui/native/FlexView.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/FlexView.test.cpp
@@ -33,3 +33,69 @@ TEST_F(QuiFlexViewTest, RendersChildren) {
   EXPECT_EQ(child2.rendered, 1);
   EXPECT_EQ(child3.rendered, 1);
 }
+
+TEST_F(QuiFlexViewTest, HitTestReturnsTrueIfPointIssWithinViewBounds) {
+  child1.desiredSize.x = 100.0f;
+  child1.desiredSize.y = 30.0f;
+  child2.desiredSize.x = 50.0f;
+  child2.desiredSize.y = 20.0f;
+  child3.desiredSize.x = 300.0f;
+  child3.desiredSize.y = 40.0f;
+
+  qui::Constraints constraints;
+  constraints.min.x = 0.0f;
+  constraints.max.x = 1000.0f;
+  constraints.min.y = 0.0f;
+  constraints.max.y = 1000.0f;
+
+  glm::vec2 position;
+  position.x = 200.0f;
+  position.y = 150.0f;
+
+  auto output = view.layout({constraints, position});
+
+  EXPECT_EQ(output.size.x, 450.0f);
+  EXPECT_EQ(output.size.y, 40.0f);
+
+  // Bounds = [200, 150, 650, 190]
+  EXPECT_TRUE(view.hitTest({200.0f, 150.0f}));
+  EXPECT_TRUE(view.hitTest({200.0f, 190.0f}));
+  EXPECT_TRUE(view.hitTest({650.0f, 190.0f}));
+  EXPECT_TRUE(view.hitTest({650.0f, 150.0f}));
+  EXPECT_TRUE(view.hitTest({250.0f, 170.0f}));
+}
+
+TEST_F(QuiFlexViewTest, HitTestReturnsFalseIfPointIsOutsideOfViewBounds) {
+  child1.desiredSize.x = 100.0f;
+  child1.desiredSize.y = 30.0f;
+  child2.desiredSize.x = 50.0f;
+  child2.desiredSize.y = 20.0f;
+  child3.desiredSize.x = 300.0f;
+  child3.desiredSize.y = 40.0f;
+
+  qui::Constraints constraints;
+  constraints.min.x = 0.0f;
+  constraints.max.x = 1000.0f;
+  constraints.min.y = 0.0f;
+  constraints.max.y = 1000.0f;
+
+  glm::vec2 position;
+  position.x = 200.0f;
+  position.y = 150.0f;
+
+  auto output = view.layout({constraints, position});
+
+  // Bounds = [200, 150, 650, 190]
+  EXPECT_FALSE(view.hitTest({200.0f, 149.0f}));
+  EXPECT_FALSE(view.hitTest({200.0f, 191.0f}));
+  EXPECT_FALSE(view.hitTest({650.0f, 149.0f}));
+  EXPECT_FALSE(view.hitTest({650.0f, 191.0f}));
+
+  EXPECT_FALSE(view.hitTest({199.0f, 150.0f}));
+  EXPECT_FALSE(view.hitTest({651.0f, 150.0f}));
+  EXPECT_FALSE(view.hitTest({199.0f, 190.0f}));
+  EXPECT_FALSE(view.hitTest({651.0f, 190.0f}));
+
+  EXPECT_FALSE(view.hitTest({400.0f, 130.0f}));
+  EXPECT_FALSE(view.hitTest({700.0f, 240.0f}));
+}

--- a/engine/tests/quoll-tests/qui/native/MockComponent.h
+++ b/engine/tests/quoll-tests/qui/native/MockComponent.h
@@ -7,7 +7,7 @@ class MockComponent : public qui::Component {
 public:
   MockComponent(u32 value) : value(value) {}
 
-  void build() override {
+  void build(qui::BuildContext &context) override {
     mView.value = value;
     buildCount++;
   }

--- a/engine/tests/quoll-tests/qui/native/MockView.h
+++ b/engine/tests/quoll-tests/qui/native/MockView.h
@@ -14,6 +14,11 @@ public:
     return {size};
   }
 
+  constexpr bool hitTest(const glm::vec2 &pos) override {
+    return pos.x >= position.x && pos.x <= position.x + size.x &&
+           pos.y >= position.y && pos.y <= position.y + size.y;
+  }
+
 public:
   qui::LayoutInput input;
 

--- a/engine/tests/quoll-tests/qui/native/QuiComponentTest.h
+++ b/engine/tests/quoll-tests/qui/native/QuiComponentTest.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "quoll/qui/component/BuildContext.h"
+#include "quoll-tests/Testing.h"
+
+class QuiComponentTest : public ::testing::Test {
+public:
+  qui::BuildContext buildContext{};
+};

--- a/engine/tests/quoll-tests/qui/native/Text.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Text.test.cpp
@@ -2,11 +2,9 @@
 #include "quoll/qui/component/Element.h"
 #include "quoll/qui/native/Text.h"
 #include "quoll/qui/reactive/Scope.h"
-#include "quoll-tests/Testing.h"
+#include "QuiComponentTest.h"
 
-class QuiTextTest : public testing::Test {
-public:
-};
+class QuiTextTest : public QuiComponentTest {};
 
 TEST_F(QuiTextTest, CreatesText) {
   qui::Element el = qui::Text("Hello world");
@@ -27,7 +25,7 @@ TEST_F(QuiTextTest, CreatesTextWithAllProps) {
 TEST_F(QuiTextTest, BuildingTextUpdatesView) {
   qui::Element el = qui::Text("Hello world").color(qui::Color::Red);
 
-  el.build();
+  el.build(buildContext);
 
   auto *view = static_cast<qui::TextView *>(el.getView());
 
@@ -41,7 +39,7 @@ TEST_F(QuiTextTest, UpdatingTextPropertiesAfterBuildUpdatesTheView) {
   auto color = scope.signal(qui::Color::Red);
 
   qui::Element el = qui::Text(text).color(color);
-  el.build();
+  el.build(buildContext);
   auto *view = static_cast<qui::TextView *>(el.getView());
 
   EXPECT_EQ(view->getText(), "Hello world");

--- a/engine/tests/quoll-tests/qui/native/TextView.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/TextView.test.cpp
@@ -46,3 +46,40 @@ TEST_F(QuiTextViewTest, LayoutSetsInputPositionAsTextViewPosition) {
   view.layout({.constraints = {}, .position = {40.0f, 50.0f}});
   EXPECT_EQ(view.getPosition(), glm::vec2(40.0f, 50.0f));
 }
+
+TEST_F(QuiTextViewTest, HitTestReturnsTrueIfPointIsWithinViewBounds) {
+  qui::TextView view;
+  view.setText("Hello world");
+
+  qui::Constraints constraints(0.0f, 0.0f, 50.0f, 100.0f);
+  auto output =
+      view.layout({.constraints = constraints, .position = {40.0f, 50.0f}});
+
+  EXPECT_TRUE(view.hitTest({40.0f, 50.0f}));
+  EXPECT_TRUE(view.hitTest({40.0f, 76.0f}));
+  EXPECT_TRUE(view.hitTest({75.0f, 50.0f}));
+  EXPECT_TRUE(view.hitTest({75.0f, 76.0f}));
+  EXPECT_TRUE(view.hitTest({60.0f, 65.0f}));
+}
+
+TEST_F(QuiTextViewTest, HitTestReturnsFalseIfPointIsOutsideOfViewBounds) {
+  qui::TextView view;
+  view.setText("Hello world");
+
+  qui::Constraints constraints(0.0f, 0.0f, 50.0f, 100.0f);
+  auto output =
+      view.layout({.constraints = constraints, .position = {40.0f, 50.0f}});
+
+  EXPECT_FALSE(view.hitTest({40.0f, 49.0f}));
+  EXPECT_FALSE(view.hitTest({40.0f, 77.0f}));
+  EXPECT_FALSE(view.hitTest({75.0f, 49.0f}));
+  EXPECT_FALSE(view.hitTest({75.0f, 77.0f}));
+
+  EXPECT_FALSE(view.hitTest({39.0f, 50.0f}));
+  EXPECT_FALSE(view.hitTest({76.0f, 50.0f}));
+  EXPECT_FALSE(view.hitTest({39.0f, 76.0f}));
+  EXPECT_FALSE(view.hitTest({76.0f, 76.0f}));
+
+  EXPECT_FALSE(view.hitTest({20.0f, 10.0f}));
+  EXPECT_FALSE(view.hitTest({120.0f, 160.0f}));
+}


### PR DESCRIPTION
- Provide build context to all components
- Create base class for native component tests
- Add hit test to view interface
- Implement hit test for text, box, and flex views