### PR TITLE
Add pressable component

### DIFF
--- a/engine/lib/quoll/profiler/ImguiDebugLayer.cpp
+++ b/engine/lib/quoll/profiler/ImguiDebugLayer.cpp
@@ -7,18 +7,16 @@
 
 namespace quoll {
 
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
 static constexpr auto ColoredText =
     qui::component([](qui::Value<quoll::String> text) {
-      static constexpr f32 BoxSize = 40.0f;
       return qui::Box(qui::Text(text).color(qui::Color::Yellow))
           .background(qui::Color::Red)
-          .width(BoxSize)
-          .height(BoxSize);
+          .width(40.0f)
+          .height(40.0f);
     });
 
 static constexpr auto DemoQuiFlexbox = qui::component([]() {
-  static constexpr glm::vec2 BoxSize{200.0f, 300.0f};
-  static constexpr glm::vec2 Spacing{5.0f, 5.0f};
   return qui::Box(qui::Flex({
                                 ColoredText("1"),
                                 ColoredText("2"),
@@ -30,30 +28,75 @@ static constexpr auto DemoQuiFlexbox = qui::component([]() {
                                 ColoredText("8"),
                             })
                       .wrap(qui::Wrap::Wrap)
-                      .spacing(Spacing))
-      .width(BoxSize.x)
-      .height(BoxSize.y);
+                      .spacing(glm::vec2(5.0f)))
+      .width(200.0f)
+      .height(300.0f);
+});
+
+struct ButtonStyle {
+  qui::Color color;
+  qui::Color backgroundColor;
+};
+
+static constexpr auto ColoredButton = qui::component(
+    [](qui::Scope &scope, qui::Value<quoll::String> text,
+       qui::Value<ButtonStyle> style, qui::Value<ButtonStyle> hoverStyle,
+       qui::Value<ButtonStyle> activeStyle) {
+      auto hovered = scope.signal(false);
+      auto clicked = scope.signal(false);
+
+      auto color =
+          scope.computation([hovered, clicked, hoverStyle, activeStyle, style] {
+            if (hovered()) {
+              return hoverStyle().color;
+            }
+
+            return clicked() ? activeStyle().color : style().color;
+          });
+
+      auto backgroundColor =
+          scope.computation([hovered, clicked, hoverStyle, activeStyle, style] {
+            if (hovered()) {
+              return hoverStyle().backgroundColor;
+            }
+
+            return clicked() ? activeStyle().backgroundColor
+                             : style().backgroundColor;
+          });
+
+      return qui::Pressable(qui::Box(qui::Text(text).color(color))
+                                .padding(qui::EdgeInsets(5.0f))
+                                .background(backgroundColor))
+          .onHoverIn([hovered](const auto &) mutable { hovered.set(true); })
+          .onHoverOut([hovered](const auto &) mutable { hovered.set(false); })
+          .onPress(
+              [clicked](const auto &) mutable { clicked.set(!clicked()); });
+    });
+
+static constexpr auto DemoPressable = qui::component([]() {
+  return ColoredButton(
+      "Hello world",
+      ButtonStyle{.color = qui::Color::White, .backgroundColor = 0x2e86deff},
+      ButtonStyle{.color = qui::Color::White, .backgroundColor = 0x54a0ffff},
+      ButtonStyle{.color = qui::Color::White, .backgroundColor = 0xee5253ff});
 });
 
 static constexpr auto DemoQui = qui::component([]() {
-  static constexpr f32 BorderRadius = 5.0f;
-  static constexpr f32 Padding = 5.0f;
-  static constexpr f32 Spacing = 10.0f;
-
   return qui::Flex({qui::Box(qui::Text("Red text on a yellow background")
                                  .color(qui::Color::Red))
-                        .padding(qui::EdgeInsets(Padding))
+                        .padding(qui::EdgeInsets(5.0f))
                         .background(qui::Color::Yellow)
                         .width(100.0f)
-                        .borderRadius(BorderRadius),
+                        .borderRadius(5.0f),
 
                     qui::Box(qui::Text("Text with resizable sizing"))
                         .background(qui::Color::White)
-                        .padding(qui::EdgeInsets(Padding)),
+                        .padding(qui::EdgeInsets(5.0f)),
 
-                    DemoQuiFlexbox()})
-      .spacing(glm::vec2{Spacing, 0.0f});
+                    DemoQuiFlexbox(), DemoPressable()})
+      .spacing(glm::vec2{10.0f, 0.0f});
 });
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
 ImguiDebugLayer::ImguiDebugLayer(
     const rhi::PhysicalDeviceInformation &physicalDeviceInfo,

--- a/engine/lib/quoll/qui/Components.h
+++ b/engine/lib/quoll/qui/Components.h
@@ -3,4 +3,5 @@
 #include "native/Box.h"
 #include "native/Custom.h"
 #include "native/Flex.h"
+#include "native/Pressable.h"
 #include "native/Text.h"

--- a/engine/lib/quoll/qui/Qui.cpp
+++ b/engine/lib/quoll/qui/Qui.cpp
@@ -4,20 +4,56 @@
 
 namespace qui {
 
+static void handleEvents(EventManager *events) {
+  auto imguiPos = ImGui::GetMousePos();
+  auto pos = glm::vec2{imguiPos.x, imguiPos.y};
+
+  if (ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
+    MouseEvent ev{pos};
+    for (const auto &handler : events->getMouseDownHandlers()) {
+      handler(ev);
+    }
+  }
+
+  if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
+    MouseEvent ev{pos};
+    for (const auto &handler : events->getMouseUpHandlers()) {
+      handler(ev);
+    }
+  }
+
+  if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+    MouseEvent ev{pos};
+    for (const auto &handler : events->getMouseClickHandlers()) {
+      handler(ev);
+    }
+  }
+
+  {
+    MouseEvent ev{pos};
+    for (const auto &handler : events->getMouseMoveHandlers()) {
+      handler(ev);
+    }
+  }
+}
+
 Tree Qui::createTree(Element &&element) {
   Tree tree{.root = std::move(element)};
 
-  BuildContext context{};
+  BuildContext context{tree.events.get()};
   tree.root.build(context);
 
-  return tree;
+  return std::move(tree);
 }
 
 void Qui::render(Tree &tree, glm::vec2 pos, glm::vec2 size) {
   Constraints constraints(0.0f, 0.0f, size.x, size.y);
   LayoutInput input{constraints, pos};
 
+  handleEvents(tree.events.get());
+
   auto output = tree.root.getView()->layout(input);
+
   tree.root.getView()->render();
 }
 

