### PR TITLE
Add hit test events

### DIFF
--- a/engine/lib/quoll/profiler/ImguiDebugLayer.cpp
+++ b/engine/lib/quoll/profiler/ImguiDebugLayer.cpp
@@ -91,9 +91,9 @@ static constexpr auto DemoScrollable = qui::component([]() {
                                                .width(300.0f)
                                                .height(100.0f),
 
-                                           qui::Box(qui::Text("Hello world"))
+                                           qui::Box(DemoPressable())
                                                .padding(qui::EdgeInsets(5.0f))
-                                               .background(qui::Color::Green)
+                                               .background(qui::Color::Red)
                                                .width(100.0f)
                                                .borderRadius(5.0f)
                                                .width(300.0f)

--- a/engine/lib/quoll/qui/Qui.cpp
+++ b/engine/lib/quoll/qui/Qui.cpp
@@ -1,57 +1,9 @@
 #include "quoll/core/Base.h"
+#include "component/EventProcessor.h"
+#include "component/ImGuiEventProcessorBackend.h"
 #include "Qui.h"
-#include <imgui.h>
 
 namespace qui {
-
-namespace {
-
-void handleEvents(EventManager *events) {
-  auto imguiPos = ImGui::GetMousePos();
-  auto pos = glm::vec2{imguiPos.x, imguiPos.y};
-
-  if (ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
-    const MouseEvent ev{pos};
-    for (const auto &handler : events->getMouseDownHandlers()) {
-      handler(ev);
-    }
-  }
-
-  if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
-    const MouseEvent ev{pos};
-    for (const auto &handler : events->getMouseUpHandlers()) {
-      handler(ev);
-    }
-  }
-
-  if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-    const MouseEvent ev{pos};
-    for (const auto &handler : events->getMouseClickHandlers()) {
-      handler(ev);
-    }
-  }
-
-  {
-    const MouseEvent ev{pos};
-    for (const auto &handler : events->getMouseMoveHandlers()) {
-      handler(ev);
-    }
-  }
-
-  {
-    const auto deltaX = ImGui::GetIO().MouseWheelH;
-    const auto deltaY = ImGui::GetIO().MouseWheel;
-
-    if (deltaY != 0.0f || deltaX != 0.0f) {
-      const MouseWheelEvent ev{.delta = {deltaX, deltaY}};
-      for (const auto &handler : events->getMouseWheelHandlers()) {
-        handler(ev);
-      }
-    }
-  }
-}
-
-} // namespace
 
 Tree Qui::createTree(Element &&element) {
   Tree tree{.root = std::move(element)};
@@ -66,10 +18,11 @@ void Qui::render(Tree &tree, glm::vec2 pos, glm::vec2 size) {
   const Constraints constraints(0.0f, 0.0f, size.x, size.y);
   const LayoutInput input{constraints, pos};
 
-  handleEvents(tree.events.get());
+  static EventProcessor<ImGuiEventProcessorBackend> eventProcessor;
 
-  auto output = tree.root.getView()->layout(input);
+  eventProcessor.processEvents(tree);
 
+  tree.root.getView()->layout(input);
   tree.root.getView()->render();
 }
 

--- a/engine/lib/quoll/qui/component/EventContext.h
+++ b/engine/lib/quoll/qui/component/EventContext.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "HitTestResult.h"
+
+namespace qui {
+
+struct EventContext {
+  /**
+   * Cached hit test result
+   *
+   * Used to avoid reallocating path vector every frame
+   */
+  HitTestResult hitTestResult;
+  HitTestResult activeHitTestResult;
+  HitTestResult hoveredHitTestResult;
+};
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/EventDispatcher.cpp
+++ b/engine/lib/quoll/qui/component/EventDispatcher.cpp
@@ -1,0 +1,46 @@
+#include "quoll/core/Base.h"
+#include "EventDispatcher.h"
+
+namespace qui {
+
+namespace {
+
+template <typename TEvent>
+void callHandlers(quoll::SparseSet<EventHandler<TEvent>> &handlers,
+                  const TEvent &event) {
+  for (const auto &handler : handlers) {
+    handler(event);
+  }
+}
+
+} // namespace
+
+void EventDispatcher::dispatchMouseDownEvent(const MouseEvent &event) {
+  callHandlers(mMouseDownHandlers, event);
+}
+
+void EventDispatcher::dispatchMouseUpEvent(const MouseEvent &event) {
+  callHandlers(mMouseUpHandlers, event);
+}
+
+void EventDispatcher::dispatchMouseClickEvent(const MouseEvent &event) {
+  callHandlers(mMouseClickHandlers, event);
+}
+
+void EventDispatcher::dispatchMouseEnterEvent(const MouseEvent &event) {
+  callHandlers(mMouseEnterHandlers, event);
+}
+
+void EventDispatcher::dispatchMouseExitEvent(const MouseEvent &event) {
+  callHandlers(mMouseExitHandlers, event);
+}
+
+void EventDispatcher::dispatchMouseMoveEvent(const MouseEvent &event) {
+  callHandlers(mMouseMoveHandlers, event);
+}
+
+void EventDispatcher::dispatchMouseWheelEvent(const MouseWheelEvent &event) {
+  callHandlers(mMouseWheelHandlers, event);
+}
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/EventDispatcher.h
+++ b/engine/lib/quoll/qui/component/EventDispatcher.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "quoll/core/SparseSet.h"
+#include "Events.h"
+
+namespace qui {
+
+class EventDispatcher {
+public:
+  inline void registerMouseDownHandler(EventHandler<MouseEvent> &&handler) {
+    mMouseDownHandlers.insert(handler);
+  }
+  inline void registerMouseUpHandler(EventHandler<MouseEvent> &&handler) {
+    mMouseUpHandlers.insert(handler);
+  }
+  inline void registerMouseClickHandler(EventHandler<MouseEvent> &&handler) {
+    mMouseClickHandlers.insert(handler);
+  }
+  inline void registerMouseEnterHandler(EventHandler<MouseEvent> &&handler) {
+    mMouseEnterHandlers.insert(handler);
+  }
+  inline void registerMouseExitHandler(EventHandler<MouseEvent> &&handler) {
+    mMouseExitHandlers.insert(handler);
+  }
+
+  inline void registerMouseMoveHandler(EventHandler<MouseEvent> &&handler) {
+    mMouseMoveHandlers.insert(handler);
+  }
+  inline void
+  registerMouseWheelHandler(EventHandler<MouseWheelEvent> &&handler) {
+    mMouseWheelHandlers.insert(handler);
+  }
+
+  void dispatchMouseDownEvent(const MouseEvent &event);
+  void dispatchMouseUpEvent(const MouseEvent &event);
+  void dispatchMouseClickEvent(const MouseEvent &event);
+  void dispatchMouseEnterEvent(const MouseEvent &event);
+  void dispatchMouseExitEvent(const MouseEvent &event);
+  void dispatchMouseMoveEvent(const MouseEvent &event);
+  void dispatchMouseWheelEvent(const MouseWheelEvent &event);
+
+private:
+  quoll::SparseSet<EventHandler<MouseEvent>> mMouseDownHandlers;
+  quoll::SparseSet<EventHandler<MouseEvent>> mMouseUpHandlers;
+  quoll::SparseSet<EventHandler<MouseEvent>> mMouseClickHandlers;
+  quoll::SparseSet<EventHandler<MouseEvent>> mMouseMoveHandlers;
+  quoll::SparseSet<EventHandler<MouseEvent>> mMouseEnterHandlers;
+  quoll::SparseSet<EventHandler<MouseEvent>> mMouseExitHandlers;
+  quoll::SparseSet<EventHandler<MouseWheelEvent>> mMouseWheelHandlers;
+};
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/EventProcessor.h
+++ b/engine/lib/quoll/qui/component/EventProcessor.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include "EventProcessorBackend.h"
+#include "Tree.h"
+
+namespace qui {
+
+template <EventProcessorBackend Backend> class EventProcessor {
+public:
+  constexpr void processEvents(Tree &tree) {
+    auto *root = tree.root.getView();
+    auto *globalEvents = tree.events.get();
+    auto &eventContext = tree.eventContext;
+
+    auto pos = mBackend.getMousePosition();
+
+    if (mBackend.isMouseDown()) {
+      eventContext.hitTestResult.path.clear();
+
+      const MouseEvent ev{pos};
+      if (root->hitTest(pos, eventContext.hitTestResult) &&
+          eventContext.activeHitTestResult.path.empty()) {
+        for (auto *v : eventContext.hitTestResult.path) {
+          v->getEventDispatcher().dispatchMouseDownEvent(ev);
+        }
+        eventContext.activeHitTestResult = eventContext.hitTestResult;
+      }
+
+      for (auto &handler : globalEvents->getMouseDownHandlers()) {
+        handler(ev);
+      }
+    }
+
+    if (mBackend.isMouseUp()) {
+      const MouseEvent ev{pos};
+      if (!eventContext.activeHitTestResult.path.empty()) {
+        for (auto *v : eventContext.activeHitTestResult.path) {
+          v->getEventDispatcher().dispatchMouseUpEvent(ev);
+        }
+
+        eventContext.activeHitTestResult.path.clear();
+      }
+
+      for (auto &handler : globalEvents->getMouseUpHandlers()) {
+        handler(ev);
+      }
+    }
+
+    if (mBackend.isMouseClicked()) {
+      eventContext.hitTestResult.path.clear();
+
+      const MouseEvent ev{pos};
+      if (root->hitTest(pos, eventContext.hitTestResult)) {
+        for (auto *v : eventContext.hitTestResult.path) {
+          v->getEventDispatcher().dispatchMouseClickEvent(ev);
+        }
+      }
+
+      for (auto &handler : globalEvents->getMouseClickHandlers()) {
+        handler(ev);
+      }
+    }
+
+    if (mBackend.isMouseMoved()) {
+      eventContext.hitTestResult.path.clear();
+      const MouseEvent ev{pos};
+      if (root->hitTest(pos, eventContext.hitTestResult)) {
+        auto &current = eventContext.hitTestResult.path;
+        auto &previous = eventContext.hoveredHitTestResult.path;
+
+        usize minSize = std::min(previous.size(), current.size());
+        usize mismatchIndex = minSize;
+        for (usize i = 0; i < minSize; ++i) {
+          if (previous.at(i) != current.at(i)) {
+            mismatchIndex = i;
+            break;
+          }
+        }
+
+        for (usize i = mismatchIndex; i < previous.size(); ++i) {
+          previous.at(i)->getEventDispatcher().dispatchMouseExitEvent(ev);
+        }
+
+        for (usize i = mismatchIndex; i < current.size(); ++i) {
+          current.at(i)->getEventDispatcher().dispatchMouseEnterEvent(ev);
+        }
+
+        for (usize i = 0; i < mismatchIndex; ++i) {
+          current.at(i)->getEventDispatcher().dispatchMouseMoveEvent(ev);
+        }
+      } else {
+        for (auto *view : eventContext.hoveredHitTestResult.path) {
+          view->getEventDispatcher().dispatchMouseExitEvent(ev);
+        }
+      }
+
+      eventContext.hoveredHitTestResult = eventContext.hitTestResult;
+
+      for (auto &handler : globalEvents->getMouseMoveHandlers()) {
+        handler(ev);
+      }
+    }
+
+    if (mBackend.isMouseWheel()) {
+      eventContext.hitTestResult.path.clear();
+
+      const MouseWheelEvent ev{.delta = mBackend.getMouseWheelDelta()};
+      if (root->hitTest(pos, eventContext.hitTestResult)) {
+        for (auto *v : eventContext.hitTestResult.path) {
+          v->getEventDispatcher().dispatchMouseWheelEvent(ev);
+        }
+      }
+
+      for (auto &handler : globalEvents->getMouseWheelHandlers()) {
+        handler(ev);
+      }
+    }
+  }
+
+  constexpr Backend &getBackend() { return mBackend; }
+
+private:
+  Backend mBackend;
+};
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/EventProcessorBackend.h
+++ b/engine/lib/quoll/qui/component/EventProcessorBackend.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace qui {
+
+class EventProcessorBackendInterface {
+public:
+  virtual ~EventProcessorBackendInterface() = default;
+
+  virtual glm::vec2 getMousePosition() = 0;
+  virtual glm::vec2 getMouseWheelDelta() = 0;
+
+  virtual bool isMouseClicked() = 0;
+  virtual bool isMouseDown() = 0;
+  virtual bool isMouseUp() = 0;
+  virtual bool isMouseMoved() = 0;
+  virtual bool isMouseWheel() = 0;
+};
+
+template <typename T>
+concept EventProcessorBackend =
+    std::is_base_of_v<EventProcessorBackendInterface, T>;
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/HitTestResult.h
+++ b/engine/lib/quoll/qui/component/HitTestResult.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace qui {
+
+class View;
+
+struct HitTestResult {
+  std::vector<View *> path;
+};
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/ImGuiEventProcessorBackend.cpp
+++ b/engine/lib/quoll/qui/component/ImGuiEventProcessorBackend.cpp
@@ -1,0 +1,40 @@
+#include "quoll/core/Base.h"
+#include "ImGuiEventProcessorBackend.h"
+#include <imgui.h>
+
+namespace qui {
+
+glm::vec2 ImGuiEventProcessorBackend::getMousePosition() {
+  auto imguiPos = ImGui::GetMousePos();
+  return {imguiPos.x, imguiPos.y};
+}
+
+glm::vec2 ImGuiEventProcessorBackend::getMouseWheelDelta() {
+  return {ImGui::GetIO().MouseWheelH, ImGui::GetIO().MouseWheel};
+}
+
+bool ImGuiEventProcessorBackend::isMouseClicked() {
+  return ImGui::IsMouseClicked(ImGuiMouseButton_Left);
+}
+
+bool ImGuiEventProcessorBackend::isMouseDown() {
+  return ImGui::IsMouseDown(ImGuiMouseButton_Left);
+}
+
+bool ImGuiEventProcessorBackend::isMouseUp() {
+  return ImGui::IsMouseReleased(ImGuiMouseButton_Left);
+}
+
+bool ImGuiEventProcessorBackend::isMouseMoved() {
+  const auto mousePosition = getMousePosition();
+  const bool isMoved = mousePosition != mPreviousMousePosition;
+  mPreviousMousePosition = mousePosition;
+  return isMoved;
+}
+
+bool ImGuiEventProcessorBackend::isMouseWheel() {
+  const auto wheel = getMouseWheelDelta();
+  return wheel.x != 0.0f || wheel.y != 0.0f;
+}
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/ImGuiEventProcessorBackend.h
+++ b/engine/lib/quoll/qui/component/ImGuiEventProcessorBackend.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "EventProcessorBackend.h"
+
+namespace qui {
+
+class ImGuiEventProcessorBackend : public EventProcessorBackendInterface {
+public:
+  glm::vec2 getMousePosition() override;
+  glm::vec2 getMouseWheelDelta() override;
+
+  bool isMouseClicked() override;
+  bool isMouseDown() override;
+  bool isMouseUp() override;
+  bool isMouseMoved() override;
+  bool isMouseWheel() override;
+
+private:
+  glm::vec2 mPreviousMousePosition{std::numeric_limits<f32>::infinity(),
+                                   std::numeric_limits<f32>::infinity()};
+};
+
+} // namespace qui

--- a/engine/lib/quoll/qui/component/Tree.h
+++ b/engine/lib/quoll/qui/component/Tree.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include "Element.h"
+#include "EventContext.h"
 #include "EventManager.h"
 
 namespace qui {
 
 struct Tree {
+  EventContext eventContext;
+
   std::unique_ptr<EventManager> events{new EventManager};
   Element root;
 };

--- a/engine/lib/quoll/qui/component/View.h
+++ b/engine/lib/quoll/qui/component/View.h
@@ -1,8 +1,9 @@
 #pragma once
 
-namespace qui {
+#include "EventDispatcher.h"
+#include "HitTestResult.h"
 
-class View;
+namespace qui {
 
 class Constraints {
 public:
@@ -40,10 +41,6 @@ struct LayoutOutput {
   glm::vec2 size{0.0f, 0.0f};
 };
 
-struct HitTestResult {
-  std::vector<View *> path;
-};
-
 class View {
 public:
   virtual ~View() = default;
@@ -56,6 +53,11 @@ public:
                                  HitTestResult &hitResult) {
     return false;
   }
+
+  constexpr EventDispatcher &getEventDispatcher() { return mEventDispatcher; }
+
+private:
+  EventDispatcher mEventDispatcher;
 };
 
 } // namespace qui

--- a/engine/lib/quoll/qui/native/Pressable.h
+++ b/engine/lib/quoll/qui/native/Pressable.h
@@ -43,8 +43,6 @@ private:
   PressHandler mOnHoverOut;
 
   bool mHovered = false;
-
-  EventHolder mEventHolder;
 };
 
 } // namespace qui

--- a/engine/lib/quoll/qui/native/Scrollable.h
+++ b/engine/lib/quoll/qui/native/Scrollable.h
@@ -7,7 +7,7 @@
 namespace qui {
 
 class Scrollable : public Component {
-  enum class ScrollbarState { Hidden = 0, Visible, Hovered, Active };
+  enum class ScrollbarState { Hidden = 0, Visible, Hovered };
 
 public:
   Scrollable(Value<Element> child);
@@ -18,6 +18,7 @@ public:
 
 private:
   void setScrollbarState(ScrollbarState state);
+  void setScrollbarActive(bool isActive);
 
 private:
   ScrollableView mView;
@@ -25,6 +26,7 @@ private:
 
   Value<Element> mChild;
   bool mHovered = false;
+  bool mScrollbarActive = false;
 
   glm::vec2 mPreviousMousePos{0.0f, 0.0f};
 

--- a/engine/tests/quoll-tests/qui/native/Box.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Box.test.cpp
@@ -9,14 +9,13 @@ public:
 };
 
 TEST_F(QuiBoxTest, CreatesBoxWithElements) {
-  qui::Element el = qui::Box(MockComponent(10));
+  auto tree = qui::Qui::createTree(qui::Box(MockComponent(10)));
+  auto &el = tree.root;
 
   auto *box = static_cast<const qui::Box *>(el.getComponent());
-
   auto *test1 =
       static_cast<const MockComponent *>(box->getChild().getComponent());
   EXPECT_EQ(test1->value, 10);
-
   EXPECT_EQ(box->getPadding(), qui::EdgeInsets(0.0f));
   EXPECT_EQ(box->getBackground(), qui::Color::Transparent);
   EXPECT_EQ(box->getWidth(), 0.0f);
@@ -24,7 +23,8 @@ TEST_F(QuiBoxTest, CreatesBoxWithElements) {
   EXPECT_EQ(box->getBorderRadius(), 0.0f);
 
   auto *view = static_cast<qui::BoxView *>(el.getView());
-  EXPECT_EQ(view->getChild(), nullptr);
+  auto *childView = static_cast<MockView *>(view->getChild());
+  EXPECT_EQ(childView->value, 10);
   EXPECT_EQ(view->getPadding(), qui::EdgeInsets(0.0f));
   EXPECT_EQ(view->getBackground(), qui::Color::Transparent);
   EXPECT_EQ(view->getWidth(), 0.0f);
@@ -32,19 +32,18 @@ TEST_F(QuiBoxTest, CreatesBoxWithElements) {
 }
 
 TEST_F(QuiBoxTest, CreatesBoxWithAllProps) {
-  qui::Element el = qui::Box(MockComponent(10))
-                        .background(qui::Color::Red)
-                        .padding(qui::EdgeInsets(3.5f))
-                        .borderRadius(5.0f)
-                        .width(10.0f)
-                        .height(20.0f);
+  auto tree = qui::Qui::createTree(qui::Box(MockComponent(10))
+                                       .background(qui::Color::Red)
+                                       .padding(qui::EdgeInsets(3.5f))
+                                       .borderRadius(5.0f)
+                                       .width(10.0f)
+                                       .height(20.0f));
+  auto &el = tree.root;
 
   auto *box = static_cast<const qui::Box *>(el.getComponent());
-
   auto *test1 =
       static_cast<const MockComponent *>(box->getChild().getComponent());
   EXPECT_EQ(test1->value, 10);
-
   EXPECT_EQ(box->getPadding(), qui::EdgeInsets(3.5f));
   EXPECT_EQ(box->getBackground(), qui::Color::Red);
   EXPECT_EQ(box->getWidth(), 10.0f);
@@ -52,28 +51,8 @@ TEST_F(QuiBoxTest, CreatesBoxWithAllProps) {
   EXPECT_EQ(box->getBorderRadius(), 5.0f);
 
   auto *view = static_cast<qui::BoxView *>(el.getView());
-  EXPECT_EQ(view->getChild(), nullptr);
-  EXPECT_EQ(view->getPadding(), qui::EdgeInsets(0.0f));
-  EXPECT_EQ(view->getBackground(), qui::Color::Transparent);
-  EXPECT_EQ(view->getWidth(), 0.0f);
-  EXPECT_EQ(view->getHeight(), 0.0f);
-}
-
-TEST_F(QuiBoxTest, BuildingBoxUpdatesView) {
-  qui::Element el = qui::Box(MockComponent(10))
-                        .background(qui::Color::Red)
-                        .padding(qui::EdgeInsets(3.5f))
-                        .borderRadius(5.0f)
-                        .width(10.0f)
-                        .height(20.0f);
-
-  el.build(buildContext);
-
-  auto *view = static_cast<qui::BoxView *>(el.getView());
-
   auto *childView = static_cast<MockView *>(view->getChild());
   EXPECT_EQ(childView->value, 10);
-
   EXPECT_EQ(view->getPadding(), qui::EdgeInsets(3.5f));
   EXPECT_EQ(view->getBackground(), qui::Color::Red);
   EXPECT_EQ(view->getWidth(), 10.0f);
@@ -90,15 +69,15 @@ TEST_F(QuiBoxTest, UpdatingBoxPropertiesAfterBuildUpdatesTheView) {
   auto height = scope.signal(20.0f);
   auto child = scope.signal<qui::Element>(MockComponent(10));
 
-  qui::Element el = qui::Box(child)
-                        .background(background)
-                        .padding(padding)
-                        .borderRadius(borderRadius)
-                        .width(width)
-                        .height(height);
+  auto tree = qui::Qui::createTree(qui::Box(child)
+                                       .background(background)
+                                       .padding(padding)
+                                       .borderRadius(borderRadius)
+                                       .width(width)
+                                       .height(height));
+  auto &el = tree.root;
 
   auto *box = static_cast<const qui::Box *>(el.getComponent());
-  el.build(buildContext);
 
   auto *view = static_cast<qui::BoxView *>(el.getView());
 

--- a/engine/tests/quoll-tests/qui/native/Custom.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Custom.test.cpp
@@ -26,73 +26,22 @@ private:
 
 TEST_F(QuiCustomComponentTest, ComponentWithoutPropsCreatesElementOnCall) {
   auto Test = qui::component([]() { return Person("John"); });
+  auto tree = qui::Qui::createTree(Test());
 
-  auto element = Test();
-
-  auto *component = dynamic_cast<const qui::Custom *>(element.getComponent());
+  auto *component = dynamic_cast<const qui::Custom *>(tree.root.getComponent());
   auto *person =
       dynamic_cast<const Person *>(component->getResult().getComponent());
 
   EXPECT_EQ(person->getName(), "John");
-  EXPECT_EQ(person->getAge(), 0);
+  EXPECT_EQ(person->getAge(), 20);
 }
 
 TEST_F(QuiCustomComponentTest, ComponentWithPropsCreatesElementOnCall) {
   auto Test = qui::component(
       [](qui::Value<quoll::String> name) { return Person(name); });
+  auto tree = qui::Qui::createTree(Test("John"));
 
-  auto element = Test("John");
-
-  auto *component = dynamic_cast<const qui::Custom *>(element.getComponent());
-  auto *person =
-      dynamic_cast<const Person *>(component->getResult().getComponent());
-
-  EXPECT_EQ(person->getName(), "John");
-  EXPECT_EQ(person->getAge(), 0);
-}
-
-TEST_F(QuiCustomComponentTest, ComponentWithScopeCreatesElementOnCall) {
-  auto Test = qui::component([](qui::Scope &scope) {
-    auto name = scope.signal("John");
-    return Person(name);
-  });
-
-  auto element = Test();
-
-  auto *component = dynamic_cast<const qui::Custom *>(element.getComponent());
-  auto *person =
-      dynamic_cast<const Person *>(component->getResult().getComponent());
-
-  EXPECT_EQ(person->getName(), "John");
-  EXPECT_EQ(person->getAge(), 0);
-}
-
-TEST_F(QuiCustomComponentTest, ComponentWithScopeAndPropsCreatesElementOnCall) {
-  auto Test =
-      qui::component([](qui::Scope &scope, qui::Value<quoll::String> name) {
-        auto fullName = scope.computation([name] { return name() + " Doe"; });
-
-        return Person(fullName);
-      });
-
-  auto element = Test("John");
-
-  auto *component = dynamic_cast<const qui::Custom *>(element.getComponent());
-  auto *person =
-      dynamic_cast<const Person *>(component->getResult().getComponent());
-
-  EXPECT_EQ(person->getName(), "John Doe");
-  EXPECT_EQ(person->getAge(), 0);
-}
-
-TEST_F(QuiCustomComponentTest, BuildingComponnetBuildsTheResult) {
-  auto Test = qui::component([]() { return Person("John"); });
-
-  auto element = Test();
-
-  element.build(buildContext);
-
-  auto *component = dynamic_cast<const qui::Custom *>(element.getComponent());
+  auto *component = dynamic_cast<const qui::Custom *>(tree.root.getComponent());
   auto *person =
       dynamic_cast<const Person *>(component->getResult().getComponent());
 
@@ -102,10 +51,9 @@ TEST_F(QuiCustomComponentTest, BuildingComponnetBuildsTheResult) {
 
 TEST_F(QuiCustomComponentTest, GettingViewReturnsViewOfResult) {
   auto Test = qui::component([]() { return Person("John"); });
+  auto tree = qui::Qui::createTree(Test());
 
-  auto element = Test();
-
-  auto *view = dynamic_cast<MockView *>(element.getView());
+  auto *view = dynamic_cast<MockView *>(tree.root.getView());
 
   ASSERT_NE(view, nullptr);
   EXPECT_EQ(view->value, 20);

--- a/engine/tests/quoll-tests/qui/native/Element.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Element.test.cpp
@@ -17,25 +17,27 @@ TEST_F(QuiElementTest, CreatesElementFromComponent) {
 }
 
 TEST_F(QuiElementTest, BuildingElementBuildsComponent) {
-  qui::Element element = MockComponent(20);
-  auto *component = dynamic_cast<const MockComponent *>(element.getComponent());
-
-  element.build(buildContext);
+  auto tree = qui::Qui::createTree(MockComponent(20));
+  auto *component =
+      dynamic_cast<const MockComponent *>(tree.root.getComponent());
 
   EXPECT_EQ(component->value, 20);
-  EXPECT_EQ(dynamic_cast<MockView *>(element.getView())->value, 20);
+  EXPECT_EQ(dynamic_cast<MockView *>(tree.root.getView())->value, 20);
   EXPECT_EQ(component->buildCount, 1);
 }
 
 TEST_F(QuiElementTest, RebuildingElementDoesNotBuildComponentAgain) {
-  qui::Element element = MockComponent(20);
-  auto *component = dynamic_cast<const MockComponent *>(element.getComponent());
+  auto tree = qui::Qui::createTree(MockComponent(20));
+  auto *component =
+      dynamic_cast<const MockComponent *>(tree.root.getComponent());
 
-  element.build(buildContext);
-  element.build(buildContext);
-  element.build(buildContext);
+  qui::BuildContext buildContext{tree.events.get()};
+
+  tree.root.build(buildContext);
+  tree.root.build(buildContext);
+  tree.root.build(buildContext);
 
   EXPECT_EQ(component->value, 20);
-  EXPECT_EQ(dynamic_cast<MockView *>(element.getView())->value, 20);
+  EXPECT_EQ(dynamic_cast<MockView *>(tree.root.getView())->value, 20);
   EXPECT_EQ(component->buildCount, 1);
 }

--- a/engine/tests/quoll-tests/qui/native/Flex.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Flex.test.cpp
@@ -9,42 +9,55 @@ public:
 };
 
 TEST_F(QuiFlexTest, CreatesFlexWithElements) {
-  qui::Element el = qui::Flex({MockComponent(10), MockComponent(20)});
+  auto tree =
+      qui::Qui::createTree(qui::Flex({MockComponent(10), MockComponent(20)}));
+  auto &el = tree.root;
 
-  auto *flex = static_cast<const qui::Flex *>(el.getComponent());
+  {
+    auto *flex = static_cast<const qui::Flex *>(el.getComponent());
+    EXPECT_EQ(flex->getChildren().size(), 2);
+    EXPECT_EQ(flex->getDirection(), qui::Direction::Row);
+    EXPECT_EQ(flex->getShrink(), 1.0f);
+    EXPECT_EQ(flex->getGrow(), 0.0f);
+    EXPECT_EQ(flex->getSpacing(), glm::vec2(0.0f));
+    EXPECT_EQ(flex->getWrap(), qui::Wrap::NoWrap);
 
-  EXPECT_EQ(flex->getChildren().size(), 2);
+    auto *child1 = static_cast<const MockComponent *>(
+        flex->getChildren().at(0).getComponent());
+    EXPECT_EQ(child1->value, 10);
 
-  EXPECT_EQ(flex->getDirection(), qui::Direction::Row);
-  EXPECT_EQ(flex->getShrink(), 1.0f);
-  EXPECT_EQ(flex->getGrow(), 0.0f);
-  EXPECT_EQ(flex->getSpacing(), glm::vec2(0.0f));
-  EXPECT_EQ(flex->getWrap(), qui::Wrap::NoWrap);
+    auto *child2 = static_cast<const MockComponent *>(
+        flex->getChildren().at(1).getComponent());
+    EXPECT_EQ(child2->value, 20);
+  }
 
-  auto *child1 = static_cast<const MockComponent *>(
-      flex->getChildren().at(0).getComponent());
-  EXPECT_EQ(child1->value, 10);
+  {
+    auto *view = static_cast<qui::FlexView *>(el.getView());
 
-  auto *child2 = static_cast<const MockComponent *>(
-      flex->getChildren().at(1).getComponent());
-  EXPECT_EQ(child2->value, 20);
+    EXPECT_EQ(view->getChildren().size(), 2);
+    EXPECT_EQ(view->getDirection(), qui::Direction::Row);
+    EXPECT_EQ(view->getWrap(), qui::Wrap::NoWrap);
+    EXPECT_EQ(view->getShrink(), 1.0f);
+    EXPECT_EQ(view->getGrow(), 0.0f);
+    EXPECT_EQ(view->getSpacing(), glm::vec2(0.0f));
 
-  auto *view = static_cast<qui::FlexView *>(el.getView());
-  EXPECT_EQ(view->getChildren().size(), 0);
-  EXPECT_EQ(view->getDirection(), qui::Direction::Row);
-  EXPECT_EQ(view->getShrink(), 1.0f);
-  EXPECT_EQ(view->getGrow(), 0.0f);
-  EXPECT_EQ(view->getSpacing(), glm::vec2(0.0f));
-  EXPECT_EQ(view->getWrap(), qui::Wrap::NoWrap);
+    auto *child1 = static_cast<MockView *>(view->getChildren().at(0));
+    EXPECT_EQ(child1->value, 10);
+
+    auto *child2 = static_cast<MockView *>(view->getChildren().at(1));
+    EXPECT_EQ(child2->value, 20);
+  }
 }
 
 TEST_F(QuiFlexTest, CreatesFlexWithAllProps) {
-  qui::Element el = qui::Flex({MockComponent(10), MockComponent(20)})
-                        .direction(qui::Direction::Column)
-                        .wrap(qui::Wrap::Wrap)
-                        .shrink(2.0f)
-                        .grow(3.0f)
-                        .spacing(glm::vec2{2.0f, 5.0f});
+  auto tree =
+      qui::Qui::createTree(qui::Flex({MockComponent(10), MockComponent(20)})
+                               .direction(qui::Direction::Column)
+                               .wrap(qui::Wrap::Wrap)
+                               .shrink(2.0f)
+                               .grow(3.0f)
+                               .spacing(glm::vec2{2.0f, 5.0f}));
+  auto &el = tree.root;
 
   auto *flex = static_cast<const qui::Flex *>(el.getComponent());
 
@@ -62,38 +75,22 @@ TEST_F(QuiFlexTest, CreatesFlexWithAllProps) {
       flex->getChildren().at(1).getComponent());
   EXPECT_EQ(child2->value, 20);
 
-  auto *view = static_cast<qui::FlexView *>(el.getView());
-  EXPECT_EQ(view->getChildren().size(), 0);
-  EXPECT_EQ(view->getDirection(), qui::Direction::Row);
-  EXPECT_EQ(view->getShrink(), 1.0f);
-  EXPECT_EQ(view->getGrow(), 0.0f);
-  EXPECT_EQ(view->getSpacing(), glm::vec2(0.0f));
-  EXPECT_EQ(view->getWrap(), qui::Wrap::NoWrap);
-}
+  {
+    auto *view = static_cast<qui::FlexView *>(el.getView());
 
-TEST_F(QuiFlexTest, BuildingFlexUpdatesView) {
-  qui::Element el = qui::Flex({MockComponent(10), MockComponent(20)})
-                        .direction(qui::Direction::Column)
-                        .wrap(qui::Wrap::Wrap)
-                        .shrink(2.0f)
-                        .grow(3.0f)
-                        .spacing(glm::vec2{2.0f, 5.0f});
+    EXPECT_EQ(view->getChildren().size(), 2);
+    EXPECT_EQ(view->getDirection(), qui::Direction::Column);
+    EXPECT_EQ(view->getWrap(), qui::Wrap::Wrap);
+    EXPECT_EQ(view->getShrink(), 2.0f);
+    EXPECT_EQ(view->getGrow(), 3.0f);
+    EXPECT_EQ(view->getSpacing(), glm::vec2(2.0f, 5.0f));
 
-  el.build(buildContext);
-  auto *view = static_cast<qui::FlexView *>(el.getView());
+    auto *child1 = static_cast<MockView *>(view->getChildren().at(0));
+    EXPECT_EQ(child1->value, 10);
 
-  EXPECT_EQ(view->getChildren().size(), 2);
-  EXPECT_EQ(view->getDirection(), qui::Direction::Column);
-  EXPECT_EQ(view->getWrap(), qui::Wrap::Wrap);
-  EXPECT_EQ(view->getShrink(), 2.0f);
-  EXPECT_EQ(view->getGrow(), 3.0f);
-  EXPECT_EQ(view->getSpacing(), glm::vec2(2.0f, 5.0f));
-
-  auto *child1 = static_cast<MockView *>(view->getChildren().at(0));
-  EXPECT_EQ(child1->value, 10);
-
-  auto *child2 = static_cast<MockView *>(view->getChildren().at(1));
-  EXPECT_EQ(child2->value, 20);
+    auto *child2 = static_cast<MockView *>(view->getChildren().at(1));
+    EXPECT_EQ(child2->value, 20);
+  }
 }
 
 TEST_F(QuiFlexTest, UpdatingFlexPropertiesAfterBuildUpdatesTheView) {
@@ -106,14 +103,13 @@ TEST_F(QuiFlexTest, UpdatingFlexPropertiesAfterBuildUpdatesTheView) {
   auto grow = scope.signal(3.0f);
   auto spacing = scope.signal(glm::vec2{2.0f, 5.0f});
 
-  qui::Element el = qui::Flex(children)
-                        .direction(direction)
-                        .wrap(wrap)
-                        .shrink(shrink)
-                        .grow(grow)
-                        .spacing(spacing);
-
-  el.build(buildContext);
+  auto tree = qui::Qui::createTree(qui::Flex(children)
+                                       .direction(direction)
+                                       .wrap(wrap)
+                                       .shrink(shrink)
+                                       .grow(grow)
+                                       .spacing(spacing));
+  auto &el = tree.root;
 
   auto *view = static_cast<qui::FlexView *>(el.getView());
 

--- a/engine/tests/quoll-tests/qui/native/FlexView.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/FlexView.test.cpp
@@ -84,10 +84,28 @@ TEST_F(QuiFlexViewTest, HitTestReturnsChildIfPointIsWithinChildBounds) {
 
   {
     qui::HitTestResult hitResult;
-    EXPECT_TRUE(view.hitTest({350.0f, 170.0f}, hitResult));
+    EXPECT_TRUE(view.hitTest({300.0f, 150.0f}, hitResult));
+    EXPECT_EQ(hitResult.path.size(), 3);
+    EXPECT_EQ(hitResult.path.at(0), &view);
+    EXPECT_EQ(hitResult.path.at(1), &child1);
+    EXPECT_EQ(hitResult.path.at(2), &child2);
+  }
+
+  {
+    qui::HitTestResult hitResult;
+    EXPECT_TRUE(view.hitTest({349.0f, 170.0f}, hitResult));
     EXPECT_EQ(hitResult.path.size(), 2);
     EXPECT_EQ(hitResult.path.at(0), &view);
     EXPECT_EQ(hitResult.path.at(1), &child2);
+  }
+
+  {
+    qui::HitTestResult hitResult;
+    EXPECT_TRUE(view.hitTest({350.0f, 170.0f}, hitResult));
+    EXPECT_EQ(hitResult.path.size(), 3);
+    EXPECT_EQ(hitResult.path.at(0), &view);
+    EXPECT_EQ(hitResult.path.at(1), &child2);
+    EXPECT_EQ(hitResult.path.at(2), &child3);
   }
 
   {

--- a/engine/tests/quoll-tests/qui/native/MockEventController.h
+++ b/engine/tests/quoll-tests/qui/native/MockEventController.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "quoll/qui/component/EventProcessor.h"
+#include "MockEventProcessorBackend.h"
+
+class MockEventController {
+public:
+  MockEventController(qui::Tree &tree) : mTree(&tree) {}
+
+  constexpr void click(glm::vec2 position) {
+    events.mMouseClicked = true;
+    events.mMousePosition = position;
+    eventProcessor.processEvents(*mTree);
+  }
+
+  constexpr void mouseDown(glm::vec2 position) {
+    events.mMouseDown = true;
+    events.mMousePosition = position;
+    eventProcessor.processEvents(*mTree);
+  }
+
+  constexpr void mouseUp(glm::vec2 position) {
+    events.mMouseUp = true;
+    events.mMousePosition = position;
+    eventProcessor.processEvents(*mTree);
+  }
+
+  constexpr void mouseMove(glm::vec2 position) {
+    events.mMouseMove = true;
+    events.mMousePosition = position;
+    eventProcessor.processEvents(*mTree);
+  }
+
+  constexpr void mouseWheel(glm::vec2 delta) {
+    events.mMouseWheel = true;
+    events.mMouseWheelDelta = delta;
+    eventProcessor.processEvents(*mTree);
+  }
+
+public:
+  qui::EventProcessor<MockEventProcessorBackend> eventProcessor;
+  MockEventProcessorBackend &events = eventProcessor.getBackend();
+  qui::Tree *mTree = nullptr;
+};

--- a/engine/tests/quoll-tests/qui/native/MockEventProcessorBackend.h
+++ b/engine/tests/quoll-tests/qui/native/MockEventProcessorBackend.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "quoll/qui/component/EventProcessorBackend.h"
+
+class MockEventProcessorBackend : public qui::EventProcessorBackendInterface {
+public:
+  constexpr glm::vec2 getMousePosition() override { return mMousePosition; }
+  constexpr glm::vec2 getMouseWheelDelta() override { return mMouseWheelDelta; }
+
+  constexpr bool isMouseClicked() override {
+    bool temp = mMouseClicked;
+    mMouseClicked = false;
+    return temp;
+  }
+
+  constexpr bool isMouseDown() override {
+    bool temp = mMouseDown;
+    mMouseDown = false;
+    return temp;
+  }
+
+  constexpr bool isMouseUp() override {
+    bool temp = mMouseUp;
+    mMouseUp = false;
+    return temp;
+  }
+
+  constexpr bool isMouseMoved() override {
+    bool temp = mMouseMove;
+    mMouseMove = false;
+    return temp;
+  }
+
+  constexpr bool isMouseWheel() override {
+    bool temp = mMouseWheel;
+    mMouseWheel = false;
+    return temp;
+  }
+
+public:
+  glm::vec2 mMousePosition{0.0f, 0.0f};
+  glm::vec2 mMouseWheelDelta{0.0f, 0.0f};
+
+  bool mMouseClicked{false};
+  bool mMouseDown{false};
+  bool mMouseUp{false};
+  bool mMouseMove{false};
+  bool mMouseWheel{false};
+};

--- a/engine/tests/quoll-tests/qui/native/QuiComponentTest.h
+++ b/engine/tests/quoll-tests/qui/native/QuiComponentTest.h
@@ -1,35 +1,10 @@
 #pragma once
 
+#include "quoll/qui/Qui.h"
 #include "quoll/qui/component/BuildContext.h"
 #include "quoll-tests/Testing.h"
+#include "MockEventController.h"
 
 class QuiComponentTest : public ::testing::Test {
 public:
-  void dispatchMouseWheelEvent(qui::MouseWheelEvent ev) {
-    for (auto &handler : eventManager.getMouseWheelHandlers()) {
-      handler(ev);
-    }
-  }
-
-  void dispatchMouseMoveEvent(qui::MouseEvent ev) {
-    for (auto &handler : eventManager.getMouseMoveHandlers()) {
-      handler(ev);
-    }
-  }
-
-  void dispatchMouseDownEvent(qui::MouseEvent ev) {
-    for (auto &handler : eventManager.getMouseDownHandlers()) {
-      handler(ev);
-    }
-  }
-
-  void dispatchMouseUpEvent(qui::MouseEvent ev) {
-    for (auto &handler : eventManager.getMouseUpHandlers()) {
-      handler(ev);
-    }
-  }
-
-public:
-  qui::EventManager eventManager;
-  qui::BuildContext buildContext{&eventManager};
 };

--- a/engine/tests/quoll-tests/qui/native/Scrollable.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Scrollable.test.cpp
@@ -15,34 +15,35 @@ public:
 };
 
 TEST_F(QuiScrollableTest, MouseWheelDoesNothingIfComponentIsNotHovered) {
-  qui::Element element = qui::Scrollable(child);
-  element.build(buildContext);
-  element.getView()->layout(
-      {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
-  auto *view = dynamic_cast<qui::ScrollableView *>(element.getView());
+  auto tree = qui::Qui::createTree(qui::Scrollable(child));
+  MockEventController events(tree);
+
+  tree.root.getView()->layout(
+      {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {100.0f, 100.0f}});
+  auto *view = dynamic_cast<qui::ScrollableView *>(tree.root.getView());
 
   EXPECT_EQ(view->getScrollableContent().getScrollOffset(),
             glm::vec2(0.0f, 0.0f));
 
-  dispatchMouseWheelEvent({glm::vec2{-20.0f, -30.0f}});
+  events.mouseWheel({glm::vec2{-20.0f, -30.0f}});
 
   EXPECT_EQ(view->getScrollableContent().getScrollOffset(),
             glm::vec2(0.0f, 0.0f));
 }
 
 TEST_F(QuiScrollableTest, MouseWheelDoesNothingIfScrollbarIsDragging) {
-  qui::Element element = qui::Scrollable(child);
-  element.build(buildContext);
-  element.getView()->layout(
+  auto tree = qui::Qui::createTree(qui::Scrollable(child));
+  MockEventController events(tree);
+
+  tree.root.getView()->layout(
       {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
-  auto *view = dynamic_cast<qui::ScrollableView *>(element.getView());
+  auto *view = dynamic_cast<qui::ScrollableView *>(tree.root.getView());
 
   EXPECT_EQ(view->getScrollableContent().getScrollOffset(),
             glm::vec2(0.0f, 0.0f));
 
-  dispatchMouseMoveEvent({glm::vec2{195.0f, 20.0f}});
-  dispatchMouseDownEvent({glm::vec2{195.0f, 20.0f}});
-  dispatchMouseWheelEvent({glm::vec2{-20.0f, -30.0f}});
+  events.mouseDown({glm::vec2{195.0f, 20.0f}});
+  events.mouseWheel({glm::vec2{-20.0f, -30.0f}});
 
   EXPECT_EQ(view->getScrollableContent().getScrollOffset(),
             glm::vec2(0.0f, 0.0f));
@@ -51,106 +52,111 @@ TEST_F(QuiScrollableTest, MouseWheelDoesNothingIfScrollbarIsDragging) {
 TEST_F(
     QuiScrollableTest,
     MouseWheelUpdatesScrollOffsetIfComponentIsHoveredAndScrollbarIsNotDragging) {
-  qui::Element element = qui::Scrollable(child);
-  element.build(buildContext);
-  element.getView()->layout(
+  auto tree = qui::Qui::createTree(qui::Scrollable(child));
+  MockEventController events(tree);
+
+  tree.root.getView()->layout(
       {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
-  auto *view = dynamic_cast<qui::ScrollableView *>(element.getView());
+  auto *view = dynamic_cast<qui::ScrollableView *>(tree.root.getView());
 
   EXPECT_EQ(view->getScrollableContent().getScrollOffset(),
             glm::vec2(0.0f, 0.0f));
 
-  dispatchMouseMoveEvent({glm::vec2{150.0f, 150.0f}});
-  dispatchMouseWheelEvent({glm::vec2{-20.0f, -30.0f}});
+  events.mouseMove({glm::vec2{150.0f, 150.0f}});
+  events.mouseWheel({glm::vec2{-20.0f, -30.0f}});
 
   EXPECT_EQ(view->getScrollableContent().getScrollOffset(),
             glm::vec2(-100.0f, -150.0f));
 }
 
 TEST_F(QuiScrollableTest, ScrollbarIsNotVisibleWhenComponentIsNotHovered) {
-  qui::Element element = qui::Scrollable(child);
-  element.build(buildContext);
-  element.getView()->layout(
+  auto tree = qui::Qui::createTree(qui::Scrollable(child));
+  MockEventController events(tree);
+
+  tree.root.getView()->layout(
       {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
-  auto *view = dynamic_cast<qui::ScrollableView *>(element.getView());
+  auto *view = dynamic_cast<qui::ScrollableView *>(tree.root.getView());
 
   EXPECT_FALSE(view->isScrollbarVisible());
 
-  dispatchMouseMoveEvent({glm::vec2{1000.0, 0.0f}});
+  events.mouseMove({glm::vec2{1000.0, 0.0f}});
   EXPECT_FALSE(view->isScrollbarVisible());
 }
 
 TEST_F(QuiScrollableTest, ThinScrollbarIsVisibleWhenComponentIsHovered) {
-  qui::Element element = qui::Scrollable(child);
-  element.build(buildContext);
-  element.getView()->layout(
-      {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
-  auto *view = dynamic_cast<qui::ScrollableView *>(element.getView());
+  auto tree = qui::Qui::createTree(qui::Scrollable(child));
+  MockEventController events(tree);
 
-  dispatchMouseMoveEvent({glm::vec2{150.0f, 150.0f}});
+  tree.root.getView()->layout(
+      {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
+  auto *view = dynamic_cast<qui::ScrollableView *>(tree.root.getView());
+
+  events.mouseMove({glm::vec2{150.0f, 150.0f}});
   EXPECT_TRUE(view->isScrollbarVisible());
   EXPECT_EQ(view->getScrollbar().getThickness(), 6.0f);
 }
 
 TEST_F(QuiScrollableTest, ThickScrollbarIsVisibleWhenScrollbarIsHovered) {
-  qui::Element element = qui::Scrollable(child);
-  element.build(buildContext);
-  element.getView()->layout(
-      {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
-  auto *view = dynamic_cast<qui::ScrollableView *>(element.getView());
+  auto tree = qui::Qui::createTree(qui::Scrollable(child));
+  MockEventController events(tree);
 
-  dispatchMouseMoveEvent({glm::vec2{195.0f, 20.0f}});
+  tree.root.getView()->layout(
+      {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
+  auto *view = dynamic_cast<qui::ScrollableView *>(tree.root.getView());
+
+  events.mouseMove({glm::vec2{195.0f, 20.0f}});
   EXPECT_TRUE(view->isScrollbarVisible());
   EXPECT_EQ(view->getScrollbar().getThickness(), 12.0f);
 }
 
 TEST_F(QuiScrollableTest, ScrollbarStaysActiveIfDraggingStarted) {
-  qui::Element element = qui::Scrollable(child);
-  element.build(buildContext);
-  element.getView()->layout(
-      {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
-  auto *view = dynamic_cast<qui::ScrollableView *>(element.getView());
+  auto tree = qui::Qui::createTree(qui::Scrollable(child));
+  MockEventController events(tree);
 
-  dispatchMouseMoveEvent({glm::vec2{195.0f, 20.0f}});
-  dispatchMouseDownEvent({glm::vec2{195.0f, 20.0f}});
+  tree.root.getView()->layout(
+      {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
+  auto *view = dynamic_cast<qui::ScrollableView *>(tree.root.getView());
+
+  events.mouseDown({195.0f, 20.0f});
 
   EXPECT_TRUE(view->isScrollbarVisible());
   EXPECT_EQ(view->getScrollbar().getThickness(), 12.0f);
 
-  dispatchMouseMoveEvent({glm::vec2{1000.0f, 1000.0f}});
+  events.mouseMove({glm::vec2{1000.0f, 1000.0f}});
   EXPECT_TRUE(view->isScrollbarVisible());
   EXPECT_EQ(view->getScrollbar().getThickness(), 12.0f);
 }
 
 TEST_F(QuiScrollableTest,
        EndingScrollbarDragSetsScrollbarStateBasedOnMousePosition) {
-  qui::Element element = qui::Scrollable(child);
-  element.build(buildContext);
-  element.getView()->layout(
-      {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
-  auto *view = dynamic_cast<qui::ScrollableView *>(element.getView());
+  auto tree = qui::Qui::createTree(qui::Scrollable(child));
+  MockEventController events(tree);
 
-  dispatchMouseMoveEvent({glm::vec2{195.0f, 20.0f}});
+  tree.root.getView()->layout(
+      {qui::Constraints(200.0f, 300.0f, 200.0f, 300.0f), {0.0f, 0.0f}});
+  auto *view = dynamic_cast<qui::ScrollableView *>(tree.root.getView());
+
+  events.mouseMove({glm::vec2{195.0f, 20.0f}});
 
   // Hovered state
-  dispatchMouseMoveEvent({glm::vec2{195.0f, 20.0f}});
-  dispatchMouseDownEvent({glm::vec2{195.0f, 20.0f}});
-  dispatchMouseUpEvent({glm::vec2{195.0f, 20.0f}});
+  events.mouseMove({glm::vec2{195.0f, 20.0f}});
+  events.mouseDown({glm::vec2{195.0f, 20.0f}});
+  events.mouseUp({glm::vec2{195.0f, 20.0f}});
   EXPECT_TRUE(view->isScrollbarVisible());
   EXPECT_EQ(view->getScrollbar().getThickness(), 12.0f);
 
   // Visible state
-  dispatchMouseMoveEvent({glm::vec2{195.0f, 20.0f}});
-  dispatchMouseDownEvent({glm::vec2{195.0f, 20.0f}});
-  dispatchMouseMoveEvent({glm::vec2{150.0f, 150.0f}});
-  dispatchMouseUpEvent({glm::vec2{150.0f, 150.0f}});
+  events.mouseMove({glm::vec2{195.0f, 20.0f}});
+  events.mouseDown({glm::vec2{195.0f, 20.0f}});
+  events.mouseMove({glm::vec2{150.0f, 150.0f}});
+  events.mouseUp({glm::vec2{150.0f, 150.0f}});
   EXPECT_TRUE(view->isScrollbarVisible());
   EXPECT_EQ(view->getScrollbar().getThickness(), 6.0f);
 
   // Hidden state
-  dispatchMouseMoveEvent({glm::vec2{195.0f, 20.0f}});
-  dispatchMouseDownEvent({glm::vec2{195.0f, 20.0f}});
-  dispatchMouseMoveEvent({glm::vec2{1000.0, 1000.0f}});
-  dispatchMouseUpEvent({glm::vec2{1000.0f, 1000.0f}});
+  events.mouseMove({glm::vec2{195.0f, 20.0f}});
+  events.mouseDown({glm::vec2{195.0f, 20.0f}});
+  events.mouseMove({glm::vec2{1000.0, 1000.0f}});
+  events.mouseUp({glm::vec2{1000.0f, 1000.0f}});
   EXPECT_FALSE(view->isScrollbarVisible());
 }

--- a/engine/tests/quoll-tests/qui/native/Text.test.cpp
+++ b/engine/tests/quoll-tests/qui/native/Text.test.cpp
@@ -7,7 +7,8 @@
 class QuiTextTest : public QuiComponentTest {};
 
 TEST_F(QuiTextTest, CreatesText) {
-  qui::Element el = qui::Text("Hello world");
+  auto tree = qui::Qui::createTree(qui::Text("Hello world"));
+  auto &el = tree.root;
   auto *text = static_cast<const qui::Text *>(el.getComponent());
 
   EXPECT_EQ(text->getText(), "Hello world");
@@ -15,7 +16,9 @@ TEST_F(QuiTextTest, CreatesText) {
 }
 
 TEST_F(QuiTextTest, CreatesTextWithAllProps) {
-  qui::Element el = qui::Text("Hello world").color(qui::Color::Red);
+  auto tree =
+      qui::Qui::createTree(qui::Text("Hello world").color(qui::Color::Red));
+  auto &el = tree.root;
   auto *text = static_cast<const qui::Text *>(el.getComponent());
 
   EXPECT_EQ(text->getText(), "Hello world");
@@ -23,9 +26,9 @@ TEST_F(QuiTextTest, CreatesTextWithAllProps) {
 }
 
 TEST_F(QuiTextTest, BuildingTextUpdatesView) {
-  qui::Element el = qui::Text("Hello world").color(qui::Color::Red);
-
-  el.build(buildContext);
+  auto tree =
+      qui::Qui::createTree(qui::Text("Hello world").color(qui::Color::Red));
+  auto &el = tree.root;
 
   auto *view = static_cast<qui::TextView *>(el.getView());
 
@@ -38,8 +41,9 @@ TEST_F(QuiTextTest, UpdatingTextPropertiesAfterBuildUpdatesTheView) {
   auto text = scope.signal("Hello world");
   auto color = scope.signal(qui::Color::Red);
 
-  qui::Element el = qui::Text(text).color(color);
-  el.build(buildContext);
+  auto tree = qui::Qui::createTree(qui::Text(text).color(color));
+  auto &el = tree.root;
+
   auto *view = static_cast<qui::TextView *>(el.getView());
 
   EXPECT_EQ(view->getText(), "Hello world");


### PR DESCRIPTION
- Add event dispatcher to Views
- Dispatch events to views if view hit test is true on mouse events
- Update scrollable and pressable to use hit test events
- Test component events using event processor
- Create event processor
- Create imgui event processor backend
- Create mock event processor backend
- Create event controller that processes events on created events
- Create tree in all component tests instead of just element