--- a/engine/lib/quoll/qui/component/BuildContext.h
+++ b/engine/lib/quoll/qui/component/BuildContext.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include "EventManager.h"
+
 namespace qui {
 
-struct BuildContext {};
+struct BuildContext {
+  EventManager *eventManager = nullptr;
+};
 
 } // namespace qui

--- a/engine/lib/quoll/qui/component/EventManager.cpp
+++ b/engine/lib/quoll/qui/component/EventManager.cpp
@@ -1,0 +1,45 @@
+#include "quoll/core/Base.h"
+#include "EventManager.h"
+
+namespace qui {
+
+EventHolder::~EventHolder() {
+  for (auto handle : mMouseClickHandles) {
+    mManager->mMouseClickHandlers.erase(handle);
+  }
+
+  for (auto handle : mMouseDownHandles) {
+    mManager->mMouseDownHandlers.erase(handle);
+  }
+
+  for (auto handle : mMouseUpHandles) {
+    mManager->mMouseUpHandlers.erase(handle);
+  }
+
+  for (auto handle : mMouseMoveHandles) {
+    mManager->mMouseMoveHandlers.erase(handle);
+  }
+}
+
+void EventHolder::registerMouseClickHandler(
+    EventHandler<MouseEvent> &&handler) {
+  auto handle = mManager->mMouseClickHandlers.insert(std::move(handler));
+  mMouseClickHandles.push_back(handle);
+}
+
+void EventHolder::registerMouseDownHandler(EventHandler<MouseEvent> &&handler) {
+  auto handle = mManager->mMouseDownHandlers.insert(std::move(handler));
+  mMouseDownHandles.push_back(handle);
+}
+
+void EventHolder::registerMouseUpHandler(EventHandler<MouseEvent> &&handler) {
+  auto handle = mManager->mMouseUpHandlers.insert(std::move(handler));
+  mMouseUpHandles.push_back(handle);
+}
+
+void EventHolder::registerMouseMoveHandler(EventHandler<MouseEvent> &&handler) {
+  auto handle = mManager->mMouseMoveHandlers.insert(std::move(handler));
+  mMouseMoveHandles.push_back(handle);
+}
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/EventManager.h
+++ b/engine/lib/quoll/qui/component/EventManager.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "quoll/core/SparseSet.h"
+#include "Events.h"
+
+namespace qui {
+
+class EventManager;
+
+class EventHolder {
+public:
+  constexpr EventHolder() = default;
+  constexpr EventHolder(EventManager *manager) : mManager(manager) {}
+  constexpr EventHolder(EventHolder &&rhs) noexcept
+      : mManager(rhs.mManager),
+        mMouseClickHandles(std::move(rhs.mMouseClickHandles)),
+        mMouseDownHandles(std::move(rhs.mMouseDownHandles)),
+        mMouseUpHandles(std::move(rhs.mMouseUpHandles)),
+        mMouseMoveHandles(std::move(rhs.mMouseMoveHandles)) {}
+
+  constexpr EventHolder &operator=(EventHolder &&rhs) noexcept {
+    mManager = rhs.mManager;
+    mMouseClickHandles = std::move(rhs.mMouseClickHandles);
+    mMouseDownHandles = std::move(rhs.mMouseDownHandles);
+    mMouseUpHandles = std::move(rhs.mMouseUpHandles);
+    mMouseMoveHandles = std::move(rhs.mMouseMoveHandles);
+    return *this;
+  }
+
+  constexpr EventHolder(const EventHolder &rhs) {
+    mManager = rhs.mManager;
+    mMouseClickHandles = rhs.mMouseClickHandles;
+    mMouseDownHandles = rhs.mMouseDownHandles;
+    mMouseUpHandles = rhs.mMouseUpHandles;
+    mMouseMoveHandles = rhs.mMouseMoveHandles;
+  };
+
+  constexpr EventHolder &operator=(const EventHolder &) = delete;
+  ~EventHolder();
+
+  void registerMouseClickHandler(EventHandler<MouseEvent> &&handler);
+  void registerMouseDownHandler(EventHandler<MouseEvent> &&handler);
+  void registerMouseUpHandler(EventHandler<MouseEvent> &&handler);
+  void registerMouseMoveHandler(EventHandler<MouseEvent> &&handler);
+
+private:
+  EventManager *mManager{nullptr};
+
+  std::vector<usize> mMouseClickHandles;
+  std::vector<usize> mMouseDownHandles;
+  std::vector<usize> mMouseUpHandles;
+  std::vector<usize> mMouseMoveHandles;
+};
+
+class EventManager {
+  friend class EventHolder;
+  using MouseEventSet = quoll::SparseSet<EventHandler<MouseEvent>>;
+
+public:
+  inline MouseEventSet &getMouseClickHandlers() { return mMouseClickHandlers; }
+  inline MouseEventSet &getMouseDownHandlers() { return mMouseDownHandlers; }
+  inline MouseEventSet &getMouseUpHandlers() { return mMouseUpHandlers; }
+  inline MouseEventSet &getMouseMoveHandlers() { return mMouseMoveHandlers; }
+  inline EventHolder createEventHolder() { return EventHolder(this); }
+
+private:
+  quoll::SparseSet<EventHandler<MouseEvent>> mMouseClickHandlers;
+  quoll::SparseSet<EventHandler<MouseEvent>> mMouseDownHandlers;
+  quoll::SparseSet<EventHandler<MouseEvent>> mMouseUpHandlers;
+  quoll::SparseSet<EventHandler<MouseEvent>> mMouseMoveHandlers;
+};
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/Events.h
+++ b/engine/lib/quoll/qui/component/Events.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace qui {
+
+struct MouseEvent {
+  glm::vec2 point;
+};
+
+template <typename TEvent>
+using EventHandler = std::function<void(const TEvent &)>;
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/Tree.h
+++ b/engine/lib/quoll/qui/component/Tree.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "Element.h"
+#include "EventManager.h"
 
 namespace qui {
 
 struct Tree {
+  std::unique_ptr<EventManager> events{new EventManager};
   Element root;
 };
 

--- a/engine/lib/quoll/qui/native/Pressable.cpp
+++ b/engine/lib/quoll/qui/native/Pressable.cpp
@@ -1,0 +1,85 @@
+#include "quoll/core/Base.h"
+#include "Pressable.h"
+
+namespace qui {
+
+Pressable::Pressable(Value<Element> child) : mChild(child) {}
+
+Pressable &Pressable::onPress(PressHandler &&handler) {
+  mOnPress = std::move(handler);
+  return *this;
+}
+
+Pressable &Pressable::onPressDown(PressHandler &&handler) {
+  mOnPressDown = std::move(handler);
+  return *this;
+}
+
+Pressable &Pressable::onPressUp(PressHandler &&handler) {
+  mOnPressUp = std::move(handler);
+  return *this;
+}
+
+Pressable &Pressable::onHoverIn(PressHandler &&handler) {
+  mOnHoverIn = std::move(handler);
+  return *this;
+}
+
+Pressable &Pressable::onHoverOut(PressHandler &&handler) {
+  mOnHoverOut = std::move(handler);
+  return *this;
+}
+
+void Pressable::build(BuildContext &context) {
+  mEventHolder = context.eventManager->createEventHolder();
+
+  auto observeChild = [this, &context]() { mChild().build(context); };
+
+  mChild.observe(observeChild);
+  observeChild();
+
+  if (mOnPress) {
+    mEventHolder.registerMouseClickHandler(
+        [this](const MouseEvent &mouseEvent) {
+          if (getView()->hitTest(mouseEvent.point)) {
+            mOnPress({.point = mouseEvent.point});
+          }
+        });
+  }
+
+  if (mOnPressDown) {
+    mEventHolder.registerMouseDownHandler([this](const MouseEvent &mouseEvent) {
+      if (getView()->hitTest(mouseEvent.point)) {
+        mOnPressDown({.point = mouseEvent.point});
+      }
+    });
+  }
+
+  if (mOnPressUp) {
+    mEventHolder.registerMouseUpHandler([this](const MouseEvent &mouseEvent) {
+      if (getView()->hitTest(mouseEvent.point)) {
+        mOnPressUp({.point = mouseEvent.point});
+      }
+    });
+  }
+
+  if (mOnHoverIn || mOnHoverOut) {
+    mEventHolder.registerMouseMoveHandler([this](const MouseEvent &mouseEvent) {
+      bool hitTest = getView()->hitTest(mouseEvent.point);
+
+      if (!mHovered && hitTest) {
+        mHovered = true;
+        if (mOnHoverIn) {
+          mOnHoverIn({.point = mouseEvent.point});
+        }
+      } else if (mHovered && !hitTest) {
+        mHovered = false;
+        if (mOnHoverOut) {
+          mOnHoverOut({.point = mouseEvent.point});
+        }
+      }
+    });
+  }
+}
+
+} // namespace qui

--- a/engine/lib/quoll/qui/native/Pressable.h
+++ b/engine/lib/quoll/qui/native/Pressable.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "../component/Element.h"
+#include "../reactive/Value.h"
+
+namespace qui {
+
+struct PressEvent {
+  glm::vec2 point;
+};
+
+class Pressable : public Component {
+  using PressHandler = std::function<void(const PressEvent &event)>;
+
+public:
+  Pressable(Value<Element> child);
+
+  Pressable &onPress(PressHandler &&handler);
+  Pressable &onPressDown(PressHandler &&handler);
+  Pressable &onPressUp(PressHandler &&handler);
+  Pressable &onHoverIn(PressHandler &&handler);
+  Pressable &onHoverOut(PressHandler &&handler);
+
+  void build(BuildContext &context) override;
+
+  constexpr View *getView() override { return mChild().getView(); }
+
+public:
+  inline auto getChild() const { return mChild(); }
+  inline auto getOnPress() const { return mOnPress; }
+  inline auto getOnPressDown() const { return mOnPressDown; }
+  inline auto getOnPressUp() const { return mOnPressUp; }
+  inline auto getOnHoverIn() const { return mOnHoverIn; }
+  inline auto getOnHoverOut() const { return mOnHoverOut; }
+
+private:
+  Value<Element> mChild;
+
+  PressHandler mOnPress;
+  PressHandler mOnPressDown;
+  PressHandler mOnPressUp;
+  PressHandler mOnHoverIn;
+  PressHandler mOnHoverOut;
+
+  bool mHovered = false;
+
+  EventHolder mEventHolder;
+};
+
+} // namespace qui

--- a/engine/lib/quoll/qui/reactive/ReactiveArena.h
+++ b/engine/lib/quoll/qui/reactive/ReactiveArena.h
@@ -8,7 +8,7 @@ class ReactiveArena {
 public:
   template <std::derived_from<ReactiveNode> TNode, typename... Args>
   inline TNode *allocate(Args &&...args) {
-    auto node = new TNode(std::forward<Args>(args)...);
+    auto *node = new TNode(std::forward<Args>(args)...);
     mNodes.insert_or_assign(node, std::unique_ptr<ReactiveNode>(node));
     return node;
   }

--- a/engine/lib/quoll/qui/reactive/Scope.h
+++ b/engine/lib/quoll/qui/reactive/Scope.h
@@ -7,12 +7,14 @@ namespace qui {
 
 class Scope {
 public:
+  inline Scope() : mGlobals(new rgraph::ReactiveNodeGlobals) {}
+
   template <typename TData> auto signal(const TData &data) {
-    return Signal(&mGlobals, data);
+    return Signal(mGlobals.get(), data);
   }
 
   template <typename TData> auto signal(TData &&data) {
-    return Signal(&mGlobals, std::forward<TData>(data));
+    return Signal(mGlobals.get(), std::forward<TData>(data));
   }
 
   template <typename TData> auto signal(std::initializer_list<TData> &&data) {
@@ -22,7 +24,7 @@ public:
   auto signal(const char *data) { return signal<quoll::String>(data); }
 
   template <std::invocable TFunction> auto computation(TFunction &&fn) {
-    return Computation(&mGlobals, std::forward<TFunction>(fn));
+    return Computation(mGlobals.get(), std::forward<TFunction>(fn));
   }
 
   template <typename... TArgs>
@@ -33,7 +35,7 @@ public:
   }
 
 private:
-  rgraph::ReactiveNodeGlobals mGlobals{};
+  std::unique_ptr<rgraph::ReactiveNodeGlobals> mGlobals;
 };
 
 } // namespace qui

--- a/engine/tests/quoll-tests/qui/native/Pressable.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Pressable.test.cpp
@@ -1,0 +1,312 @@
+#include "quoll/core/Base.h"
+#include "quoll/qui/native/Pressable.h"
+#include "quoll/qui/reactive/Scope.h"
+#include "MockComponent.h"
+#include "QuiComponentTest.h"
+
+class QuiPressableTest : public QuiComponentTest {
+public:
+  using PressHandler = ::testing::MockFunction<void(const qui::PressEvent &)>;
+};
+
+TEST_F(QuiPressableTest, CreatesPressableElementWithChild) {
+  qui::Element element = qui::Pressable(MockComponent(20));
+
+  auto *component = static_cast<const qui::Pressable *>(element.getComponent());
+
+  EXPECT_FALSE(component->getOnPress());
+  EXPECT_FALSE(component->getOnPressDown());
+  EXPECT_FALSE(component->getOnPressUp());
+  EXPECT_FALSE(component->getOnHoverIn());
+  EXPECT_FALSE(component->getOnHoverOut());
+
+  auto *child =
+      dynamic_cast<const MockComponent *>(component->getChild().getComponent());
+  EXPECT_EQ(child->value, 20);
+
+  auto *view = dynamic_cast<MockView *>(element.getView());
+  ASSERT_NE(view, nullptr);
+
+  EXPECT_EQ(view->value, 0);
+  EXPECT_EQ(child->mView.value, 0);
+}
+
+TEST_F(QuiPressableTest, CreatesPressableElementWithAllProps) {
+  PressHandler handlePress, handlePressDown, handlePressUp, handleHoverIn,
+      handleHoverOut;
+
+  EXPECT_CALL(handlePress, Call(::testing::_)).Times(1);
+  EXPECT_CALL(handlePressDown, Call(::testing::_)).Times(1);
+  EXPECT_CALL(handlePressUp, Call(::testing::_)).Times(1);
+  EXPECT_CALL(handleHoverIn, Call(::testing::_)).Times(1);
+  EXPECT_CALL(handleHoverOut, Call(::testing::_)).Times(1);
+
+  qui::Element element = qui::Pressable(MockComponent(20))
+                             .onPress(handlePress.AsStdFunction())
+                             .onPressDown(handlePressDown.AsStdFunction())
+                             .onPressUp(handlePressUp.AsStdFunction())
+                             .onHoverIn(handleHoverIn.AsStdFunction())
+                             .onHoverOut(handleHoverOut.AsStdFunction());
+
+  auto *component = static_cast<const qui::Pressable *>(element.getComponent());
+
+  EXPECT_TRUE(component->getOnPress());
+  EXPECT_TRUE(component->getOnPressDown());
+  EXPECT_TRUE(component->getOnPressUp());
+  EXPECT_TRUE(component->getOnHoverIn());
+  EXPECT_TRUE(component->getOnHoverOut());
+
+  auto *child =
+      static_cast<const MockComponent *>(component->getChild().getComponent());
+  EXPECT_EQ(child->value, 20);
+
+  auto *view = dynamic_cast<MockView *>(element.getView());
+  ASSERT_NE(view, nullptr);
+
+  EXPECT_EQ(view->value, 0);
+  EXPECT_EQ(child->mView.value, 0);
+
+  qui::PressEvent ev{};
+  component->getOnPress()(ev);
+  component->getOnPressDown()(ev);
+  component->getOnPressUp()(ev);
+  component->getOnHoverIn()(ev);
+  component->getOnHoverOut()(ev);
+}
+
+TEST_F(QuiPressableTest, BuildCallsChildBuild) {
+  qui::Element element = qui::Pressable(MockComponent(20));
+
+  element.build(buildContext);
+
+  auto *component = static_cast<const qui::Pressable *>(element.getComponent());
+  auto *child =
+      static_cast<const MockComponent *>(component->getChild().getComponent());
+  EXPECT_EQ(child->value, 20);
+
+  auto *view = dynamic_cast<MockView *>(element.getView());
+  ASSERT_NE(view, nullptr);
+  EXPECT_EQ(view->value, 20);
+  EXPECT_EQ(child->mView.value, 20);
+}
+
+TEST_F(QuiPressableTest, UpdatingChildRebuildsChild) {
+  PressHandler handlePress, handlePressDown, handlePressUp, handleHoverIn,
+      handleHoverOut;
+
+  qui::Scope scope;
+  auto childEl = scope.signal<qui::Element>(MockComponent(20));
+
+  qui::Element element = qui::Pressable(childEl);
+
+  element.build(buildContext);
+
+  {
+    auto *component =
+        static_cast<const qui::Pressable *>(element.getComponent());
+    auto *child = static_cast<const MockComponent *>(
+        component->getChild().getComponent());
+    EXPECT_EQ(child->value, 20);
+
+    auto *view = dynamic_cast<MockView *>(element.getView());
+    ASSERT_NE(view, nullptr);
+    EXPECT_EQ(view->value, 20);
+    EXPECT_EQ(child->mView.value, 20);
+  }
+
+  childEl.set(MockComponent(40));
+  {
+    auto *component =
+        static_cast<const qui::Pressable *>(element.getComponent());
+    auto *child = static_cast<const MockComponent *>(
+        component->getChild().getComponent());
+    EXPECT_EQ(child->value, 40);
+
+    auto *view = dynamic_cast<MockView *>(element.getView());
+    ASSERT_NE(view, nullptr);
+    EXPECT_EQ(view->value, 40);
+    EXPECT_EQ(child->mView.value, 40);
+  }
+}
+
+using QuiPressableEventsTest = QuiPressableTest;
+
+MATCHER_P(PressEventEq, point, "") { return arg.point == point; }
+
+TEST_F(QuiPressableEventsTest,
+       MouseClickEventCallsPressHandlerIfViewHitTestIsTrueForMousePosition) {
+  PressHandler pressHandler;
+
+  EXPECT_CALL(pressHandler, Call(PressEventEq(glm::vec2{50.0f, 60.0f})))
+      .Times(1);
+
+  MockComponent component(20);
+  component.mView.desiredSize = {100, 100};
+
+  qui::Element element =
+      qui::Pressable(component).onPress(pressHandler.AsStdFunction());
+
+  element.build(buildContext);
+  element.getView()->layout({});
+
+  ASSERT_EQ(buildContext.eventManager->getMouseClickHandlers().size(), 1);
+  auto mouseHandler = buildContext.eventManager->getMouseClickHandlers().at(0);
+  mouseHandler(qui::MouseEvent{glm::vec2{50, 60}});
+  mouseHandler(qui::MouseEvent{glm::vec2{150, 120}});
+}
+
+TEST_F(QuiPressableEventsTest,
+       MouseDownEventCallsPressDownHandlerIfViewHitTestIsTrueForMousePosition) {
+  PressHandler pressHandler;
+
+  EXPECT_CALL(pressHandler, Call(PressEventEq(glm::vec2{50.0f, 60.0f})))
+      .Times(1);
+
+  MockComponent component(20);
+  component.mView.desiredSize = {100, 100};
+
+  qui::Element element =
+      qui::Pressable(component).onPressDown(pressHandler.AsStdFunction());
+
+  element.build(buildContext);
+  element.getView()->layout({});
+
+  ASSERT_EQ(buildContext.eventManager->getMouseDownHandlers().size(), 1);
+  auto mouseHandler = buildContext.eventManager->getMouseDownHandlers().at(0);
+  mouseHandler(qui::MouseEvent{glm::vec2{50, 60}});
+  mouseHandler(qui::MouseEvent{glm::vec2{150, 120}});
+}
+
+TEST_F(QuiPressableEventsTest,
+       MouseUpEventCallsPressUpHandlerIfViewHitTestIsTrueForMousePosition) {
+  PressHandler pressHandler;
+
+  EXPECT_CALL(pressHandler, Call(PressEventEq(glm::vec2{50.0f, 60.0f})))
+      .Times(1);
+
+  MockComponent component(20);
+  component.mView.desiredSize = {100, 100};
+
+  qui::Element element =
+      qui::Pressable(component).onPressDown(pressHandler.AsStdFunction());
+
+  element.build(buildContext);
+  element.getView()->layout({});
+
+  ASSERT_EQ(buildContext.eventManager->getMouseDownHandlers().size(), 1);
+
+  auto mouseHandler = buildContext.eventManager->getMouseDownHandlers().at(0);
+  mouseHandler(qui::MouseEvent{glm::vec2{50, 60}});
+  mouseHandler(qui::MouseEvent{glm::vec2{150, 120}});
+}
+
+TEST_F(
+    QuiPressableEventsTest,
+    MouseMoveEventCallsHoverInHandlerIfViewHitTestIsTrueForMousePositionAndElementIsNotHoveredYet) {
+  PressHandler pressHandler;
+
+  EXPECT_CALL(pressHandler, Call(PressEventEq(glm::vec2{50.0f, 60.0f})))
+      .Times(1);
+
+  MockComponent component(20);
+  component.mView.desiredSize = {100, 100};
+
+  qui::Element element =
+      qui::Pressable(component).onHoverIn(pressHandler.AsStdFunction());
+
+  element.build(buildContext);
+  element.getView()->layout({});
+
+  ASSERT_EQ(buildContext.eventManager->getMouseMoveHandlers().size(), 1);
+
+  auto mouseHandler = buildContext.eventManager->getMouseMoveHandlers().at(0);
+  mouseHandler(qui::MouseEvent{glm::vec2{50, 60}});
+  mouseHandler(qui::MouseEvent{glm::vec2{60, 70}});
+  mouseHandler(qui::MouseEvent{glm::vec2{150, 120}});
+}
+
+TEST_F(
+    QuiPressableEventsTest,
+    MouseMoveEventCallsHoverOutHandlerIfViewHitTestIsTrueForMousePositionAndElementIsAlreadyHovered) {
+  PressHandler pressHandler;
+
+  EXPECT_CALL(pressHandler, Call(PressEventEq(glm::vec2{150.0f, 120.0f})))
+      .Times(1);
+
+  MockComponent component(20);
+  component.mView.desiredSize = {100, 100};
+
+  qui::Element element =
+      qui::Pressable(component).onHoverOut(pressHandler.AsStdFunction());
+
+  element.build(buildContext);
+  element.getView()->layout({});
+
+  ASSERT_EQ(buildContext.eventManager->getMouseMoveHandlers().size(), 1);
+
+  auto mouseHandler = buildContext.eventManager->getMouseMoveHandlers().at(0);
+  mouseHandler(qui::MouseEvent{glm::vec2{50, 60}});
+  mouseHandler(qui::MouseEvent{glm::vec2{60, 70}});
+  mouseHandler(qui::MouseEvent{glm::vec2{150, 120}});
+  mouseHandler(qui::MouseEvent{glm::vec2{250, 320}});
+}
+
+TEST_F(
+    QuiPressableEventsTest,
+    MouseMoveEventsCallBothHoverInAndHoverOutHandlersIfMousePositionGoesInAndOutOfView) {
+  PressHandler hoverInHandler, hoverOutHandler;
+
+  EXPECT_CALL(hoverInHandler, Call(PressEventEq(glm::vec2{50.0f, 60.0f})))
+      .Times(1);
+  EXPECT_CALL(hoverOutHandler, Call(PressEventEq(glm::vec2{150.0f, 120.0f})))
+      .Times(1);
+
+  MockComponent component(20);
+  component.mView.desiredSize = {100, 100};
+
+  qui::Element element = qui::Pressable(component)
+                             .onHoverIn(hoverInHandler.AsStdFunction())
+                             .onHoverOut(hoverOutHandler.AsStdFunction());
+
+  element.build(buildContext);
+  element.getView()->layout({});
+
+  ASSERT_EQ(buildContext.eventManager->getMouseMoveHandlers().size(), 1);
+
+  auto mouseHandler = buildContext.eventManager->getMouseMoveHandlers().at(0);
+  mouseHandler(qui::MouseEvent{glm::vec2{50, 60}});
+  mouseHandler(qui::MouseEvent{glm::vec2{60, 70}});
+  mouseHandler(qui::MouseEvent{glm::vec2{150, 120}});
+  mouseHandler(qui::MouseEvent{glm::vec2{250, 320}});
+}
+
+TEST_F(QuiPressableEventsTest,
+       EventsAreClearedIsComponentIsDestroyedAfterBuild) {
+
+  {
+    PressHandler handlePress, handlePressDown, handlePressUp, handleHoverIn,
+        handleHoverOut;
+
+    MockComponent component(20);
+    component.mView.desiredSize = {100, 100};
+
+    qui::Element element = qui::Pressable(component)
+                               .onPress(handlePress.AsStdFunction())
+                               .onPressDown(handlePressDown.AsStdFunction())
+                               .onPressUp(handlePressUp.AsStdFunction())
+                               .onHoverIn(handleHoverIn.AsStdFunction())
+                               .onHoverOut(handleHoverOut.AsStdFunction());
+
+    element.build(buildContext);
+
+    EXPECT_EQ(buildContext.eventManager->getMouseClickHandlers().size(), 1);
+    EXPECT_EQ(buildContext.eventManager->getMouseDownHandlers().size(), 1);
+    EXPECT_EQ(buildContext.eventManager->getMouseUpHandlers().size(), 1);
+    EXPECT_EQ(buildContext.eventManager->getMouseMoveHandlers().size(), 1);
+  }
+
+  EXPECT_EQ(buildContext.eventManager->getMouseClickHandlers().size(), 0);
+  EXPECT_EQ(buildContext.eventManager->getMouseDownHandlers().size(), 0);
+  EXPECT_EQ(buildContext.eventManager->getMouseUpHandlers().size(), 0);
+  EXPECT_EQ(buildContext.eventManager->getMouseMoveHandlers().size(), 0);
+}

--- a/engine/tests/quoll-tests/qui/native/QuiComponentTest.h
+++ b/engine/tests/quoll-tests/qui/native/QuiComponentTest.h
@@ -5,5 +5,6 @@
 
 class QuiComponentTest : public ::testing::Test {
 public:
-  qui::BuildContext buildContext{};
+  qui::EventManager eventManager;
+  qui::BuildContext buildContext{&eventManager};
 };


### PR DESCRIPTION
- Add mouse click, down, up, and move listeners to UI system
- Add press, press down, press up, and hover in/out to Pressable
- Clean up events after component is destroyed
- Store reactive globals within a scope in a heap
- Add Button demo to Qui debug window